### PR TITLE
Fixed AMQ-5187 added support for virtual destination subscription recovery

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/broker/region/DestinationFilter.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/region/DestinationFilter.java
@@ -406,4 +406,15 @@ public class DestinationFilter implements Destination {
     public Destination getNext() {
         return next;
     }
+
+    public <T> T getAdaptor(Class <? extends T> clazz) {
+        if (clazz.isInstance(this)) {
+            return clazz.cast(this);
+        } else if (next != null && clazz.isInstance(next)) {
+            return clazz.cast(next);
+        } else if (next instanceof DestinationFilter) {
+            return ((DestinationFilter)next).getAdaptor(clazz);
+        }
+        return null;
+    }
 }

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/region/virtual/CompositeQueue.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/region/virtual/CompositeQueue.java
@@ -32,4 +32,11 @@ public class CompositeQueue extends CompositeDestination {
     public ActiveMQDestination getVirtualDestination() {
         return new ActiveMQQueue(getName());
     }
+
+    @Override
+    public Destination interceptMappedDestination(Destination destination) {
+        // nothing to do for mapped destinations
+        return destination;
+    }
+
 }

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/region/virtual/CompositeTopic.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/region/virtual/CompositeTopic.java
@@ -16,6 +16,7 @@
  */
 package org.apache.activemq.broker.region.virtual;
 
+import org.apache.activemq.broker.region.Destination;
 import org.apache.activemq.command.ActiveMQDestination;
 import org.apache.activemq.command.ActiveMQTopic;
 
