### PR TITLE
https://issues.apache.org/jira/browse/AMQ-4848 - Karaf update added Transport Connectors...

### DIFF
--- a/activemq-console/src/main/java/org/apache/activemq/console/command/ListCommand.java
+++ b/activemq-console/src/main/java/org/apache/activemq/console/command/ListCommand.java
@@ -16,6 +16,7 @@
  */
 package org.apache.activemq.console.command;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -23,7 +24,6 @@ import java.util.Set;
 import org.apache.activemq.console.util.JmxMBeansUtil;
 
 public class ListCommand extends AbstractJmxCommand {
-
     protected String[] helpFile = new String[] {
         "Task Usage: Main list [list-options]",
         "Description:  Lists all available broker in the specified JMX context.",
@@ -56,10 +56,13 @@ public class ListCommand extends AbstractJmxCommand {
      */
     protected void runTask(List tokens) throws Exception {
         try {
-            Set<String> propsView = new HashSet<String>();
-            propsView.add("brokerName");
-            context.printMBean(JmxMBeansUtil.filterMBeansView(JmxMBeansUtil.getAllBrokers(createJmxConnection()), propsView));
-        } catch (Exception e) {
+        	Set<String> propsView = new HashSet<String>();
+            propsView.add("BrokerName");
+            propsView.add("TransportConnectors");
+            List<String> queryAddObjects = new ArrayList<String>(10);
+            List addMBeans = JmxMBeansUtil.queryMBeans(createJmxConnection(), queryAddObjects, propsView);
+            context.printMBean(JmxMBeansUtil.filterMBeansView(addMBeans, propsView));
+            } catch (Exception e) {
             context.printException(new RuntimeException("Failed to execute list task. Reason: " + e));
             throw new Exception(e);
         }

--- a/activemq-karaf-itest/src/test/java/org/apache/activemq/karaf/itest/ActiveMQBrokerFeatureTest.java
+++ b/activemq-karaf-itest/src/test/java/org/apache/activemq/karaf/itest/ActiveMQBrokerFeatureTest.java
@@ -43,11 +43,10 @@ public class ActiveMQBrokerFeatureTest extends AbstractJmsFeatureTest {
 
     @Test(timeout=5 * 60 * 1000)
     public void test() throws Throwable {
-
-        withinReason(new Callable<Boolean>() {
+          withinReason(new Callable<Boolean>() {
             @Override
-            public Boolean call() throws Exception {
-                assertEquals("brokerName = amq-broker", executeCommand("activemq:list").trim());
+            public Boolean call() throws Exception { 
+                assertEquals("BrokerName = amq-broker", executeCommand("activemq:list").trim().split("\n")[0]);
                 return true;
             }
         });


### PR DESCRIPTION
This was a fix that I sent pull request #28 which was from Jun 17, 2014. I fixed activemq:list command and it now displays the transport connectors available for the broker on karaf. Can anyone review this patch. If the fix is good then can this be merged? 

![screen shot 2015-02-11 at 4 14 05 pm 2](https://cloud.githubusercontent.com/assets/1269759/6156952/a8b3eae2-b20b-11e4-8cd1-7ae9bca809d0.png)

Also I've updated the pax exam unit test so the integration test does not fail.

![screen shot 2015-02-11 at 4 26 39 pm 2](https://cloud.githubusercontent.com/assets/1269759/6156968/cfaef740-b20b-11e4-9dd7-1fe04a2e84b9.png)
