### PR TITLE
AMQ-5106 fix: unable to build trunk from scratch due to missing dependency (eclipse:eclipse)

### DIFF
--- a/activemq-karaf-itest/pom.xml
+++ b/activemq-karaf-itest/pom.xml
@@ -129,6 +129,10 @@
           <groupId>org.eclipse</groupId>
           <artifactId>osgi</artifactId>
         </exclusion>
+	<exclusion>
+	  <groupId>org.apache.xerces</groupId>
+	  <artifactId>xercesImpl</artifactId>
+	</exclusion>
       </exclusions>
     </dependency>
     <dependency>


### PR DESCRIPTION
This will fix the issue:

https://issues.apache.org/jira/browse/AMQ-5106
