### PR TITLE
AMQ-5977: Add LSB headers to ínit script

### DIFF
--- a/assembly/src/release/bin/activemq
+++ b/assembly/src/release/bin/activemq
@@ -1,4 +1,15 @@
 #!/bin/sh
+
+### BEGIN INIT INFO
+# Provides:          activemq
+# Required-Start:    $remote_fs $network $syslog
+# Required-Stop:     $remote_fs $network $syslog
+# Default-Start:     3 5
+# Default-Stop:      0 1 6
+# Short-Description: Starts ActiveMQ
+# Description:       Starts ActiveMQ Message Broker Server
+### END INIT INFO
+
 # ------------------------------------------------------------------------
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with


### PR DESCRIPTION
Add LSB headers to init script to fix problems when setting up ActiveMQ
as a daemon with chkconfig on RHEL and clones.

Signed-off-by: Gregor Zurowski <gregor@zurowski.org>