@@ -31,4 +32,14 @@ public class CompositeTopic extends CompositeDestination {
     public ActiveMQDestination getVirtualDestination() {
         return new ActiveMQTopic(getName());
     }
+
+    @Override
+    public Destination interceptMappedDestination(Destination destination) {
+        if (!isForwardOnly() && destination.getActiveMQDestination().isQueue()) {
+            // recover retroactive messages in mapped Queue
+            return new MappedQueueFilter(getVirtualDestination(), destination);
+        }
+        return destination;
+    }
+
 }

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/region/virtual/MappedQueueFilter.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/region/virtual/MappedQueueFilter.java
@@ -1,0 +1,91 @@
+package org.apache.activemq.broker.region.virtual;
+
+import java.util.Set;
+
+import org.apache.activemq.broker.ConnectionContext;
+import org.apache.activemq.broker.region.BaseDestination;
+import org.apache.activemq.broker.region.Destination;
+import org.apache.activemq.broker.region.DestinationFilter;
+import org.apache.activemq.broker.region.IndirectMessageReference;
+import org.apache.activemq.broker.region.RegionBroker;
+import org.apache.activemq.broker.region.Subscription;
+import org.apache.activemq.broker.region.Topic;
+import org.apache.activemq.command.ActiveMQDestination;
+import org.apache.activemq.command.Message;
+import org.apache.activemq.util.SubscriptionKey;
+
+/**
+ * Creates a mapped Queue that can recover messages from subscription recovery policy of its Virtual Topic.
+ *
+ * @author Dhiraj Bokde
+ */
+public class MappedQueueFilter extends DestinationFilter {
+
+    private final ActiveMQDestination virtualDestination;
+
+    public MappedQueueFilter(ActiveMQDestination virtualDestination, Destination destination) {
+        super(destination);
+        this.virtualDestination = virtualDestination;
+    }
+
+    @Override
+    public synchronized void addSubscription(ConnectionContext context, Subscription sub) throws Exception {
+        // recover messages for first consumer only
+        boolean noSubs = getConsumers().isEmpty();
+
+        super.addSubscription(context, sub);
+
+        if (noSubs && !getConsumers().isEmpty()) {
+            // new subscription added, recover retroactive messages
+            final RegionBroker regionBroker = (RegionBroker) context.getBroker().getAdaptor(RegionBroker.class);
+            final Set<Destination> virtualDests = regionBroker.getDestinations(virtualDestination);
+
+            final ActiveMQDestination newDestination = sub.getActiveMQDestination();
+            final BaseDestination regionDest = getBaseDestination((Destination)
+                regionBroker.getDestinations(newDestination).toArray()[0]);
+
+            for (Destination virtualDest : virtualDests) {
+                if (virtualDest.getActiveMQDestination().isTopic() &&
+                    (virtualDest.isAlwaysRetroactive() || sub.getConsumerInfo().isRetroactive())) {
+                    Topic topic = (Topic) getBaseDestination(virtualDest);
+                    if (topic != null) {
+                        // re-use browse() to get recovered messages
+                        final Message[] messages = topic.getSubscriptionRecoveryPolicy().browse(
+                            topic.getActiveMQDestination());
+
+                        // add recovered messages to subscription
+                        for (Message message : messages) {
+                            final Message copy = message.copy();
+                            copy.setOriginalDestination(message.getDestination());
+                            copy.setDestination(newDestination);
+                            copy.setRegionDestination(regionDest);
+                            sub.addRecoveredMessage(context,
+                                newDestination.isQueue() ? new IndirectMessageReference(copy) : copy);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private BaseDestination getBaseDestination(Destination virtualDest) {
+        if (virtualDest instanceof BaseDestination) {
+            return (BaseDestination) virtualDest;
+        } else if (virtualDest instanceof DestinationFilter) {
+            return ((DestinationFilter)virtualDest).getAdaptor(BaseDestination.class);
+        }
+        return null;
+    }
+
+    @Override
+    public synchronized void removeSubscription(ConnectionContext context,
+                                                Subscription sub, long lastDeliveredSequenceId) throws Exception {
+        super.removeSubscription(context, sub, lastDeliveredSequenceId);
+    }
+
+    @Override
+    public synchronized void deleteSubscription(ConnectionContext context, SubscriptionKey key) throws Exception {
+        super.deleteSubscription(context, key);
+    }
+
+}

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/region/virtual/VirtualDestination.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/region/virtual/VirtualDestination.java
@@ -36,4 +36,15 @@ public interface VirtualDestination extends DestinationInterceptor {
      * Creates a virtual destination from the physical destination
      */
     Destination intercept(Destination destination);
+
+    /**
+     * Returns mapped destination(s)
+     */
+    ActiveMQDestination getMappedDestinations();
+
+    /**
+     * Creates a mapped destination
+     */
+    Destination interceptMappedDestination(Destination destination);
+
 }

--- a/activemq-mqtt/src/test/java/org/apache/activemq/transport/mqtt/MQTTTest.java
+++ b/activemq-mqtt/src/test/java/org/apache/activemq/transport/mqtt/MQTTTest.java
@@ -32,6 +32,7 @@ import javax.jms.Connection;
 import javax.jms.Destination;
 import javax.jms.MessageConsumer;
 import javax.jms.MessageProducer;
+import javax.jms.Queue;
 import javax.jms.Session;
 import javax.jms.TextMessage;
 
@@ -44,11 +45,19 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import org.apache.activemq.ActiveMQConnection;
+import org.apache.activemq.ActiveMQConnectionFactory;
+import org.apache.activemq.broker.TransportConnector;
+import org.apache.activemq.broker.region.DestinationInterceptor;
 import org.apache.activemq.broker.region.policy.LastImageSubscriptionRecoveryPolicy;
 import org.apache.activemq.broker.region.policy.PolicyEntry;
 import org.apache.activemq.broker.region.policy.PolicyMap;
 import org.apache.activemq.broker.region.policy.RetainedMessageSubscriptionRecoveryPolicy;
+import org.apache.activemq.broker.region.virtual.CompositeTopic;
+import org.apache.activemq.broker.region.virtual.VirtualDestination;
+import org.apache.activemq.broker.region.virtual.VirtualDestinationInterceptor;
+import org.apache.activemq.command.ActiveMQDestination;
 import org.apache.activemq.command.ActiveMQMessage;
+import org.apache.activemq.command.ActiveMQQueue;
 import org.apache.activemq.command.ActiveMQTopic;
 import org.apache.activemq.util.ByteSequence;
 import org.apache.activemq.util.Wait;
@@ -958,6 +967,162 @@ public class MQTTTest extends MQTTTestSupport {
             bs = message.getContent();
             assertEquals(payload, new String(bs.data, bs.offset, bs.length));
         }
+
+        activeMQConnection.close();
+        provider.disconnect();
+    }
+
+    @Test(timeout = 60 * 1000)
+    public void testSendMQTTReceiveJMSVirtualTopic() throws Exception {
+
+        final MQTTClientProvider provider = getMQTTClientProvider();
+        initializeConnection(provider);
+        final String DESTINATION_NAME = "Consumer.jms.VirtualTopic.TopicA";
+
+        // send retained message
+        final String RETAINED = "RETAINED";
+        final String MQTT_DESTINATION_NAME = "VirtualTopic/TopicA";
+        provider.publish(MQTT_DESTINATION_NAME, RETAINED.getBytes(), AT_LEAST_ONCE, true);
+
+        ActiveMQConnection activeMQConnection = (ActiveMQConnection) new ActiveMQConnectionFactory(jmsUri).createConnection();
+        // MUST set to true to receive retained messages
+        activeMQConnection.setUseRetroactiveConsumer(true);
+        activeMQConnection.start();
+        Session s = activeMQConnection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+        Queue jmsQueue = s.createQueue(DESTINATION_NAME);
+        MessageConsumer consumer = s.createConsumer(jmsQueue);
+
+        // check whether we received retained message on JMS subscribe
+        ActiveMQMessage message = (ActiveMQMessage) consumer.receive(5000);
+        assertNotNull("Should get retained message", message);
+        ByteSequence bs = message.getContent();
+        assertEquals(RETAINED, new String(bs.data, bs.offset, bs.length));
+        assertTrue(message.getBooleanProperty(RetainedMessageSubscriptionRecoveryPolicy.RETAINED_PROPERTY));
+
+        for (int i = 0; i < NUM_MESSAGES; i++) {
+            String payload = "Test Message: " + i;
+            provider.publish(MQTT_DESTINATION_NAME, payload.getBytes(), AT_LEAST_ONCE);
+            message = (ActiveMQMessage) consumer.receive(5000);
+            assertNotNull("Should get a message", message);
+            bs = message.getContent();
+            assertEquals(payload, new String(bs.data, bs.offset, bs.length));
+        }
+
+        // re-create consumer and check we received retained message again
+        consumer.close();
+        consumer = s.createConsumer(jmsQueue);
+        message = (ActiveMQMessage) consumer.receive(5000);
+        assertNotNull("Should get retained message", message);
+        bs = message.getContent();
+        assertEquals(RETAINED, new String(bs.data, bs.offset, bs.length));
+        assertTrue(message.getBooleanProperty(RetainedMessageSubscriptionRecoveryPolicy.RETAINED_PROPERTY));
+
+        activeMQConnection.close();
+        provider.disconnect();
+    }
+
+    @Test(timeout = 60 * 1000)
+    public void testSendMQTTReceiveJMSCompositeDestinations() throws Exception {
+
+        stopBroker();
+        startBroker(false);
+
+        // configure composite topic
+        final String COMPOSITE_TOPIC = "Composite.TopicA";
+        final String FORWARD_QUEUE = "Composite.Queue.A";
+        final String FORWARD_TOPIC = "Composite.Topic.A";
+        final CompositeTopic compositeTopic = new CompositeTopic();
+        compositeTopic.setName(COMPOSITE_TOPIC);
+        final ArrayList<ActiveMQDestination> forwardDestinations = new ArrayList<ActiveMQDestination>();
+        forwardDestinations.add(new ActiveMQQueue(FORWARD_QUEUE));
+        forwardDestinations.add(new ActiveMQTopic(FORWARD_TOPIC));
+        compositeTopic.setForwardTo(forwardDestinations);
+        // NOTE: allows retained messages to be set on the Composite
+        compositeTopic.setForwardOnly(false);
+
+        final VirtualDestinationInterceptor destinationInterceptor = new VirtualDestinationInterceptor();
+        destinationInterceptor.setVirtualDestinations(new VirtualDestination[] {compositeTopic} );
+        brokerService.setDestinationInterceptors(new DestinationInterceptor[] { destinationInterceptor });
+        brokerService.start();
+        brokerService.waitUntilStarted();
+
+        final MQTTClientProvider provider = getMQTTClientProvider();
+        initializeConnection(provider);
+
+        // send retained message
+        final String MQTT_TOPIC = "Composite/TopicA";
+        final String RETAINED = "RETAINED";
+        provider.publish(MQTT_TOPIC, RETAINED.getBytes(), AT_LEAST_ONCE, true);
+
+        ActiveMQConnection activeMQConnection = (ActiveMQConnection) new ActiveMQConnectionFactory(jmsUri).createConnection();
+        // MUST set to true to receive retained messages
+        activeMQConnection.setUseRetroactiveConsumer(true);
+        activeMQConnection.setClientID("jms-client");
+        activeMQConnection.start();
+        Session s = activeMQConnection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+
+        javax.jms.Queue jmsQueue = s.createQueue(FORWARD_QUEUE);
+        javax.jms.Topic jmsTopic = s.createTopic(FORWARD_TOPIC);
+
+        MessageConsumer queueConsumer = s.createConsumer(jmsQueue);
+        MessageConsumer topicConsumer = s.createDurableSubscriber(jmsTopic, "jms-subscription");
+
+        // check whether we received retained message twice on mapped Queue, once marked as RETAINED
+        ActiveMQMessage message;
+        ByteSequence bs;
+        for (int i = 0; i < 2; i++) {
+            message = (ActiveMQMessage) queueConsumer.receive(5000);
+            assertNotNull("Should get retained message from " + FORWARD_QUEUE, message);
+            bs = message.getContent();
+            assertEquals(RETAINED, new String(bs.data, bs.offset, bs.length));
+            assertTrue(message.getBooleanProperty(RetainedMessageSubscriptionRecoveryPolicy.RETAIN_PROPERTY) != message.getBooleanProperty(RetainedMessageSubscriptionRecoveryPolicy.RETAINED_PROPERTY));
+        }
+
+        // check whether we received retained message on mapped Topic
+        message = (ActiveMQMessage) topicConsumer.receive(5000);
+        assertNotNull("Should get retained message from " + FORWARD_TOPIC, message);
+        bs = message.getContent();
+        assertEquals(RETAINED, new String(bs.data, bs.offset, bs.length));
+        assertFalse(message.getBooleanProperty(RetainedMessageSubscriptionRecoveryPolicy.RETAIN_PROPERTY));
+        assertTrue(message.getBooleanProperty(RetainedMessageSubscriptionRecoveryPolicy.RETAINED_PROPERTY));
+
+        for (int i = 0; i < NUM_MESSAGES; i++) {
+            String payload = "Test Message: " + i;
+            provider.publish(MQTT_TOPIC, payload.getBytes(), AT_LEAST_ONCE);
+
+            message = (ActiveMQMessage) queueConsumer.receive(5000);
+            assertNotNull("Should get a message from " + FORWARD_QUEUE, message);
+            bs = message.getContent();
+            assertEquals(payload, new String(bs.data, bs.offset, bs.length));
+
+            message = (ActiveMQMessage) topicConsumer.receive(5000);
+            assertNotNull("Should get a message from " + FORWARD_TOPIC, message);
+            bs = message.getContent();
+            assertEquals(payload, new String(bs.data, bs.offset, bs.length));
+        }
+
+        // close consumer and look for retained messages again
+        queueConsumer.close();
+        topicConsumer.close();
+
+        queueConsumer = s.createConsumer(jmsQueue);
+        topicConsumer = s.createDurableSubscriber(jmsTopic, "jms-subscription");
+
+        // check whether we received retained message on mapped Queue, again
+        message = (ActiveMQMessage) queueConsumer.receive(5000);
+        assertNotNull("Should get recovered retained message from " + FORWARD_QUEUE, message);
+        bs = message.getContent();
+        assertEquals(RETAINED, new String(bs.data, bs.offset, bs.length));
+        assertTrue(message.getBooleanProperty(RetainedMessageSubscriptionRecoveryPolicy.RETAINED_PROPERTY));
+        assertNull("Should not get second retained message from " + FORWARD_QUEUE, queueConsumer.receive(5000));
+
+        // check whether we received retained message on mapped Topic, again
+        message = (ActiveMQMessage) topicConsumer.receive(5000);
+        assertNotNull("Should get recovered retained message from " + FORWARD_TOPIC, message);
+        bs = message.getContent();
+        assertEquals(RETAINED, new String(bs.data, bs.offset, bs.length));
+        assertTrue(message.getBooleanProperty(RetainedMessageSubscriptionRecoveryPolicy.RETAINED_PROPERTY));
+        assertNull("Should not get second retained message from " + FORWARD_TOPIC, topicConsumer.receive(5000));
 
         activeMQConnection.close();
         provider.disconnect();

--- a/activemq-mqtt/src/test/java/org/apache/activemq/transport/mqtt/MQTTTest.java
+++ b/activemq-mqtt/src/test/java/org/apache/activemq/transport/mqtt/MQTTTest.java
@@ -46,7 +46,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import org.apache.activemq.ActiveMQConnection;
 import org.apache.activemq.ActiveMQConnectionFactory;
-import org.apache.activemq.broker.TransportConnector;
 import org.apache.activemq.broker.region.DestinationInterceptor;
 import org.apache.activemq.broker.region.policy.LastImageSubscriptionRecoveryPolicy;
 import org.apache.activemq.broker.region.policy.PolicyEntry;
@@ -1041,8 +1040,8 @@ public class MQTTTest extends MQTTTestSupport {
         compositeTopic.setForwardOnly(false);
 
         final VirtualDestinationInterceptor destinationInterceptor = new VirtualDestinationInterceptor();
-        destinationInterceptor.setVirtualDestinations(new VirtualDestination[] {compositeTopic} );
-        brokerService.setDestinationInterceptors(new DestinationInterceptor[] { destinationInterceptor });
+        destinationInterceptor.setVirtualDestinations(new VirtualDestination[]{compositeTopic});
+        brokerService.setDestinationInterceptors(new DestinationInterceptor[]{destinationInterceptor});
         brokerService.start();
         brokerService.waitUntilStarted();
 

--- a/activemq-mqtt/src/test/java/org/apache/activemq/transport/mqtt/MQTTTest.java
+++ b/activemq-mqtt/src/test/java/org/apache/activemq/transport/mqtt/MQTTTest.java
@@ -692,7 +692,7 @@ public class MQTTTest extends MQTTTestSupport {
         connection.connect();
         final String TOPIC = "TopicA/";
         final String[] topics = new String[] { TOPIC, "TopicA/+" };
-        connection.subscribe(new Topic[] { new Topic(topics[0], QoS.AT_LEAST_ONCE), new Topic(topics[1], QoS.EXACTLY_ONCE) });
+        connection.subscribe(new Topic[]{new Topic(topics[0], QoS.AT_LEAST_ONCE), new Topic(topics[1], QoS.EXACTLY_ONCE)});
 
         // publish non-retained message
         connection.publish(TOPIC, TOPIC.getBytes(), QoS.EXACTLY_ONCE, false);
@@ -761,7 +761,7 @@ public class MQTTTest extends MQTTTestSupport {
         BlockingConnection connection = mqtt.blockingConnection();
         connection.connect();
         final String TOPIC = "TopicA/";
-        connection.subscribe(new Topic[] { new Topic(TOPIC, QoS.EXACTLY_ONCE) });
+        connection.subscribe(new Topic[]{new Topic(TOPIC, QoS.EXACTLY_ONCE)});
 
         // publish non-retained messages
         final int TOTAL_MESSAGES = 10;
@@ -1123,6 +1123,10 @@ public class MQTTTest extends MQTTTestSupport {
         assertEquals(RETAINED, new String(bs.data, bs.offset, bs.length));
         assertTrue(message.getBooleanProperty(RetainedMessageSubscriptionRecoveryPolicy.RETAINED_PROPERTY));
         assertNull("Should not get second retained message from " + FORWARD_TOPIC, topicConsumer.receive(5000));
+
+        // create second queue consumer and verify that it doesn't trigger message recovery
+        final MessageConsumer queueConsumer2 = s.createConsumer(jmsQueue);
+        assertNull("Second consumer MUST not receive retained message from " + FORWARD_QUEUE, queueConsumer2.receive(5000));
 
         activeMQConnection.close();
         provider.disconnect();

--- a/activemq-mqtt/src/test/java/org/apache/activemq/transport/mqtt/MQTTTestSupport.java
+++ b/activemq-mqtt/src/test/java/org/apache/activemq/transport/mqtt/MQTTTestSupport.java
@@ -119,6 +119,10 @@ public class MQTTTestSupport {
     }
 
     public void startBroker() throws Exception {
+        startBroker(true);
+    }
+
+    public void startBroker(boolean start) throws Exception {
 
         createBroker();
 
@@ -160,8 +164,10 @@ public class MQTTTestSupport {
             brokerService.setPlugins(plugins.toArray(array));
         }
 
-        brokerService.start();
-        brokerService.waitUntilStarted();
+        if (start) {
+            brokerService.start();
+            brokerService.waitUntilStarted();
+        }
     }
 
     protected void applyMemoryLimitPolicy() throws Exception {


### PR DESCRIPTION
This patch adds support for applying subscription recovery policy to mapped Queues for virtual destinations. This is a MUST for mapping MQTT retained messages from Virtual/Composite Topics to mapped Queues. 

Since it depends on AMQ-5160, it Includes commits from https://github.com/apache/activemq/pull/22. 