### PR TITLE
Changes for https://issues.apache.org/jira/browse/AMQ-5642.

### DIFF
--- a/activemq-rar/src/main/rar/META-INF/ra.xml
+++ b/activemq-rar/src/main/rar/META-INF/ra.xml
@@ -186,6 +186,14 @@
             <config-property-type>java.lang.Boolean</config-property-type>
           </config-property>
       </adminobject>
+      <adminobject>
+          <adminobject-interface>javax.jms.XAConnectionFactory</adminobject-interface>
+          <adminobject-class>org.apache.activemq.ActiveMQXAConnectionFactory</adminobject-class>
+          <config-property>
+            <config-property-name>brokerURL</config-property-name>
+            <config-property-type>java.lang.String</config-property-type>
+          </config-property>
+       </adminobject>
 
 
     </resourceadapter>


### PR DESCRIPTION
This would allow for configuration in the resource-adapter like this:

```xml
<admin-object class-name="org.apache.activemq.ActiveMQXAConnectionFactory" jndi-name="java:/AMQXAConnectionFactory" enabled="true" use-java-context="true" pool-name="AMQXAConnectionFactory">
    <config-property name="brokerURL">
          failover:(tcp://localhost:61616)?jms.rmIdFromConnectionId=true&amp;maxReconnectAttempts=0&amp;jms.xaAckMode=2&amp;jms.userName=admin&amp;jms.password=admin
     </config-property>
</admin-object>
```