### PR TITLE
Fix to only include the activemq opts for memory when start is called.  ...

### DIFF
--- a/assembly/src/release/bin/activemq
+++ b/assembly/src/release/bin/activemq
@@ -297,7 +297,7 @@ invokeJar(){
    fi
    # Execute java binary
    if [ -n "$PIDFILE" ] && [ "$PIDFILE" != "stop" ];then
-      $EXEC_OPTION $DOIT_PREFIX "\"$JAVACMD\" $ACTIVEMQ_OPTS $ACTIVEMQ_DEBUG_OPTS \
+      $EXEC_OPTION $DOIT_PREFIX "\"$JAVACMD\" $ACTIVEMQ_OPTS_MEMORY $ACTIVEMQ_OPTS $ACTIVEMQ_DEBUG_OPTS \
               -Dactivemq.classpath=\"${ACTIVEMQ_CLASSPATH}\" \
               -Dactivemq.home=\"${ACTIVEMQ_HOME}\" \
               -Dactivemq.base=\"${ACTIVEMQ_BASE}\" \

--- a/assembly/src/release/bin/env
+++ b/assembly/src/release/bin/env
@@ -24,7 +24,7 @@ if [ -z "$ACTIVEMQ_OPTS_MEMORY" ] ; then
 fi
 
 if [ -z "$ACTIVEMQ_OPTS" ] ; then
-    ACTIVEMQ_OPTS="$ACTIVEMQ_OPTS_MEMORY -Djava.util.logging.config.file=logging.properties -Djava.security.auth.login.config=$ACTIVEMQ_CONF/login.config"
+    ACTIVEMQ_OPTS="-Djava.util.logging.config.file=logging.properties -Djava.security.auth.login.config=$ACTIVEMQ_CONF/login.config"
 fi
 
 # Uncomment to enable audit logging


### PR DESCRIPTION
...If we don't do this we end up potentially allocating too much memory if -Xms is a high value.
