### PR TITLE
AMQ-5645 - Updated DayOfMonth cron to roll to next month properly.

### DIFF
--- a/activemq-client/src/main/java/org/apache/activemq/broker/scheduler/CronParser.java
+++ b/activemq-client/src/main/java/org/apache/activemq/broker/scheduler/CronParser.java
@@ -324,7 +324,7 @@ public class CronParser {
         CronEntry hours = new CronEntry("Hours", tokens.get(HOURS), 0, 24);
         hours.currentWhen = calculateValues(hours);
         result.add(hours);
-        CronEntry dayOfMonth = new CronEntry("DayOfMonth", tokens.get(DAY_OF_MONTH), 1, 31);
+        CronEntry dayOfMonth = new CronEntry("DayOfMonth", tokens.get(DAY_OF_MONTH), 1, 32);
         dayOfMonth.currentWhen = calculateValues(dayOfMonth);
         result.add(dayOfMonth);
         CronEntry month = new CronEntry("Month", tokens.get(MONTH), 1, 12);

--- a/activemq-client/src/test/java/org/apache/activemq/broker/scheduler/CronParserTest.java
+++ b/activemq-client/src/test/java/org/apache/activemq/broker/scheduler/CronParserTest.java
@@ -188,6 +188,52 @@ public class CronParserTest {
     }
 
     @Test
+    public void testgetStartNextMonth() throws MessageFormatException {
+
+        // using an absolute date so that result will be absolute - Wednesday 15 Dec 2010
+        Calendar current = Calendar.getInstance();
+        current.set(2010, Calendar.DECEMBER, 15, 9, 15, 30);
+        LOG.debug("start:" + current.getTime());
+
+        String test = "* * 1 * *";
+        long next = CronParser.getNextScheduledTime(test, current.getTimeInMillis());
+
+        Calendar result = Calendar.getInstance();
+        result.setTimeInMillis(next);
+        LOG.debug("next:" + result.getTime());
+
+        assertEquals(0,result.get(Calendar.SECOND));
+        assertEquals(0,result.get(Calendar.MINUTE));
+        assertEquals(0,result.get(Calendar.HOUR_OF_DAY));
+        assertEquals(1,result.get(Calendar.DAY_OF_MONTH));
+        assertEquals(Calendar.JANUARY,result.get(Calendar.MONTH));
+        assertEquals(2011,result.get(Calendar.YEAR));
+    }
+
+    @Test
+    public void testgetNextStartCurrMonth() throws MessageFormatException {
+
+        // using an absolute date so that result will be absolute - Wednesday 15 Dec 2010
+        Calendar current = Calendar.getInstance();
+        current.set(2010, Calendar.DECEMBER, 15, 9, 15, 30);
+        LOG.debug("start:" + current.getTime());
+
+        String test = "* * 1 12 *";
+        long next = CronParser.getNextScheduledTime(test, current.getTimeInMillis());
+
+        Calendar result = Calendar.getInstance();
+        result.setTimeInMillis(next);
+        LOG.debug("next:" + result.getTime());
+
+        assertEquals(0,result.get(Calendar.SECOND));
+        assertEquals(0,result.get(Calendar.MINUTE));
+        assertEquals(0,result.get(Calendar.HOUR_OF_DAY));
+        assertEquals(1,result.get(Calendar.DAY_OF_MONTH));
+        assertEquals(Calendar.DECEMBER,result.get(Calendar.MONTH));
+        assertEquals(2011,result.get(Calendar.YEAR));
+    }
+
+    @Test
     public void testgetNextTimeDays() throws MessageFormatException {
 
         // using an absolute date so that result will be absolute - Monday 15 Nov 2010


### PR DESCRIPTION
For the Minutes and Hours tokens in CronParser.buildCronEntries() the CronEntry.end value was correctly +1 of actually allowed end values (ex. a time of 10:60 is not possible).  Updated DayOfMonth to also be +1 (32 instead of 31).  Expanded unit tests included.
