### PR TITLE
revise set and get methods name of Activation Spec properties "Redeliver...

### DIFF
--- a/activemq-ra/src/main/java/org/apache/activemq/ra/ActiveMQActivationSpec.java
+++ b/activemq-ra/src/main/java/org/apache/activemq/ra/ActiveMQActivationSpec.java
@@ -593,7 +593,15 @@ public class ActiveMQActivationSpec implements MessageActivationSpec, Serializab
         }
     }
 
+    @Deprecated
     public double getBackOffMultiplier() {
+        if (redeliveryPolicy == null) {
+            return 0;
+        }
+        return redeliveryPolicy.getBackOffMultiplier();
+    }
+
+    public double getRedeliveryBackOffMultiplier() {
         if (redeliveryPolicy == null) {
             return 0;
         }
@@ -614,6 +622,7 @@ public class ActiveMQActivationSpec implements MessageActivationSpec, Serializab
         return redeliveryPolicy.getMaximumRedeliveries();
     }
 
+    @Deprecated
     public boolean isUseExponentialBackOff() {
         if (redeliveryPolicy == null) {
             return false;
@@ -621,11 +630,20 @@ public class ActiveMQActivationSpec implements MessageActivationSpec, Serializab
         return redeliveryPolicy.isUseExponentialBackOff();
     }
 
-    /**
-     * 
-     */
+    public boolean isRedeliveryUseExponentialBackOff() {
+        if (redeliveryPolicy == null) {
+            return false;
+        }
+        return redeliveryPolicy.isUseExponentialBackOff();
+    }
+
+    @Deprecated
     public void setBackOffMultiplier(double backOffMultiplier) {
         lazyCreateRedeliveryPolicy().setBackOffMultiplier(backOffMultiplier);
+    }
+
+    public void setRedeliveryBackOffMultiplier(double redeliveryBackOffMultiplier) {
+        lazyCreateRedeliveryPolicy().setBackOffMultiplier(redeliveryBackOffMultiplier);
     }
     
     public long getMaximumRedeliveryDelay() {
@@ -654,11 +672,13 @@ public class ActiveMQActivationSpec implements MessageActivationSpec, Serializab
         lazyCreateRedeliveryPolicy().setMaximumRedeliveries(maximumRedeliveries);
     }
 
-    /**
-     * 
-     */
+
     public void setUseExponentialBackOff(boolean useExponentialBackOff) {
         lazyCreateRedeliveryPolicy().setUseExponentialBackOff(useExponentialBackOff);
+    }
+
+    public void setRedeliveryUseExponentialBackOff(boolean redeliveryUseExponentialBackOff) {
+        lazyCreateRedeliveryPolicy().setUseExponentialBackOff(redeliveryUseExponentialBackOff);
     }
 
     // don't use getter to avoid causing introspection errors in containers

--- a/activemq-ra/src/main/java/org/apache/activemq/ra/MessageActivationSpec.java
+++ b/activemq-ra/src/main/java/org/apache/activemq/ra/MessageActivationSpec.java
@@ -115,7 +115,10 @@ public interface MessageActivationSpec extends ActivationSpec {
 
     String getMaxMessagesPerBatch();
 
+    @Deprecated
     double getBackOffMultiplier();
+
+    double getRedeliveryBackOffMultiplier();
     
     long getMaximumRedeliveryDelay();
 
@@ -123,7 +126,10 @@ public interface MessageActivationSpec extends ActivationSpec {
 
     int getMaximumRedeliveries();
 
+    @Deprecated
     boolean isUseExponentialBackOff();
+
+    boolean isRedeliveryUseExponentialBackOff();
 
     RedeliveryPolicy redeliveryPolicy();
 


### PR DESCRIPTION
...yBackOffMultiplier" and "RedeliveryUseExponentialBackOff" to allow configuration through @ActivationConfigProperty.

https://issues.apache.org/jira/browse/AMQ-5613

Activation Spec properties[1] "RedeliveryBackOffMultiplier" and "RedeliveryUseExponentialBackOff" can not be used within @ActivationConfigProperty, in contrast, it accepts "backOffMultiplier" and "useExponentialBackOff".

[1] http://activemq.apache.org/resource-adapter-properties.html
