### PR TITLE
Adding the ability to limit the maximum size of a message

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/broker/TransportConnection.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/TransportConnection.java
@@ -98,6 +98,7 @@ import org.apache.activemq.transport.Transport;
 import org.apache.activemq.transport.TransportDisposedIOException;
 import org.apache.activemq.util.IntrospectionSupport;
 import org.apache.activemq.util.MarshallingSupport;
+import org.apache.activemq.util.SizeFormatterUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -538,6 +539,11 @@ public class TransportConnection implements Connection, Task, CommandVisitor {
         ProducerId producerId = messageSend.getProducerId();
         ProducerBrokerExchange producerExchange = getProducerBrokerExchange(producerId);
         if (producerExchange.canDispatch(messageSend)) {
+            if (messageSend.getSize() > connector.getMaximumMessageSize()){
+                throw new IllegalStateException("Can't send message using producer " + 
+                        messageSend.getProducerId() + ": message exceeds maximum message size limit of: " + 
+                        SizeFormatterUtils.humanReadableBytes(connector.getMaximumMessageSize()));
+            }
             broker.send(producerExchange, messageSend);
         }
         return null;

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/TransportConnector.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/TransportConnector.java
@@ -73,6 +73,7 @@ public class TransportConnector implements Connector, BrokerServiceAware {
     private boolean auditNetworkProducers = false;
     private int maximumProducersAllowedPerConnection = Integer.MAX_VALUE;
     private int maximumConsumersAllowedPerConnection  = Integer.MAX_VALUE;
+    private int maximumMessageSize = Integer.MAX_VALUE;
     private PublishedAddressPolicy publishedAddressPolicy = new PublishedAddressPolicy();
     private boolean allowLinkStealing;
 
@@ -122,6 +123,7 @@ public class TransportConnector implements Connector, BrokerServiceAware {
         rc.setAuditNetworkProducers(isAuditNetworkProducers());
         rc.setMaximumConsumersAllowedPerConnection(getMaximumConsumersAllowedPerConnection());
         rc.setMaximumProducersAllowedPerConnection(getMaximumProducersAllowedPerConnection());
+        rc.setMaximumMessageSize(getMaximumMessageSize());
         rc.setPublishedAddressPolicy(getPublishedAddressPolicy());
         rc.setAllowLinkStealing(isAllowLinkStealing());
         return rc;
@@ -611,8 +613,26 @@ public class TransportConnector implements Connector, BrokerServiceAware {
         return maximumConsumersAllowedPerConnection;
     }
 
+    
     public void setMaximumConsumersAllowedPerConnection(int maximumConsumersAllowedPerConnection) {
         this.maximumConsumersAllowedPerConnection = maximumConsumersAllowedPerConnection;
+    }
+    
+    public int getMaximumMessageSize() {
+        return maximumMessageSize;
+    }
+
+    /**
+     * The maximum size of messages that can be sent through this transport.  The default is
+     * Integer.MAX_VALUE
+     * 
+     * When set using Xbean, values of the form "20 Mb", "1024kb", and "1g" can be used
+     * @org.apache.xbean.Property propertyEditor="org.apache.activemq.util.MemoryPropertyEditor"
+     *
+     * @param the maximumMessageSize
+     */
+    public void setMaximumMessageSize(int maximumMessageSize) {
+        this.maximumMessageSize = maximumMessageSize;
     }
 
     /**

--- a/activemq-broker/src/main/java/org/apache/activemq/util/SizeFormatterUtils.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/util/SizeFormatterUtils.java
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.util;
+
+import java.text.DecimalFormat;
+
+/**
+ * Utility class to help displaying bytes in a human readable way.
+ *
+ */
+public class SizeFormatterUtils {
+
+    private static final DecimalFormat formatter = new DecimalFormat("#.###");
+
+    private static String[] units = { "KiB", "MiB", "GiB", "TiB", "PiB", "EiB" };
+    private static String[] siUnits = { "KB", "MB", "GB", "TB", "PB", "EB" };
+
+    /**
+     * Format the bytes in a human readable way.  Supports both SI units (base 1000)
+     * and base 1024. This method will round to 3 decimal places.
+     * 
+     * @param bytes the bytes to format
+     * @param si true for SI, else false
+     * @return
+     */
+    public static String humanReadableBytes(long bytes, boolean si) {
+        for (int i = units.length - 1; i >= 0; i--) {
+            double unit = Math.pow(si ? 1000 : 1024, i + 1);
+            if (bytes >= unit) {
+                return formatter.format(bytes / unit) + " " + (si ? siUnits[i] : units[i]);
+            }
+        }
+        return bytes + " B";
+    }
+
+    /**
+     * Formats the bytes in a human readable way using base 1024. This method will round to 3 decimal places.
+     * 
+     * @param bytes the bytes to format
+     * @return
+     */
+    public static String humanReadableBytes(long bytes) {
+        return humanReadableBytes(bytes, false);
+    }
+}

--- a/activemq-broker/src/test/java/org/apache/activemq/util/SizeFormatterUtilsTest.java
+++ b/activemq-broker/src/test/java/org/apache/activemq/util/SizeFormatterUtilsTest.java
@@ -1,0 +1,125 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.util;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class SizeFormatterUtilsTest {
+
+    @Test
+    public void bTest() {
+        assertEquals("1 B", SizeFormatterUtils.humanReadableBytes(1));
+        assertEquals("750 B", SizeFormatterUtils.humanReadableBytes(750));
+    }
+    
+    @Test
+    public void kbTest() {
+        assertEquals("1 KiB", SizeFormatterUtils.humanReadableBytes(1024));
+        assertEquals("1.5 KiB", SizeFormatterUtils.humanReadableBytes(1536));
+    }
+
+    @Test
+    public void mbTest() {
+        assertEquals("1 MiB",
+                SizeFormatterUtils.humanReadableBytes((long) Math.pow(1024, 2)));
+        assertEquals("37 MiB", SizeFormatterUtils.humanReadableBytes(38797312));
+        assertEquals("100.03 MiB", SizeFormatterUtils.humanReadableBytes(104889057));
+    }
+
+    @Test
+    public void gbTest() {
+        assertEquals("1 GiB",
+                SizeFormatterUtils.humanReadableBytes((long) Math.pow(1024, 3)));
+        assertEquals("2 GiB",
+                SizeFormatterUtils.humanReadableBytes(Integer.MAX_VALUE));
+    }
+
+    @Test
+    public void tbTest() {
+        assertEquals("1 TiB",
+                SizeFormatterUtils.humanReadableBytes((long) Math.pow(1024, 4)));
+        assertEquals("30 TiB",
+                SizeFormatterUtils.humanReadableBytes(30 * (long) Math.pow(1024, 4)));
+    }
+
+    @Test
+    public void pbTest() {
+        assertEquals("1 PiB",
+                SizeFormatterUtils.humanReadableBytes((long) Math.pow(1024, 5)));
+        assertEquals("2 PiB",
+                SizeFormatterUtils.humanReadableBytes(2 * (long) Math.pow(1024, 5)));
+    }
+
+    @Test
+    public void ebTest() {
+        assertEquals("2 EiB",
+                SizeFormatterUtils.humanReadableBytes(2 * (long) Math.pow(1024, 6)));
+    }
+    
+    @Test
+    public void bSiTest() {
+        assertEquals("1 B", SizeFormatterUtils.humanReadableBytes(1, true));
+        assertEquals("750 B", SizeFormatterUtils.humanReadableBytes(750, true));
+    }
+    
+    @Test
+    public void kbSiTest() {
+        assertEquals("1 KB", SizeFormatterUtils.humanReadableBytes(1000, true));
+        assertEquals("1.5 KB", SizeFormatterUtils.humanReadableBytes(1500, true));
+    }
+
+    @Test
+    public void mbSiTest() {
+        assertEquals("1 MB",
+                SizeFormatterUtils.humanReadableBytes((long) Math.pow(1000, 2), true));
+        assertEquals("38 MB", SizeFormatterUtils.humanReadableBytes(38000000, true));
+    }
+
+    @Test
+    public void gbSiTest() {
+        assertEquals("1 GB",
+                SizeFormatterUtils.humanReadableBytes((long) Math.pow(1000, 3), true));
+        assertEquals("2.147 GB",
+                SizeFormatterUtils.humanReadableBytes(Integer.MAX_VALUE, true));
+    }
+
+    @Test
+    public void tbSiTest() {
+        assertEquals("1 TB",
+                SizeFormatterUtils.humanReadableBytes((long) Math.pow(1000, 4), true));
+        assertEquals("30 TB",
+                SizeFormatterUtils.humanReadableBytes(30 * (long) Math.pow(1000, 4), true));
+    }
+
+    @Test
+    public void pbSiTest() {
+        assertEquals("1 PB",
+                SizeFormatterUtils.humanReadableBytes((long) Math.pow(1000, 5), true));
+        assertEquals("2 PB",
+                SizeFormatterUtils.humanReadableBytes(2 * (long) Math.pow(1000, 5), true));
+    }
+
+    @Test
+    public void ebSiTest() {
+        assertEquals("2 EB",
+                SizeFormatterUtils.humanReadableBytes(2 * (long) Math.pow(1000, 6), true));
+    }
+
+}

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/transport/MaxMessageSizeTransportTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/transport/MaxMessageSizeTransportTest.java
@@ -1,0 +1,95 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.transport;
+
+import javax.jms.BytesMessage;
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.MessageProducer;
+import javax.jms.Queue;
+import javax.jms.Session;
+
+import org.apache.activemq.ActiveMQConnectionFactory;
+import org.apache.activemq.broker.BrokerService;
+import org.apache.activemq.broker.TransportConnector;
+import org.apache.activemq.store.memory.MemoryPersistenceAdapter;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * This tests that {@link TransportConnector#setMaximumMessageSize(int)} is
+ * enforced.
+ *
+ */
+public class MaxMessageSizeTransportTest {
+    BrokerService broker;
+    ConnectionFactory factory;
+    Connection connection;
+    Session session;
+    MessageProducer producer;
+    Queue queue;
+
+    @Before
+    public void setUp() throws Exception {
+        broker = new BrokerService();
+
+        MemoryPersistenceAdapter persistenceAdapter = new MemoryPersistenceAdapter();
+        broker.setPersistenceAdapter(persistenceAdapter);
+        TransportConnector connector = broker.addConnector("tcp://localhost:0");
+
+        // Set maximum size at 30 kbytes
+        connector.setMaximumMessageSize(30720);
+        broker.start();
+        factory = new ActiveMQConnectionFactory(broker.getTransportConnectors()
+                .get(0).getConnectUri().toString());
+        connection = factory.createConnection();
+        connection.start();
+        session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+        queue = session.createQueue("queue.test");
+        producer = session.createProducer(queue);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        session.close();
+        connection.stop();
+        connection.close();
+        broker.stop();
+    }
+
+    /**
+     * Test successful message publish
+     */
+    @Test
+    public void testMaxDestinationDefaultPolicySuccess() throws Exception {
+        BytesMessage m = session.createBytesMessage();
+        m.writeBytes(new byte[20000]);
+        producer.send(m);
+    }
+
+    /**
+     * Test that a message over the limit throws a JMSException
+     */
+    @Test(expected = javax.jms.JMSException.class)
+    public void testMessageSendTooLarge() throws Exception {
+        BytesMessage m = session.createBytesMessage();
+        m.writeBytes(new byte[35000]);
+        producer.send(m);
+    }
+
+}


### PR DESCRIPTION
Adding the ability to limit the maximum size of a message sent by a client per transport.

This can be configured in on the transport connector in xml.  For example:

```xml
<broker>
  ...
  <transportConnectors>
    <transportConnector name="nio" uri="nio://0.0.0.0:61616" maximumMessageSize="1 mb"/>  
  </<transportConnectors>
  ...
</broker>
```

This resolves https://issues.apache.org/jira/browse/AMQ-5774