### PR TITLE
Remove hawt.io console and restore back to just the old console

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -411,12 +411,6 @@
       <version>1.1.1</version>
     </dependency>
     <dependency>
-      <groupId>io.hawt</groupId>
-      <artifactId>hawtio-web</artifactId>
-      <version>${hawtio-version}</version>
-      <type>war</type>
-    </dependency>
-    <dependency>
       <groupId>org.fusesource.insight</groupId>
       <artifactId>insight-log-core</artifactId>
       <version>${insight-version}</version>

--- a/assembly/src/main/descriptors/common-bin.xml
+++ b/assembly/src/main/descriptors/common-bin.xml
@@ -100,22 +100,6 @@
   </fileSets>
 
   <dependencySets>
-    <dependencySet>
-      <outputDirectory>/webapps/hawtio</outputDirectory>
-      <unpack>true</unpack>
-      <unpackOptions>
-        <excludes>
-          <exclude>WEB-INF/lib/slf4j-api-*.jar</exclude>
-          <exclude>WEB-INF/lib/log4j-*.jar</exclude>
-          <exclude>WEB-INF/lib/commons-codec-*.jar</exclude>
-          <exclude>WEB-INF/lib/org.eclipse.jgit-*.jar</exclude>
-        </excludes>
-      </unpackOptions>
-      <scope>runtime</scope>
-      <includes>
-        <include>io.hawt:hawtio-web:war</include>
-      </includes>
-    </dependencySet>
 
     <!-- Copy over jar files -->
     <dependencySet>
@@ -278,8 +262,6 @@
         <!-- REST API -->
         <include>org.jolokia:jolokia-core</include>
         <include>com.googlecode.json-simple:json-simple</include>
-        <!-- ADDITIONAL HAWTIO PLUGINS -->
-        <include>org.ops4j.pax.url:pax-url-aether</include>
       </includes>
     </dependencySet>
   </dependencySets>

--- a/assembly/src/release/bin/activemq
+++ b/assembly/src/release/bin/activemq
@@ -250,7 +250,7 @@ if [ "$CONFIG_LOAD" != "yes" ];then
 fi
 
 if [ -z "$ACTIVEMQ_OPTS" ] ; then
-    ACTIVEMQ_OPTS="$ACTIVEMQ_OPTS_MEMORY -Djava.util.logging.config.file=logging.properties -Dhawtio.realm=activemq -Dhawtio.role=admins -Dhawtio.rolePrincipalClasses=org.apache.activemq.jaas.GroupPrincipal -Djava.security.auth.login.config=$ACTIVEMQ_CONF/login.config"
+    ACTIVEMQ_OPTS="$ACTIVEMQ_OPTS_MEMORY -Djava.util.logging.config.file=logging.properties -Djava.security.auth.login.config=$ACTIVEMQ_CONF/login.config"
 fi
 
 # create configuration if requested

--- a/assembly/src/release/bin/activemq-admin
+++ b/assembly/src/release/bin/activemq-admin
@@ -148,7 +148,7 @@ ACTIVEMQ_CLASSPATH="${ACTIVEMQ_CONF};"$ACTIVEMQ_CLASSPATH
 
 if [ ""$1 = "start" ] ; then
     if [ -z "$ACTIVEMQ_OPTS" ] ; then
-        ACTIVEMQ_OPTS="-Xmx1G -Dorg.apache.activemq.UseDedicatedTaskRunner=true -Djava.util.logging.config.file=logging.properties -Dhawtio.realm=activemq -Dhawtio.role=admins -Dhawtio.rolePrincipalClasses=org.apache.activemq.jaas.GroupPrincipal -Djava.security.auth.login.config=$ACTIVEMQ_CONF/login.config"
+        ACTIVEMQ_OPTS="-Xmx1G -Dorg.apache.activemq.UseDedicatedTaskRunner=true -Djava.util.logging.config.file=logging.properties -Djava.security.auth.login.config=$ACTIVEMQ_CONF/login.config"
     fi
 
     if [ -z "$SUNJMX" ] ; then

