### PR TITLE
https://issues.apache.org/jira/browse/AMQ-5875

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/broker/region/TopicRegion.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/region/TopicRegion.java
@@ -424,4 +424,8 @@ public class TopicRegion extends AbstractRegion {
     public DurableTopicSubscription getDurableSubscription(SubscriptionKey key) {
         return durableSubscriptions.get(key);
     }
+
+    public Map<SubscriptionKey, DurableTopicSubscription> getDurableSubscriptions() {
+        return durableSubscriptions;
+    }
 }

--- a/activemq-broker/src/main/java/org/apache/activemq/network/DurableConduitBridge.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/network/DurableConduitBridge.java
@@ -18,7 +18,9 @@ package org.apache.activemq.network;
 
 import java.io.IOException;
 
+import org.apache.activemq.broker.region.RegionBroker;
 import org.apache.activemq.broker.region.Subscription;
+import org.apache.activemq.broker.region.TopicRegion;
 import org.apache.activemq.command.ActiveMQDestination;
 import org.apache.activemq.command.ConsumerId;
 import org.apache.activemq.command.ConsumerInfo;
@@ -64,11 +66,15 @@ public class DurableConduitBridge extends ConduitBridge {
                     try {
                         //Filtering by non-empty subscriptions, see AMQ-5875
                         if (dest.isTopic()) {
+                            RegionBroker regionBroker = (RegionBroker) brokerService.getRegionBroker();
+                            TopicRegion topicRegion = (TopicRegion) regionBroker.getTopicRegion();
+
                             String candidateSubName = getSubscriberName(dest);
-                            for (Subscription subscription : this.getRegionSubscriptions(dest)) {
+                            for (Subscription subscription : topicRegion.getDurableSubscriptions().values()) {
                                 String subName = subscription.getConsumerInfo().getSubscriptionName();
                                 if (subName != null && subName.equals(candidateSubName)) {
                                     DemandSubscription sub = createDemandSubscription(dest);
+                                    sub.getLocalInfo().setSubscriptionName(getSubscriberName(dest));
                                     sub.setStaticallyIncluded(true);
                                     addSubscription(sub);
                                     break;


### PR DESCRIPTION
Reworking DurableConduitBridge to look up subscriptions from the
msesage store instead of the RegionBroker since inactive subscriptions
need to be looked at as well when dynamicOnly is false for a
network bridge.