### PR TITLE
https://issues.apache.org/jira/browse/AMQ-4929 - remove old and unused org.apache.activemq.broker.BrokerService#setSupportFailOver

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/broker/BrokerService.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/BrokerService.java
@@ -1770,13 +1770,7 @@ public class BrokerService implements Service {
         return this.supportFailOver;
     }
 
-    /**
-     * @param supportFailOver
-     *            the supportFailOver to set
-     */
-    public void setSupportFailOver(boolean supportFailOver) {
-        this.supportFailOver = supportFailOver;
-    }
+  
 
     /**
      * Looks up and lazily creates if necessary the destination for the given


### PR DESCRIPTION
I've removed the unused method `org.apache.activemq.broker.BrokerService#setSupportFailOver`. Thank you for taking the time to review this patch and merging to master.