--- a/assembly/src/release/bin/activemq-admin.bat
+++ b/assembly/src/release/bin/activemq-admin.bat
@@ -80,7 +80,7 @@ if "%ACTIVEMQ_TMP%" == "" set ACTIVEMQ_TMP=%ACTIVEMQ_DATA%\tmp
 if /i not "%1" == "start" goto debugOpts
 
 
-if "%ACTIVEMQ_OPTS%" == "" set ACTIVEMQ_OPTS=-Xmx1G -Dorg.apache.activemq.UseDedicatedTaskRunner=true -Djava.util.logging.config.file=logging.properties -Dhawtio.realm=activemq -Dhawtio.role=admins -Dhawtio.rolePrincipalClasses=org.apache.activemq.jaas.GroupPrincipal -Djava.security.auth.login.config=%ACTIVEMQ_CONF%\login.config
+if "%ACTIVEMQ_OPTS%" == "" set ACTIVEMQ_OPTS=-Xmx1G -Dorg.apache.activemq.UseDedicatedTaskRunner=true -Djava.util.logging.config.file=logging.properties -Djava.security.auth.login.config=%ACTIVEMQ_CONF%\login.config
 
 if "%SUNJMX%" == "" set SUNJMX=-Dcom.sun.management.jmxremote
 REM set SUNJMX=-Dcom.sun.management.jmxremote.port=1099 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false

--- a/assembly/src/release/bin/activemq.bat
+++ b/assembly/src/release/bin/activemq.bat
@@ -77,7 +77,7 @@ if "%ACTIVEMQ_DATA%" == "" set ACTIVEMQ_DATA=%ACTIVEMQ_HOME%\data
 
 if "%ACTIVEMQ_TMP%" == "" set ACTIVEMQ_TMP=%ACTIVEMQ_DATA%\tmp
 
-if "%ACTIVEMQ_OPTS%" == "" set ACTIVEMQ_OPTS=-Xms1G -Xmx1G -Djava.util.logging.config.file=logging.properties -Dhawtio.realm=activemq -Dhawtio.role=admins -Dhawtio.rolePrincipalClasses=org.apache.activemq.jaas.GroupPrincipal -Djava.security.auth.login.config=%ACTIVEMQ_CONF%\login.config
+if "%ACTIVEMQ_OPTS%" == "" set ACTIVEMQ_OPTS=-Xms1G -Xmx1G -Djava.util.logging.config.file=logging.properties -Djava.security.auth.login.config=%ACTIVEMQ_CONF%\login.config
 
 if "%SUNJMX%" == "" set SUNJMX=-Dcom.sun.management.jmxremote
 REM set SUNJMX=-Dcom.sun.management.jmxremote.port=1099 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false

--- a/assembly/src/release/bin/linux-x86-32/wrapper.conf
+++ b/assembly/src/release/bin/linux-x86-32/wrapper.conf
@@ -56,10 +56,7 @@ wrapper.java.additional.8=-Dorg.apache.activemq.UseDedicatedTaskRunner=true
 wrapper.java.additional.9=-Djava.util.logging.config.file=logging.properties
 wrapper.java.additional.10=-Dactivemq.conf=%ACTIVEMQ_CONF%
 wrapper.java.additional.11=-Dactivemq.data=%ACTIVEMQ_DATA%
-wrapper.java.additional.12=-Dhawtio.realm=activemq
-wrapper.java.additional.13=-Dhawtio.role=admins
-wrapper.java.additional.14=-Dhawtio.rolePrincipalClasses=org.apache.activemq.jaas.GroupPrincipal
-wrapper.java.additional.15=-Djava.security.auth.login.config=%ACTIVEMQ_CONF%/login.config
+wrapper.java.additional.12=-Djava.security.auth.login.config=%ACTIVEMQ_CONF%/login.config
 
 # Uncomment to enable jmx
 #wrapper.java.additional.n=-Dcom.sun.management.jmxremote.port=1616

