### PR TITLE
Wrap Zookeeper bundle

### DIFF
--- a/activemq-karaf/src/main/resources/features-core.xml
+++ b/activemq-karaf/src/main/resources/features-core.xml
@@ -31,7 +31,7 @@
         <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jaxb-impl/${jaxb-bundle-version}</bundle>
         <bundle dependency="false">mvn:commons-pool/commons-pool/${commons-pool-version}</bundle>
         <bundle dependency="false">mvn:commons-net/commons-net/${commons-net-version}</bundle>
-        <bundle dependency='true'>mvn:org.apache.zookeeper/zookeeper/${zookeeper-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:org.apache.zookeeper/zookeeper/3.4.5$Import-Package=*;resolution:=optional&amp;Export-Package=org.apache.zookeeper*;-noimport:=true&amp;overwrite=merge</bundle>
         <!-- uber osgi bundle means client is not that lean, todo: introduce client osgi bundle -->
         <bundle dependency="false">mvn:org.apache.xbean/xbean-spring/${xbean-version}</bundle>
         <bundle>mvn:org.apache.activemq/activemq-osgi/${project.version}</bundle>


### PR DESCRIPTION
ActiveMQ 5.10.0 fails with a class not found error when the zookeeper bundle is deployed as part of the activemq-client feature installation.

The Zookeeper bundle was wrapped in the features.xml in 5.9.1 but this seems to have been lost when the features were split into features-core & features.