### PR TITLE
Fixing missing volatile on references in VMTransport

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/transport/vm/VMTransport.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/transport/vm/VMTransport.java
@@ -56,9 +56,9 @@ public class VMTransport implements Transport, Task {
     protected final long id;
 
     // Implementation
-    private LinkedBlockingQueue<Object> messageQueue;
-    private TaskRunnerFactory taskRunnerFactory;
-    private TaskRunner taskRunner;
+    private volatile LinkedBlockingQueue<Object> messageQueue;
+    private volatile TaskRunnerFactory taskRunnerFactory;
+    private volatile TaskRunner taskRunner;
 
     // Transport State
     protected final AtomicBoolean started = new AtomicBoolean();


### PR DESCRIPTION
Fixing missing volatile on references in VMTransport to prevent a synchronization bug.

This resolves https://issues.apache.org/jira/browse/AMQ-5787