### PR TITLE
AMQ-4598 purge enhancement

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/broker/region/Queue.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/region/Queue.java
@@ -1248,7 +1248,7 @@ public class Queue extends BaseDestination implements Task, UsageListener, Index
             LOG.info("{} purged of {} messages", getActiveMQDestination().getQualifiedName(), originalMessageCount);
         }
         gc();
-        this.destinationStatistics.getMessages().setCount(0);
+        this.destinationStatistics.getMessages().setCount(this.destinationStatistics.getInflight().getCount());
         getMessages().clear();
     }
 


### PR DESCRIPTION
Reset queue counter during "purge" to the number of inflight messages, so that they are not "hidden" while still being processed.
