### PR TITLE
https://issues.apache.org/jira/browse/AMQ-5843

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/broker/region/BaseDestination.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/region/BaseDestination.java
@@ -84,6 +84,7 @@ public abstract class BaseDestination implements Destination {
     private boolean advisoryForDelivery;
     private boolean advisoryForConsumed;
     private boolean sendAdvisoryIfNoConsumers;
+    private boolean includeBodyForAdvisory;
     protected final DestinationStatistics destinationStatistics = new DestinationStatistics();
     protected final BrokerService brokerService;
     protected final Broker regionBroker;
@@ -464,6 +465,14 @@ public abstract class BaseDestination implements Destination {
 
     public void setSendAdvisoryIfNoConsumers(boolean sendAdvisoryIfNoConsumers) {
         this.sendAdvisoryIfNoConsumers = sendAdvisoryIfNoConsumers;
+    }
+
+    public boolean isIncludeBodyForAdvisory() {
+        return includeBodyForAdvisory;
+    }
+
+    public void setIncludeBodyForAdvisory(boolean includeBodyForAdvisory) {
+        this.includeBodyForAdvisory = includeBodyForAdvisory;
     }
 
     /**

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/region/policy/PolicyEntry.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/region/policy/PolicyEntry.java
@@ -81,6 +81,7 @@ public class PolicyEntry extends DestinationMapEntry {
     private boolean advisoryWhenFull;
     private boolean advisoryForDelivery;
     private boolean advisoryForConsumed;
+    private boolean includeBodyForAdvisory;
     private long expireMessagesPeriod = BaseDestination.EXPIRE_MESSAGE_PERIOD;
     private int maxExpirePageSize = BaseDestination.MAX_BROWSE_PAGE_SIZE;
     private int queuePrefetch=ActiveMQPrefetchPolicy.DEFAULT_QUEUE_PREFETCH;
@@ -200,6 +201,7 @@ public class PolicyEntry extends DestinationMapEntry {
         destination.setAdvisoryForSlowConsumers(isAdvisoryForSlowConsumers());
         destination.setAdvisoryForFastProducers(isAdvisoryForFastProducers());
         destination.setAdvisoryWhenFull(isAdvisoryWhenFull());
+        destination.setIncludeBodyForAdvisory(isIncludeBodyForAdvisory());
         destination.setSendAdvisoryIfNoConsumers(isSendAdvisoryIfNoConsumers());
     }
 
@@ -738,6 +740,26 @@ public class PolicyEntry extends DestinationMapEntry {
      */
     public void setAdvisoryForFastProducers(boolean advisoryForFastProducers) {
         this.advisoryForFastProducers = advisoryForFastProducers;
+    }
+
+    /**
+     * Returns true if the original message body should be included when applicable
+     * for advisory messages
+     *
+     * @return
+     */
+    public boolean isIncludeBodyForAdvisory() {
+        return includeBodyForAdvisory;
+    }
+
+    /**
+     * Sets if the original message body should be included when applicable
+     * for advisory messages
+     *
+     * @param includeBodyForAdvisory
+     */
+    public void setIncludeBodyForAdvisory(boolean includeBodyForAdvisory) {
+        this.includeBodyForAdvisory = includeBodyForAdvisory;
     }
 
     public void setMaxExpirePageSize(int maxExpirePageSize) {


### PR DESCRIPTION
Adding a new property on PolicyEntry called includeBodyForAdvisory which will
include the original message body when sending advisory messages that include
the original message, instead of clearing it out.  This is turned off by default.