### PR TITLE
Ensure JMX is started on XBeanBrokerService

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/broker/BrokerService.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/BrokerService.java
@@ -2487,11 +2487,14 @@ public class BrokerService implements Service {
     }
 
     protected void startManagementContext() throws Exception {
-        getManagementContext().setBrokerName(brokerName);
-        getManagementContext().start();
-        adminView = new BrokerView(this, null);
-        ObjectName objectName = getBrokerObjectName();
-        AnnotatedMBean.registerMBean(getManagementContext(), adminView, objectName);
+        if (!getManagementContext().isStarted())
+        {
+           getManagementContext().setBrokerName(brokerName);
+           getManagementContext().start();
+           adminView = new BrokerView(this, null);
+           ObjectName objectName = getBrokerObjectName();
+           AnnotatedMBean.registerMBean(getManagementContext(), adminView, objectName);
+        }
     }
 
     /**

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/jmx/ManagementContext.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/jmx/ManagementContext.java
@@ -315,6 +315,11 @@ public class ManagementContext implements Service {
         return connectorStarting.get() || (connectorServer != null && connectorServer.isActive());
     }
 
+    public boolean isStarted()
+    {
+       return started.get();
+    }
+
     /**
      * Enables/disables the searching for the Java 5 platform MBeanServer
      */

--- a/activemq-spring/src/main/java/org/apache/activemq/xbean/XBeanBrokerService.java
+++ b/activemq-spring/src/main/java/org/apache/activemq/xbean/XBeanBrokerService.java
@@ -68,7 +68,12 @@ public class XBeanBrokerService extends BrokerService {
      * @org.apache.xbean.InitMethod
      */
     public void afterPropertiesSet() throws Exception {
+        if (shouldAutostart() && isUseJmx() && !getManagementContext().isStarted()) {
+           startManagementContext();
+        }
+
         ensureSystemUsageHasStore();
+
         if (shouldAutostart()) {
             start();
         }

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/broker/jmx/JMXMasterSlaveSharedStoreTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/broker/jmx/JMXMasterSlaveSharedStoreTest.java
@@ -1,0 +1,157 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.broker.jmx;
+
+import javax.management.MBeanServerConnection;
+import javax.management.ObjectName;
+import javax.management.remote.JMXConnector;
+import javax.management.remote.JMXConnectorFactory;
+import javax.management.remote.JMXServiceURL;
+import java.io.File;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.activemq.TestSupport;
+import org.apache.activemq.store.PersistenceAdapter;
+import org.apache.activemq.store.kahadb.KahaDBPersistenceAdapter;
+import org.apache.activemq.xbean.XBeanBrokerService;
+import org.junit.Test;
+
+public class JMXMasterSlaveSharedStoreTest extends TestSupport
+{
+   protected XBeanBrokerService master;
+   protected XBeanBrokerService slave;
+   protected AtomicReference<XBeanBrokerService> slaveAtomicReference = new AtomicReference<XBeanBrokerService>();
+   protected CountDownLatch slaveStarted = new CountDownLatch(1);
+   protected PersistenceAdapter persistenceAdapter;
+   protected File messageStore;
+   protected File schedulerStoreFile;
+
+   @Override
+   protected void setUp() throws Exception
+   {
+      setMaxTestTime(TimeUnit.MINUTES.toMillis(10));
+      setAutoFail(true);
+
+      messageStore = new File("target/activemq-data/kahadb/JMXMasterSlaveSharedStoreTest");
+      schedulerStoreFile = new File("target/activemq-data/scheduler/JMXMasterSlaveSharedStoreTest/");
+
+      if (System.getProperty("basedir") == null) {
+         File file = new File(".");
+         System.setProperty("basedir", file.getAbsolutePath());
+      }
+
+      createMaster();
+
+      // Give master a chance to aquire lock.
+      Thread.sleep(1000);
+      createSlave();
+
+      super.setUp();
+   }
+
+   protected void createMaster() throws Exception
+   {
+      master = createXBeanBrokerService("master", 62001, 1098);
+      master.afterPropertiesSet();
+   }
+
+   protected void createSlave() throws Exception
+   {
+      // Start the Brokers async since starting them up could be a blocking operation..
+      new Thread(new Runnable() {
+         public void run() {
+            try
+            {
+               slave = createXBeanBrokerService("slave", 62002, 1099);
+               slave.afterPropertiesSet();
+               slaveAtomicReference.set(slave);
+               slaveStarted.countDown();
+            }
+            catch (Exception e)
+            {
+               e.printStackTrace();
+            }
+         }
+
+      }).start();
+
+      // Wait for slave to be set as new broker.
+      Thread.sleep(100);
+   }
+
+   private ManagementContext createManagementContext(String name, int port)
+   {
+      ManagementContext managementContext = new ManagementContext();
+      managementContext.setBrokerName(name);
+      managementContext.setConnectorPort(port);
+      managementContext.setConnectorHost("localhost");
+      managementContext.setCreateConnector(true);
+      return managementContext;
+   }
+
+   private XBeanBrokerService createXBeanBrokerService(String name, int port, int jmxPort) throws Exception
+   {
+      String[] connectors = { "tcp://localhost:" + port };
+      ManagementContext managementContext = createManagementContext(name, jmxPort);
+
+      // Setup messaging store
+      PersistenceAdapter persistenceAdapter = new KahaDBPersistenceAdapter();
+      persistenceAdapter.setDirectory(messageStore);
+
+      XBeanBrokerService broker = new XBeanBrokerService();
+      broker.setUseJmx(true);
+      broker.setBrokerName(name);
+      broker.setPersistenceAdapter(persistenceAdapter);
+      broker.setTransportConnectorURIs(connectors);
+      broker.setSchedulerSupport(true);
+      broker.setSchedulerDirectoryFile(schedulerStoreFile);
+      broker.setManagementContext(managementContext);
+      return broker;
+   }
+
+   private MBeanServerConnection createJMXConnector(int port) throws Exception
+   {
+      String url = "service:jmx:rmi:///jndi/rmi://localhost:" + port + "/jmxrmi";
+      JMXConnector connector = JMXConnectorFactory.connect(new JMXServiceURL(url));
+      connector.connect();
+      return connector.getMBeanServerConnection();
+   }
+
+   private String getXBeanBrokerServiceMBeanName(String brokerName)
+   {
+      return "org.apache.activemq:type=Broker,brokerName=" + brokerName;
+   }
+
+
+   @Test
+   public void testJMXMBeanIsRegisteredForSlave() throws Exception
+   {
+      assertFalse(master.isSlave());
+      assertTrue(slave.isSlave());
+
+      // Expected MBeans:
+      ObjectName masterMBeanName = new ObjectName(getXBeanBrokerServiceMBeanName("master"));
+      ObjectName slaveMBeanName = new ObjectName(getXBeanBrokerServiceMBeanName("slave"));
+
+      MBeanServerConnection connection = createJMXConnector(1099);
+      assertFalse(connection.queryMBeans(masterMBeanName, null).isEmpty());
+      assertFalse(connection.queryMBeans(slaveMBeanName, null).isEmpty());
+   }
+}


### PR DESCRIPTION
Using the XBeanBrokerService with JMX and Scheduler Support enabled.
The ManagementContext is never started when in slave mode, since
afterPropertiesSet() blocks trying to get the scheduler shared file
lock.  This patch updates the XBeanBrokerService to start the
BrokerService ManagementContext (when isJMX==true) before trying
to get the job scheduler shared file lock..