--- a/assembly/src/release/bin/linux-x86-64/wrapper.conf
+++ b/assembly/src/release/bin/linux-x86-64/wrapper.conf
@@ -56,10 +56,7 @@ wrapper.java.additional.8=-Dorg.apache.activemq.UseDedicatedTaskRunner=true
 wrapper.java.additional.9=-Djava.util.logging.config.file=logging.properties
 wrapper.java.additional.10=-Dactivemq.conf=%ACTIVEMQ_CONF%
 wrapper.java.additional.11=-Dactivemq.data=%ACTIVEMQ_DATA%
-wrapper.java.additional.12=-Dhawtio.realm=activemq
-wrapper.java.additional.13=-Dhawtio.role=admins
-wrapper.java.additional.14=-Dhawtio.rolePrincipalClasses=org.apache.activemq.jaas.GroupPrincipal
-wrapper.java.additional.15=-Djava.security.auth.login.config=%ACTIVEMQ_CONF%/login.config
+wrapper.java.additional.12=-Djava.security.auth.login.config=%ACTIVEMQ_CONF%/login.config
 
 # Uncomment to enable jmx
 #wrapper.java.additional.n=-Dcom.sun.management.jmxremote.port=1616

--- a/assembly/src/release/bin/macosx/wrapper.conf
+++ b/assembly/src/release/bin/macosx/wrapper.conf
@@ -56,10 +56,7 @@ wrapper.java.additional.8=-Dorg.apache.activemq.UseDedicatedTaskRunner=true
 wrapper.java.additional.9=-Djava.util.logging.config.file=logging.properties
 wrapper.java.additional.10=-Dactivemq.conf=%ACTIVEMQ_CONF%
 wrapper.java.additional.11=-Dactivemq.data=%ACTIVEMQ_DATA%
-wrapper.java.additional.12=-Dhawtio.realm=activemq
-wrapper.java.additional.13=-Dhawtio.role=admins
-wrapper.java.additional.14=-Dhawtio.rolePrincipalClasses=org.apache.activemq.jaas.GroupPrincipal
-wrapper.java.additional.15=-Djava.security.auth.login.config=%ACTIVEMQ_CONF%/login.config
+wrapper.java.additional.12=-Djava.security.auth.login.config=%ACTIVEMQ_CONF%/login.config
 
 # Uncomment to enable jmx
 #wrapper.java.additional.n=-Dcom.sun.management.jmxremote.port=1616

--- a/assembly/src/release/bin/win32/wrapper.conf
+++ b/assembly/src/release/bin/win32/wrapper.conf
@@ -56,10 +56,7 @@ wrapper.java.additional.8=-Dorg.apache.activemq.UseDedicatedTaskRunner=true
 wrapper.java.additional.9=-Djava.util.logging.config.file=logging.properties
 wrapper.java.additional.10=-Dactivemq.conf="%ACTIVEMQ_CONF%"
 wrapper.java.additional.11=-Dactivemq.data="%ACTIVEMQ_DATA%"
-wrapper.java.additional.12=-Dhawtio.realm=activemq
-wrapper.java.additional.13=-Dhawtio.role=admins
-wrapper.java.additional.14=-Dhawtio.rolePrincipalClasses=org.apache.activemq.jaas.GroupPrincipal
-wrapper.java.additional.15=-Djava.security.auth.login.config="%ACTIVEMQ_CONF%/login.config"
+wrapper.java.additional.12=-Djava.security.auth.login.config="%ACTIVEMQ_CONF%/login.config"
 
 # Uncomment to enable remote jmx
 #wrapper.java.additional.n=-Dcom.sun.management.jmxremote.port=1616

--- a/assembly/src/release/bin/win64/wrapper.conf
+++ b/assembly/src/release/bin/win64/wrapper.conf
@@ -56,10 +56,7 @@ wrapper.java.additional.8=-Dorg.apache.activemq.UseDedicatedTaskRunner=true
 wrapper.java.additional.9=-Djava.util.logging.config.file=logging.properties
 wrapper.java.additional.10=-Dactivemq.conf="%ACTIVEMQ_CONF%"
 wrapper.java.additional.11=-Dactivemq.data="%ACTIVEMQ_DATA%"
