### PR TITLE
AMQ-5713 - making accessors public to remove startup error.

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/network/jms/DestinationBridge.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/network/jms/DestinationBridge.java
@@ -154,14 +154,14 @@ public abstract class DestinationBridge implements Service, MessageListener {
     /**
      * @return Returns the doHandleReplyTo.
      */
-    protected boolean isDoHandleReplyTo() {
+    public boolean isDoHandleReplyTo() {
         return doHandleReplyTo;
     }
 
     /**
      * @param doHandleReplyTo The doHandleReplyTo to set.
      */
-    protected void setDoHandleReplyTo(boolean doHandleReplyTo) {
+    public void setDoHandleReplyTo(boolean doHandleReplyTo) {
         this.doHandleReplyTo = doHandleReplyTo;
     }
 

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/xbean/DestinationBridgeAccessorsTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/xbean/DestinationBridgeAccessorsTest.java
@@ -1,0 +1,20 @@
+package org.apache.activemq.xbean;
+
+import java.net.URI;
+
+import org.apache.activemq.broker.BrokerService;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DestinationBridgeAccessorsTest extends Assert {
+
+    @Test
+    public void testCreateBroker() throws Exception {
+        XBeanBrokerFactory xBeanBrokerFactory = new XBeanBrokerFactory();
+
+        BrokerService broker = xBeanBrokerFactory.createBroker(new URI("handleReplyToActivemq.xml"));
+
+        assertNotNull(broker);
+    }
+
+}

--- a/activemq-unit-tests/src/test/resources/handleReplyToActivemq.xml
+++ b/activemq-unit-tests/src/test/resources/handleReplyToActivemq.xml
@@ -1,0 +1,38 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+
+<beans
+  xmlns="http://www.springframework.org/schema/beans"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+  http://activemq.apache.org/schema/core http://activemq.apache.org/schema/core/activemq-core.xsd">
+
+    <broker xmlns="http://activemq.apache.org/schema/core" brokerName="localhost" dataDirectory="${activemq.data}">
+
+    <jmsBridgeConnectors>
+      <jmsQueueConnector>
+        <inboundQueueBridges>
+          <inboundQueueBridge inboundQueueName="QueueA" localQueueName = "localTestQ"
+doHandleReplyTo="false"/>
+        </inboundQueueBridges>
+      </jmsQueueConnector>
+    </jmsBridgeConnectors>
+
+    </broker>
+
+</beans>
+<!-- END SNIPPET: example -->


### PR DESCRIPTION
Includes unit test DestinationBridgeAccessorsTest which replicated the problem and now passes.