### PR TITLE
TransportConnection does not synchronize iteration on synchronized list

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/broker/TransportConnection.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/TransportConnection.java
@@ -858,14 +858,17 @@ public class TransportConnection implements Connection, Task, CommandVisitor {
                 }
             }
             // Cascade the connection stop to temp destinations.
-            for (Iterator<DestinationInfo> iter = cs.getTempDestinations().iterator(); iter.hasNext(); ) {
-                DestinationInfo di = iter.next();
-                try {
-                    broker.removeDestination(cs.getContext(), di.getDestination(), 0);
-                } catch (Throwable e) {
-                    SERVICELOG.warn("Failed to remove tmp destination {}", di.getDestination(), e);
+            List<DestinationInfo> tempDestinations = cs.getTempDestinations();
+            synchronized (tempDestinations) {
+                for (Iterator<DestinationInfo> iter = tempDestinations.iterator(); iter.hasNext(); ) {
+                    DestinationInfo di = iter.next();
+                    try {
+                        broker.removeDestination(cs.getContext(), di.getDestination(), 0);
+                    } catch (Throwable e) {
+                        SERVICELOG.warn("Failed to remove tmp destination {}", di.getDestination(), e);
+                    }
+                    iter.remove();
                 }
-                iter.remove();
             }
             try {
                 broker.removeConnection(cs.getContext(), cs.getInfo(), transportException.get());


### PR DESCRIPTION
In TransportConnection.java:861, the synchronized list returned by cs.getTempDestinations() is iterated
in an unsynchronized manner, but according to the [Oracle Java 7 API specification](http://docs.oracle.com/javase/7/docs/api/java/util/Collections.html#synchronizedList%28java.util.List%29),
this is not thread-safe and can lead to non-deterministic behavior. This pull request adds a fix by synchronizing the iteration on the list returned by cs.getTempDestinations().