-wrapper.java.additional.12=-Dhawtio.realm=activemq
-wrapper.java.additional.13=-Dhawtio.role=admins
-wrapper.java.additional.14=-Dhawtio.rolePrincipalClasses=org.apache.activemq.jaas.GroupPrincipal
-wrapper.java.additional.15=-Djava.security.auth.login.config="%ACTIVEMQ_CONF%/login.config"
+wrapper.java.additional.12=-Djava.security.auth.login.config="%ACTIVEMQ_CONF%/login.config"
 
 # Uncomment to enable remote jmx
 #wrapper.java.additional.n=-Dcom.sun.management.jmxremote.port=1616

--- a/assembly/src/release/conf/activemq.xml
+++ b/assembly/src/release/conf/activemq.xml
@@ -28,12 +28,6 @@
         </property>
     </bean>
 
-    <!-- Allows log searching in hawtio console -->
-    <bean id="logQuery" class="org.fusesource.insight.log.log4j.Log4jLogQuery"
-          lazy-init="false" scope="singleton"
-          init-method="start" destroy-method="stop">
-    </bean>
-
     <!--
         The <broker> element is used to configure the ActiveMQ broker.
     -->

--- a/assembly/src/release/conf/jetty.xml
+++ b/assembly/src/release/conf/jetty.xml
@@ -61,11 +61,6 @@
                 <property name="handlers">
                     <list>
                         <bean class="org.eclipse.jetty.webapp.WebAppContext">
-                            <property name="contextPath" value="/hawtio" />
-                            <property name="war" value="${activemq.home}/webapps/hawtio" />
-                            <property name="logUrlOnStart" value="true" />
-                        </bean>
-                        <bean class="org.eclipse.jetty.webapp.WebAppContext">
                             <property name="contextPath" value="/admin" />
                             <property name="resourceBase" value="${activemq.home}/webapps/admin" />
                             <property name="logUrlOnStart" value="true" />
@@ -97,17 +92,6 @@
                 </property>
             </bean>
         </property>
-    </bean>
-
-    <bean id="rewrite" class="org.eclipse.jetty.rewrite.handler.RewriteHandler">
-      <property name="rules">
-          <set>
-              <bean class="org.eclipse.jetty.rewrite.handler.RedirectRegexRule">
-                  <property name="regex" value="/api/jolokia(.*)"/>
-                  <property name="replacement" value="/hawtio/jolokia$1"/>
-              </bean>
-          </set>
-      </property>
     </bean>
 
     <bean id="contexts" class="org.eclipse.jetty.server.handler.ContextHandlerCollection">
@@ -144,7 +128,6 @@
             <bean id="handlers" class="org.eclipse.jetty.server.handler.HandlerCollection">
                 <property name="handlers">
                     <list>
-                        <ref bean="rewrite"/>
                         <ref bean="contexts" />
                         <ref bean="securityHandler" />
                     </list>

--- a/assembly/src/release/docs/WebConsole-README.txt
+++ b/assembly/src/release/docs/WebConsole-README.txt
@@ -1,28 +1,17 @@
 Deploying the ActiveMQ-WebConsole
 =================================
 
