### PR TITLE
Fix for scala library not resolvable in Servicemix Version.

### DIFF
--- a/activemq-karaf/src/main/resources/features.xml
+++ b/activemq-karaf/src/main/resources/features.xml
@@ -59,7 +59,8 @@
       <bundle dependency="true">mvn:org.codehaus.jettison/jettison/${jettison-version}</bundle>
       <bundle dependency="true">mvn:org.codehaus.jackson/jackson-core-asl/${jackson-version}</bundle>
       <bundle dependency="true">mvn:org.codehaus.jackson/jackson-mapper-asl/${jackson-version}</bundle>
-      <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.scala-library/${scala-bundle-version}</bundle>
+      <bundle dependency='true'>wrap:mvn:org.scala-lang/scala-library/${scala-bundle-version}</bundle>
+      <!--bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.scala-library/${scala-bundle-version}</bundle-->
 <!-- Scala 2.9 is not OSGi bundle. But 2.10 is
       <bundle dependency="true">mvn:org.scala-lang/scala-library/${scala-version}</bundle>
 -->

--- a/pom.xml
+++ b/pom.xml
@@ -106,8 +106,8 @@
     <saxon-version>9.5.1-2</saxon-version>
     <saxon-bundle-version>9.5.1-1_1</saxon-bundle-version>
     <scala-plugin-version>3.1.0</scala-plugin-version>
-    <scala-version>2.9.1</scala-version>
-    <scala-bundle-version>2.9.1_3</scala-bundle-version>
+    <scala-version>2.9.2</scala-version>
+    <scala-bundle-version>2.9.2</scala-bundle-version>
     <scalatest-version>1.8</scalatest-version>
     <slf4j-version>1.7.5</slf4j-version>
     <snappy-version>1.1.0-M4</snappy-version>


### PR DESCRIPTION
Hi, 

with Active MQ 5.9.0 and 5.10-SNAPSHOT I was encountering a problem when I tried to install the activemq-blueprint feature into a Karaf 2.3.3 container. 

The error message was 
Error executing command: URL [mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.scala-library/2.9.1_3] could not be resolved

My container was able to resolve all other bundles from maven central, this was the only one failing. I made the changes in this pull request and the feature was installing fine and I was able to create a broker and use it. 

Best regards
Andreas
