### PR TITLE
Added an uncaught exception handler to ThreadPoolExecutor

### DIFF
--- a/activemq-client/src/main/java/org/apache/activemq/thread/TaskRunnerFactory.java
+++ b/activemq-client/src/main/java/org/apache/activemq/thread/TaskRunnerFactory.java
@@ -176,7 +176,13 @@ public class TaskRunnerFactory implements Executor {
                 if (threadClassLoader != null) {
                     thread.setContextClassLoader(threadClassLoader);
                 }
-
+                thread.setUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
+                    @Override
+                    public void uncaughtException(final Thread t, final Throwable e) {
+                        LOG.error("Error in thread '{}'", t.getName(), e);
+                    }
+                });
+                
                 LOG.trace("Created thread[{}]: {}", threadName, thread);
                 return thread;
             }


### PR DESCRIPTION
 Added an uncaught exception handler to ThreadPoolExecutor getExecutor() method to log errors in threads.

This resolves https://issues.apache.org/jira/browse/AMQ-5750