-From ActiveMQ 5.9 onwards ActiveMQ ships with two web consoles:
-- new console using hawtio
-- old console
-
-The old console is deprecated and replaced with a new modern console based on hawtio (http://hawt.io)
-
-The old console is accessible at its usual location at:
+From ActiveMQ 5.9 onwards ActiveMQ ships with a web console which
+is accessible at its usual location at:
   http://localhost:8161/admin/
 
-And the new console is located at:
-  http://localhost:8161/hawtio/
-
 In the default configuration ActiveMQ automatically starts the web console in the
-same VM as the broker. The console is accessibly under http://localhost:8161/hawtio/.
+same VM as the broker. The console is accessibly under http://localhost:8161/admin/.
 
 The broker may ask for credentials to login the web console the first time.
 The default username and password is admin/admin. 
 
-In the new console using hawtio, you can configure the default users, in the 
-conf/users.properties, and conf/groups.properties files.
-
-In the old web console you can configure the default users, in the
+In the web console you can configure the default users, in the
 conf/jetty-real.properties file. And in the conf/jetty.xml file you can configure
 to disable login for the web consoles.
 
@@ -69,26 +58,6 @@ or the client only (web console not available):
 
 You can then use web:list to see the context-path the console is accessible,
 that is usually: http://localhost:8181/activemqweb
-
-
-To install the new hawtio web console you install it as follows:
-
-If you use Karaf 2.3.3 or better:
-
-    features:chooseurl hawtio 
-
-For older releases you have to use addurl:
-
-    features:addurl mvn:io.hawt/hawtio-karaf/1.2-M19/xml/features
-
-And then you can install hawtio simply by:
-
-    features:install hawtio
-
-You can then use web:list to see the context-path the console is accessible,
-that is usually: http://localhost:8181/hawtio
-
-See also: http://hawt.io/getstarted/index.html for details how to install hawtio.
 
 
 Master/Slave monitoring

--- a/assembly/src/release/examples/conf/jetty-demo.xml
+++ b/assembly/src/release/examples/conf/jetty-demo.xml
@@ -61,11 +61,6 @@
                 <property name="handlers">
                     <list>
                         <bean class="org.eclipse.jetty.webapp.WebAppContext">
-                            <property name="contextPath" value="/hawtio" />
-                            <property name="war" value="${activemq.home}/webapps/hawtio" />
-                            <property name="logUrlOnStart" value="true" />
-                        </bean>
-                        <bean class="org.eclipse.jetty.webapp.WebAppContext">
                             <property name="contextPath" value="/admin" />
                             <property name="resourceBase" value="${activemq.home}/webapps/admin" />
                             <property name="logUrlOnStart" value="true" />
@@ -104,17 +99,6 @@
         </property>
     </bean>
 
-    <bean id="rewrite" class="org.eclipse.jetty.rewrite.handler.RewriteHandler">
-      <property name="rules">
-          <set>
-              <bean class="org.eclipse.jetty.rewrite.handler.RedirectRegexRule">
-                  <property name="regex" value="/api/jolokia(.*)"/>
-                  <property name="replacement" value="/hawtio/jolokia$1"/>
-              </bean>
-          </set>
-      </property>
-    </bean>
-
     <bean id="contexts" class="org.eclipse.jetty.server.handler.ContextHandlerCollection">
     </bean>
 
@@ -149,7 +133,6 @@
             <bean id="handlers" class="org.eclipse.jetty.server.handler.HandlerCollection">
                 <property name="handlers">
                     <list>
-                        <ref bean="rewrite"/>
                         <ref bean="contexts" />
                         <ref bean="securityHandler" />
                     </list>

--- a/assembly/src/release/webapps/index.html
+++ b/assembly/src/release/webapps/index.html
@@ -81,8 +81,7 @@
                                             
                                                 <p>What do you want to do next?</p>
                                                 <ul class="alternate" type="square"> 
-                                                    <li><a title="Manage ActiveMQ broker" href="/hawtio/">Manage ActiveMQ broker</a></li> 
-                                                    <li><a title="Manage ActiveMQ broker (old console)" href="/admin/">Manage ActiveMQ broker using the old console</a></li> 
+                                                    <li><a title="Manage ActiveMQ broker" href="/admin/">Manage ActiveMQ broker</a></li> 
                                                     <li><a title="See some Web demos" href="/demo/">See some Web demos (demos not included in default configuration)</a></li>  
                                                 </ul> 
                                     </div> 

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,6 @@
     <hadoop-version>1.0.0</hadoop-version>
     <hawtbuf-version>1.9</hawtbuf-version>
     <hawtdispatch-version>1.18</hawtdispatch-version>
-    <hawtio-version>1.2.1</hawtio-version>
     <howl-version>0.1.8</howl-version>
     <hsqldb-version>1.8.0.12</hsqldb-version>
     <httpclient-version>4.2.5</httpclient-version>


### PR DESCRIPTION
This should remove the hawt.io console and put things back to just having the older web console.  Thus, we should be able to get a 5.9.1 shortly.
