### PR TITLE
Activemq 5.5.1.1

### DIFF
--- a/activemq-tooling/maven-activemq-plugin/pom.xml
+++ b/activemq-tooling/maven-activemq-plugin/pom.xml
@@ -26,7 +26,8 @@
 
   <artifactId>maven-activemq-plugin</artifactId>
   <packaging>maven-plugin</packaging>
-  <name>ActiveMQ :: StartUp Plugin</name>
+  <name>ActiveMQ :: Start/Stop Plugin</name>
+  <version>5.5.1.1</version>
 
   <dependencies>
     <dependency>

--- a/activemq-tooling/maven-activemq-plugin/src/main/java/org/apache/activemq/maven/StartBrokerMojo.java
+++ b/activemq-tooling/maven-activemq-plugin/src/main/java/org/apache/activemq/maven/StartBrokerMojo.java
@@ -1,0 +1,108 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.maven;
+
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.util.Properties;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.project.MavenProject;
+
+/**
+ * Goal which starts an activemq broker.
+ *
+ * @goal run
+ * @phase process-sources
+ */
+public class StartBrokerMojo extends AbstractMojo {
+    /**
+     * The maven project.
+     *
+     * @parameter expression="${project}"
+     * @required
+     * @readonly
+     */
+    protected MavenProject project;
+
+    /**
+     * The broker configuration uri The list of currently supported URI syntaxes
+     * is described <a
+     * href="http://activemq.apache.org/how-do-i-embed-a-broker-inside-a-connection.html">here</a>
+     *
+     * @parameter expression="${configUri}"
+     *            default-value="broker:(tcp://localhost:61616)?useJmx=false&persistent=false"
+     * @required
+     */
+    private String configUri;
+
+    /**
+     * Indicates whether to fork the broker, useful for integration tests.
+     *
+     * @parameter expression="${fork}" default-value="false"
+     */
+    private boolean fork;
+
+    /**
+     * System properties to add
+     *
+     * @parameter expression="${systemProperties}"
+     */
+    private Properties systemProperties;
+
+    public void execute() throws MojoExecutionException {
+        setSystemProperties();
+        getLog().info("Loading broker configUri: " + configUri);
+
+        
+        Broker.start(fork, configUri);
+        
+        getLog().info("Started the ActiveMQ Broker");
+    }
+
+    /**
+     * Set system properties
+     */
+    protected void setSystemProperties() {
+        // Set the default properties
+        System.setProperty("activemq.base", project.getBuild().getDirectory() + "/");
+        System.setProperty("activemq.home", project.getBuild().getDirectory() + "/");
+        System.setProperty("org.apache.activemq.UseDedicatedTaskRunner", "true");
+        System.setProperty("org.apache.activemq.default.directory.prefix", project.getBuild().getDirectory() + "/");
+        System.setProperty("derby.system.home", project.getBuild().getDirectory() + "/");
+        System.setProperty("derby.storage.fileSyncTransactionLog", "true");
+
+        // Overwrite any custom properties
+        System.getProperties().putAll(systemProperties);
+    }
+}

--- a/activemq-tooling/maven-activemq-plugin/src/main/java/org/apache/activemq/maven/StopBrokerMojo.java
+++ b/activemq-tooling/maven-activemq-plugin/src/main/java/org/apache/activemq/maven/StopBrokerMojo.java
@@ -1,0 +1,52 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.maven;
+
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+
+/**
+ * Goal which stops an activemq broker.
+ *
+ * @goal stop
+ * @phase process-sources
+ */
+public class StopBrokerMojo extends AbstractMojo {
+
+    public void execute() throws MojoExecutionException {
+        Broker.stop();
+
+        getLog().info("Stopped the ActiveMQ Broker");
+    }
+}


### PR DESCRIPTION
Branched out of the 5.5.1 tag.

Adds a "stop" goal to the ActiveMQ Maven plugin for stopping the broker service on demand, requested by:
https://issues.apache.org/jira/browse/AMQ-3452
https://issues.apache.org/jira/browse/AMQ-4509
