### PR TITLE
fix the inconsistency with ElectingLevelDBStore.isMaster() under AMQ-5082

### DIFF
--- a/activemq-leveldb-store/src/main/scala/org/apache/activemq/leveldb/replicated/ElectingLevelDBStore.scala
+++ b/activemq-leveldb-store/src/main/scala/org/apache/activemq/leveldb/replicated/ElectingLevelDBStore.scala
@@ -228,6 +228,7 @@ class ElectingLevelDBStore extends ProxyLevelDBStore {
     master_started.set(true)
     master.blocking_executor.execute(^{
       master.start();
+      master_stopped.set(false)
       master_started_latch.countDown()
     })
     master.blocking_executor.execute(^{


### PR DESCRIPTION
I've run through 100 iterations of the ElectingLevelDBStoreTest, I believe this fixes the intermittent issue with the ElectingLevelDBStore failing its isMaster() check.
