### PR TITLE
Fix for https://issues.apache.org/jira/browse/AMQ-5174 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ dependency-reduced-pom.xml
 velocity.log
 
 /.metadata
+activemq-unit-tests/targetactivemq-data/
+activemq-leveldb-store/LevelDB

--- a/activemq-broker/src/main/java/org/apache/activemq/util/DefaultIOExceptionHandler.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/util/DefaultIOExceptionHandler.java
@@ -35,9 +35,8 @@ import org.slf4j.LoggerFactory;
  * @org.apache.xbean.XBean
  */
  public class DefaultIOExceptionHandler implements IOExceptionHandler {
+    private static final Logger LOG = LoggerFactory.getLogger(DefaultIOExceptionHandler.class);
 
-    private static final Logger LOG = LoggerFactory
-            .getLogger(DefaultIOExceptionHandler.class);
     protected BrokerService broker;
     private boolean ignoreAllErrors = false;
     private boolean ignoreNoSpaceErrors = true;

--- a/activemq-broker/src/main/java/org/apache/activemq/util/LeaseLockerIOExceptionHandler.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/util/LeaseLockerIOExceptionHandler.java
@@ -1,0 +1,50 @@
+package org.apache.activemq.util;
+
+import org.apache.activemq.broker.LockableServiceSupport;
+import org.apache.activemq.broker.Locker;
+import org.apache.activemq.broker.SuppressReplyException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+/**
+ * @org.apache.xbean.XBean
+ */
+public class LeaseLockerIOExceptionHandler extends DefaultIOExceptionHandler {
+    private static final Logger LOG = LoggerFactory.getLogger(LeaseLockerIOExceptionHandler.class);
+
+    public LeaseLockerIOExceptionHandler() {
+        setIgnoreSQLExceptions(false);
+        setStopStartConnectors(true);
+    }
+
+    // fail only when we get an authoritative answer from the db w/o exceptions
+    @Override
+    protected boolean hasLockOwnership() throws IOException {
+        boolean hasLock = true;
+
+        if (broker.getPersistenceAdapter() instanceof LockableServiceSupport) {
+            Locker locker = ((LockableServiceSupport) broker.getPersistenceAdapter()).getLocker();
+
+            if (locker != null) {
+                try {
+                    if (!locker.keepAlive()) {
+                        hasLock = false;
+                    }
+                }
+                catch (SuppressReplyException ignoreWhileHandlingInProgress) {
+                }
+                catch (IOException ignored) {
+                }
+
+                if (!hasLock) {
+                    LOG.warn("Lock keepAlive failed, no longer lock owner with: {}", locker);
+                    throw new IOException("Lock keepAlive failed, no longer lock owner with: " + locker);
+                }
+            }
+        }
+
+        return hasLock;
+    }
+}

--- a/activemq-jdbc-store/src/main/java/org/apache/activemq/store/jdbc/JDBCIOExceptionHandler.java
+++ b/activemq-jdbc-store/src/main/java/org/apache/activemq/store/jdbc/JDBCIOExceptionHandler.java
@@ -27,6 +27,10 @@ import org.slf4j.LoggerFactory;
 /**
  * @org.apache.xbean.XBean
  */
+/*
+ * @deprecated Use more general {@link org.apache.activemq.util.LeaseLockerIOExceptionHandler} instead
+ */
+@Deprecated
 public class JDBCIOExceptionHandler extends DefaultIOExceptionHandler {
     private static final Logger LOG = LoggerFactory.getLogger(JDBCIOExceptionHandler.class);
 

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/broker/ft/DbRestartJDBCQueueMasterSlaveLeaseQuiesceTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/broker/ft/DbRestartJDBCQueueMasterSlaveLeaseQuiesceTest.java
@@ -16,12 +16,13 @@
  */
 package org.apache.activemq.broker.ft;
 
-import java.util.concurrent.TimeUnit;
 import org.apache.activemq.ActiveMQConnection;
 import org.apache.activemq.broker.BrokerService;
-import org.apache.activemq.store.jdbc.JDBCIOExceptionHandler;
+import org.apache.activemq.util.LeaseLockerIOExceptionHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.TimeUnit;
 
 public class DbRestartJDBCQueueMasterSlaveLeaseQuiesceTest extends DbRestartJDBCQueueMasterSlaveLeaseTest {
     private static final transient Logger LOG = LoggerFactory.getLogger(DbRestartJDBCQueueMasterSlaveLeaseQuiesceTest.class);
@@ -31,7 +32,7 @@ public class DbRestartJDBCQueueMasterSlaveLeaseQuiesceTest extends DbRestartJDBC
     @Override
     protected void configureBroker(BrokerService brokerService) {
         // master and slave survive db restart and retain master/slave status
-        JDBCIOExceptionHandler stopConnectors = new JDBCIOExceptionHandler();
+        LeaseLockerIOExceptionHandler stopConnectors = new LeaseLockerIOExceptionHandler();
         brokerService.setIoExceptionHandler(stopConnectors);
     }
 

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/broker/ft/DbRestartJDBCQueueMasterSlaveLeaseTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/broker/ft/DbRestartJDBCQueueMasterSlaveLeaseTest.java
@@ -16,17 +16,14 @@
  */
 package org.apache.activemq.broker.ft;
 
-import java.io.IOException;
-import java.util.concurrent.TimeUnit;
-
-import org.apache.activemq.ActiveMQConnection;
 import org.apache.activemq.broker.BrokerService;
-import org.apache.activemq.store.jdbc.JDBCIOExceptionHandler;
 import org.apache.activemq.store.jdbc.JDBCPersistenceAdapter;
 import org.apache.activemq.store.jdbc.LeaseDatabaseLocker;
-import org.apache.activemq.util.DefaultIOExceptionHandler;
+import org.apache.activemq.util.LeaseLockerIOExceptionHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
 
 public class DbRestartJDBCQueueMasterSlaveLeaseTest extends DbRestartJDBCQueueMasterSlaveTest {
     private static final transient Logger LOG = LoggerFactory.getLogger(DbRestartJDBCQueueMasterSlaveLeaseTest.class);
@@ -43,11 +40,11 @@ public class DbRestartJDBCQueueMasterSlaveLeaseTest extends DbRestartJDBCQueueMa
     protected void configureBroker(BrokerService brokerService) {
         //let the brokers die on exception and master should have lease on restart
         // which will delay slave start till it expires
-        JDBCIOExceptionHandler trapSQLExceptions = new JDBCIOExceptionHandler();
-        trapSQLExceptions.setIgnoreSQLExceptions(false);
-        trapSQLExceptions.setStopStartConnectors(false);
-        trapSQLExceptions.setResumeCheckSleepPeriod(500l);
-        brokerService.setIoExceptionHandler(trapSQLExceptions);
+        LeaseLockerIOExceptionHandler ioExceptionHandler = new LeaseLockerIOExceptionHandler();
+        ioExceptionHandler.setIgnoreSQLExceptions(false);
+        ioExceptionHandler.setStopStartConnectors(false);
+        ioExceptionHandler.setResumeCheckSleepPeriod(500l);
+        brokerService.setIoExceptionHandler(ioExceptionHandler);
     }
 
     private long getLockKeepAlivePeriod() {

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/bugs/AMQ4636Test.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/bugs/AMQ4636Test.java
@@ -16,34 +16,28 @@
  */
 package org.apache.activemq.bugs;
 
-import java.io.IOException;
-import java.sql.SQLException;
-import java.util.concurrent.CountDownLatch;
-import javax.jms.Connection;
-import javax.jms.DeliveryMode;
-import javax.jms.Destination;
-import javax.jms.JMSException;
-import javax.jms.Message;
-import javax.jms.MessageProducer;
-import javax.jms.Session;
-import javax.jms.Topic;
-import javax.jms.TopicSubscriber;
 import org.apache.activemq.ActiveMQConnectionFactory;
 import org.apache.activemq.broker.BrokerService;
 import org.apache.activemq.broker.region.policy.PolicyEntry;
 import org.apache.activemq.broker.region.policy.PolicyMap;
 import org.apache.activemq.store.jdbc.DataSourceServiceSupport;
-import org.apache.activemq.store.jdbc.JDBCIOExceptionHandler;
 import org.apache.activemq.store.jdbc.JDBCPersistenceAdapter;
 import org.apache.activemq.store.jdbc.LeaseDatabaseLocker;
 import org.apache.activemq.store.jdbc.TransactionContext;
 import org.apache.activemq.util.IOHelper;
+import org.apache.activemq.util.LeaseLockerIOExceptionHandler;
 import org.apache.derby.jdbc.EmbeddedDataSource;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.jms.*;
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.concurrent.CountDownLatch;
+
 import static org.junit.Assert.fail;
 
 /**
@@ -114,7 +108,7 @@ public class AMQ4636Test {
         broker.setDestinationPolicy(policyMap);
         broker.setPersistenceAdapter(jdbc);
 
-        broker.setIoExceptionHandler(new JDBCIOExceptionHandler());
+        broker.setIoExceptionHandler(new LeaseLockerIOExceptionHandler());
 
         transportUrl = broker.addConnector(transportUrl).getPublishableConnectString();
         return broker;

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/bugs/TrapMessageInJDBCStoreTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/bugs/TrapMessageInJDBCStoreTest.java
@@ -19,23 +19,23 @@ package org.apache.activemq.bugs;
 import junit.framework.TestCase;
 import org.apache.activemq.ActiveMQConnectionFactory;
 import org.apache.activemq.broker.BrokerService;
-import org.apache.activemq.command.*;
-import org.apache.activemq.store.jdbc.*;
-import org.apache.activemq.util.ByteSequence;
+import org.apache.activemq.store.jdbc.DataSourceServiceSupport;
+import org.apache.activemq.store.jdbc.JDBCPersistenceAdapter;
+import org.apache.activemq.store.jdbc.LeaseDatabaseLocker;
+import org.apache.activemq.store.jdbc.TransactionContext;
 import org.apache.activemq.util.IOHelper;
+import org.apache.activemq.util.LeaseLockerIOExceptionHandler;
 import org.apache.derby.jdbc.EmbeddedDataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.jms.*;
-import javax.jms.Message;
 import java.io.IOException;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -82,7 +82,7 @@ public class TrapMessageInJDBCStoreTest extends TestCase {
 
         broker.setPersistenceAdapter(jdbc);
 
-        broker.setIoExceptionHandler(new JDBCIOExceptionHandler());
+        broker.setIoExceptionHandler(new LeaseLockerIOExceptionHandler());
 
         transportUrl = broker.addConnector(transportUrl).getPublishableConnectString();
         return broker;

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/store/jdbc/JDBCIOExceptionHandlerMockeryTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/store/jdbc/JDBCIOExceptionHandlerMockeryTest.java
@@ -16,11 +16,10 @@
  */
 package org.apache.activemq.store.jdbc;
 
-import java.io.IOException;
-import java.util.HashMap;
 import org.apache.activemq.broker.BrokerService;
 import org.apache.activemq.broker.Locker;
 import org.apache.activemq.broker.SuppressReplyException;
+import org.apache.activemq.util.LeaseLockerIOExceptionHandler;
 import org.apache.activemq.util.ServiceStopper;
 import org.apache.activemq.util.Wait;
 import org.jmock.Expectations;
@@ -31,6 +30,8 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
+import java.util.HashMap;
 
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -85,7 +86,7 @@ public class JDBCIOExceptionHandlerMockeryTest {
 
         }});
 
-        JDBCIOExceptionHandler underTest = new JDBCIOExceptionHandler();
+        LeaseLockerIOExceptionHandler underTest = new LeaseLockerIOExceptionHandler();
         underTest.setBrokerService(brokerService);
 
         try {

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/store/jdbc/JDBCIOExceptionHandlerTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/store/jdbc/JDBCIOExceptionHandlerTest.java
@@ -16,22 +16,21 @@
  */
 package org.apache.activemq.store.jdbc;
 
+import junit.framework.TestCase;
+import org.apache.activemq.ActiveMQConnectionFactory;
+import org.apache.activemq.broker.BrokerService;
+import org.apache.activemq.util.LeaseLockerIOExceptionHandler;
+import org.apache.activemq.util.Wait;
+import org.apache.derby.jdbc.EmbeddedDataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.jms.Connection;
 import java.io.PrintWriter;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
-
-import javax.jms.Connection;
-
-import junit.framework.TestCase;
-
-import org.apache.activemq.ActiveMQConnectionFactory;
-import org.apache.activemq.broker.BrokerService;
-import org.apache.activemq.util.Wait;
-import org.apache.derby.jdbc.EmbeddedDataSource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Test to see if the JDBCExceptionIOHandler will restart the transport connectors correctly after
@@ -78,10 +77,10 @@ public class JDBCIOExceptionHandlerTest extends TestCase {
         }
 
         broker.setPersistenceAdapter(jdbc);
-        JDBCIOExceptionHandler jdbcioExceptionHandler = new JDBCIOExceptionHandler();
-        jdbcioExceptionHandler.setResumeCheckSleepPeriod(1000l);
-        jdbcioExceptionHandler.setStopStartConnectors(startStopConnectors);
-        broker.setIoExceptionHandler(jdbcioExceptionHandler);
+        LeaseLockerIOExceptionHandler ioExceptionHandler = new LeaseLockerIOExceptionHandler();
+        ioExceptionHandler.setResumeCheckSleepPeriod(1000l);
+        ioExceptionHandler.setStopStartConnectors(startStopConnectors);
+        broker.setIoExceptionHandler(ioExceptionHandler);
         String connectionUri = broker.addConnector(TRANSPORT_URL).getPublishableConnectString();
 
         factory = new ActiveMQConnectionFactory(connectionUri);
@@ -137,10 +136,10 @@ public class JDBCIOExceptionHandlerTest extends TestCase {
                     }
 
                     broker.setPersistenceAdapter(jdbc);
-                    JDBCIOExceptionHandler jdbcioExceptionHandler = new JDBCIOExceptionHandler();
-                    jdbcioExceptionHandler.setResumeCheckSleepPeriod(1000l);
-                    jdbcioExceptionHandler.setStopStartConnectors(false);
-                    broker.setIoExceptionHandler(jdbcioExceptionHandler);
+                    LeaseLockerIOExceptionHandler ioExceptionHandler = new LeaseLockerIOExceptionHandler();
+                    ioExceptionHandler.setResumeCheckSleepPeriod(1000l);
+                    ioExceptionHandler.setStopStartConnectors(false);
+                    broker.setIoExceptionHandler(ioExceptionHandler);
                     slave.set(broker);
                     broker.start();
                 } catch (Exception e) {


### PR DESCRIPTION
- Cannot use the `JDBCIOExceptionHandler` when `KahaDB` is configured to use a `lease-database-locker`.
