### PR TITLE
AMQ-6135 ActiveMQ HTTP module should support Openwire serialisation

### DIFF
--- a/activemq-http/src/main/java/org/apache/activemq/transport/http/HttpClientTransport.java
+++ b/activemq-http/src/main/java/org/apache/activemq/transport/http/HttpClientTransport.java
@@ -16,8 +16,8 @@
  */
 package org.apache.activemq.transport.http;
 
-import java.io.DataInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InterruptedIOException;
 import java.net.URI;
 import java.util.zip.GZIPInputStream;
@@ -25,6 +25,7 @@ import java.util.zip.GZIPOutputStream;
 
 import org.apache.activemq.command.ShutdownInfo;
 import org.apache.activemq.transport.FutureResponse;
+import org.apache.activemq.transport.http.marshallers.HttpTransportMarshaller;
 import org.apache.activemq.transport.util.TextWireFormat;
 import org.apache.activemq.util.ByteArrayOutputStream;
 import org.apache.activemq.util.IOExceptionSupport;
@@ -86,8 +87,13 @@ public class HttpClientTransport extends HttpTransportSupport {
     protected boolean canSendCompressed = false;
     private int minSendAsCompressedSize = 0;
 
+    @Deprecated
     public HttpClientTransport(TextWireFormat wireFormat, URI remoteUrl) {
         super(wireFormat, remoteUrl);
+    }
+
+    public HttpClientTransport(final HttpTransportMarshaller marshaller, URI remoteUrl) {
+        super(marshaller, remoteUrl);
     }
 
     public FutureResponse asyncRequest(Object command) throws IOException {
@@ -102,8 +108,7 @@ public class HttpClientTransport extends HttpTransportSupport {
         }
         HttpPost httpMethod = new HttpPost(getRemoteUrl().toString());
         configureMethod(httpMethod);
-        String data = getTextWireFormat().marshalText(command);
-        byte[] bytes = data.getBytes("UTF-8");
+        byte[] bytes = asBytes(command);
         if (useCompression && canSendCompressed && bytes.length > minSendAsCompressedSize) {
             ByteArrayOutputStream bytesOut = new ByteArrayOutputStream();
             GZIPOutputStream stream = new GZIPOutputStream(bytesOut);
@@ -145,17 +150,24 @@ public class HttpClientTransport extends HttpTransportSupport {
         }
     }
 
+    private byte[] asBytes(final Object command) throws IOException {
+        final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        getMarshaller().marshal(command, outputStream);
+        return outputStream.toByteArray();
+    }
+
     @Override
     public Object request(Object command) throws IOException {
         return null;
     }
 
-    private DataInputStream createDataInputStream(HttpResponse answer) throws IOException {
-        Header encoding = answer.getEntity().getContentEncoding();
-        if (encoding != null && "gzip".equalsIgnoreCase(encoding.getValue())) {
-            return new DataInputStream(new GZIPInputStream(answer.getEntity().getContent()));
+    private InputStream createInputStream(final HttpResponse answer) throws IOException {
+        final InputStream inputStream = answer.getEntity().getContent();
+        final Header encoding = answer.getEntity().getContentEncoding();
+        if (encoding == null || !"gzip".equalsIgnoreCase(encoding.getValue())) {
+            return inputStream;
         } else {
-            return new DataInputStream(answer.getEntity().getContent());
+            return new GZIPInputStream(inputStream);
         }
     }
 
@@ -193,8 +205,8 @@ public class HttpClientTransport extends HttpTransportSupport {
                     }
                 } else {
                     receiveCounter++;
-                    DataInputStream stream = createDataInputStream(answer);
-                    Object command = getTextWireFormat().unmarshal(stream);
+                    final InputStream stream = createInputStream(answer);
+                    final Object command = getMarshaller().unmarshal(stream);
                     if (command == null) {
                         LOG.debug("Received null command from url: " + remoteUrl);
                     } else {

--- a/activemq-http/src/main/java/org/apache/activemq/transport/http/HttpTransportFactory.java
+++ b/activemq-http/src/main/java/org/apache/activemq/transport/http/HttpTransportFactory.java
@@ -28,8 +28,10 @@ import org.apache.activemq.transport.Transport;
 import org.apache.activemq.transport.TransportFactory;
 import org.apache.activemq.transport.TransportLoggerFactory;
 import org.apache.activemq.transport.TransportServer;
+import org.apache.activemq.transport.http.marshallers.HttpTransportMarshaller;
+import org.apache.activemq.transport.http.marshallers.HttpWireFormatMarshaller;
+import org.apache.activemq.transport.http.marshallers.TextWireFormatMarshallers;
 import org.apache.activemq.transport.util.TextWireFormat;
-import org.apache.activemq.transport.xstream.XStreamWireFormat;
 import org.apache.activemq.util.IOExceptionSupport;
 import org.apache.activemq.util.IntrospectionSupport;
 import org.apache.activemq.util.URISupport;
@@ -40,6 +42,16 @@ import org.slf4j.LoggerFactory;
 public class HttpTransportFactory extends TransportFactory {
 
     private static final Logger LOG = LoggerFactory.getLogger(HttpTransportFactory.class);
+    private static final String WIRE_FORMAT_XSTREAM = "xstream";
+    private final String defaultWireFormatType;
+
+    public HttpTransportFactory() {
+        defaultWireFormatType = WIRE_FORMAT_XSTREAM;
+    }
+
+    public HttpTransportFactory(final String defaultWireFormatType) {
+        this.defaultWireFormatType = defaultWireFormatType;
+    }
 
     public TransportServer doBind(URI location) throws IOException {
         try {
@@ -53,20 +65,21 @@ public class HttpTransportFactory extends TransportFactory {
         }
     }
 
-    protected TextWireFormat asTextWireFormat(WireFormat wireFormat) {
-        if (wireFormat instanceof TextWireFormat) {
-            return (TextWireFormat)wireFormat;
-        }
-        LOG.trace("Not created with a TextWireFormat: " + wireFormat);
-        return new XStreamWireFormat();
+    @Deprecated
+    protected final TextWireFormat asTextWireFormat(final WireFormat wireFormat) {
+        throw new UnsupportedOperationException("asTextWireFormat is no longer supported");
+    }
+
+    protected WireFormat processWireFormat(final WireFormat wireFormat) {
+        return wireFormat;
     }
 
     protected String getDefaultWireFormatType() {
-        return "xstream";
+        return defaultWireFormatType;
     }
 
     protected Transport createTransport(URI location, WireFormat wf) throws IOException {
-        TextWireFormat textWireFormat = asTextWireFormat(wf);
+        final WireFormat wireFormat = processWireFormat(wf);
         // need to remove options from uri
         URI uri;
         try {
@@ -76,7 +89,14 @@ public class HttpTransportFactory extends TransportFactory {
             cause.initCause(e);
             throw cause;
         }
-        return new HttpClientTransport(textWireFormat, uri);
+        return new HttpClientTransport(createMarshaller(wireFormat), uri);
+    }
+
+    protected static HttpTransportMarshaller createMarshaller(final WireFormat wireFormat)
+    {
+        return wireFormat instanceof TextWireFormat ?
+                TextWireFormatMarshallers.newTransportMarshaller((TextWireFormat)wireFormat) :
+                new HttpWireFormatMarshaller(wireFormat);
     }
 
     @SuppressWarnings("rawtypes")

--- a/activemq-http/src/main/java/org/apache/activemq/transport/http/HttpTransportSupport.java
+++ b/activemq-http/src/main/java/org/apache/activemq/transport/http/HttpTransportSupport.java
@@ -19,7 +19,10 @@ package org.apache.activemq.transport.http;
 import java.net.URI;
 
 import org.apache.activemq.transport.TransportThreadSupport;
+import org.apache.activemq.transport.http.marshallers.HttpTransportMarshaller;
+import org.apache.activemq.transport.http.marshallers.TextWireFormatMarshallers;
 import org.apache.activemq.transport.util.TextWireFormat;
+import org.apache.activemq.wireformat.WireFormat;
 
 /**
  * A useful base class for HTTP Transport implementations.
@@ -27,15 +30,23 @@ import org.apache.activemq.transport.util.TextWireFormat;
  *
  */
 public abstract class HttpTransportSupport extends TransportThreadSupport {
-    private TextWireFormat textWireFormat;
+    @Deprecated
+    private WireFormat textWireFormat;
+    private HttpTransportMarshaller marshaller;
     private URI remoteUrl;
     private String proxyHost;
     private int proxyPort = 8080;
     private String proxyUser;
     private String proxyPassword;
 
-    public HttpTransportSupport(TextWireFormat textWireFormat, URI remoteUrl) {
+    @Deprecated
+    public HttpTransportSupport(final TextWireFormat textWireFormat, final URI remoteUrl) {
+        this(TextWireFormatMarshallers.newTransportMarshaller(textWireFormat), remoteUrl);
         this.textWireFormat = textWireFormat;
+    }
+
+    public HttpTransportSupport(final HttpTransportMarshaller marshaller, final URI remoteUrl) {
+        this.marshaller = marshaller;
         this.remoteUrl = remoteUrl;
     }
 
@@ -53,12 +64,19 @@ public abstract class HttpTransportSupport extends TransportThreadSupport {
         return remoteUrl;
     }
 
+    @Deprecated
     public TextWireFormat getTextWireFormat() {
-        return textWireFormat;
+        return (TextWireFormat) textWireFormat;
     }
 
-    public void setTextWireFormat(TextWireFormat textWireFormat) {
+    public HttpTransportMarshaller getMarshaller() {
+        return marshaller;
+    }
+
+    @Deprecated
+    public void setTextWireFormat(final TextWireFormat textWireFormat) {
         this.textWireFormat = textWireFormat;
+        this.marshaller = TextWireFormatMarshallers.newTransportMarshaller(textWireFormat);
     }
 
     public String getProxyHost() {

--- a/activemq-http/src/main/java/org/apache/activemq/transport/http/marshallers/HttpTextWireFormatMarshaller.java
+++ b/activemq-http/src/main/java/org/apache/activemq/transport/http/marshallers/HttpTextWireFormatMarshaller.java
@@ -1,0 +1,51 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.transport.http.marshallers;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.activemq.transport.util.TextWireFormat;
+
+/**
+ * A {@link HttpTransportMarshaller} implementation using a {@link TextWireFormat} and UTF8 encoding.
+ */
+public class HttpTextWireFormatMarshaller implements HttpTransportMarshaller
+{
+    private static final Charset CHARSET = StandardCharsets.UTF_8;
+    private final TextWireFormat wireFormat;
+
+    public HttpTextWireFormatMarshaller(final TextWireFormat wireFormat) {
+        this.wireFormat = wireFormat;
+    }
+
+    @Override
+    public void marshal(final Object command, final OutputStream outputStream) throws IOException {
+        final String s = wireFormat.marshalText(command);
+        outputStream.write(s.getBytes(CHARSET));
+    }
+
+    @Override
+    public Object unmarshal(final InputStream stream) throws IOException {
+        return wireFormat.unmarshalText(new InputStreamReader(stream, CHARSET));
+    }
+}

--- a/activemq-http/src/main/java/org/apache/activemq/transport/http/marshallers/HttpTransportMarshaller.java
+++ b/activemq-http/src/main/java/org/apache/activemq/transport/http/marshallers/HttpTransportMarshaller.java
@@ -1,0 +1,46 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.transport.http.marshallers;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/**
+ * A generic interface for marshallers used for HTTP communication.
+ */
+public interface HttpTransportMarshaller
+{
+    /**
+     * The implementations of this method should be able to marshall the supplied object into the output stream.
+     *
+     * @param command the object to marshall
+     * @param outputStream output stream for the serialised form.
+     * @throws IOException
+     */
+    void marshal(final Object command, final OutputStream outputStream) throws IOException;
+
+    /**
+     * The implementations of this method handle unmarshalling of objects from a wire format into Java objects.
+     *
+     * @param stream the stream with the serialised form of an object
+     * @return the deserialised object
+     * @throws IOException
+     */
+    Object unmarshal(final InputStream stream) throws IOException;
+}

--- a/activemq-http/src/main/java/org/apache/activemq/transport/http/marshallers/HttpWireFormatMarshaller.java
+++ b/activemq-http/src/main/java/org/apache/activemq/transport/http/marshallers/HttpWireFormatMarshaller.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.transport.http.marshallers;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import org.apache.activemq.wireformat.WireFormat;
+
+public class HttpWireFormatMarshaller implements HttpTransportMarshaller
+{
+    private final WireFormat wireFormat;
+
+    public HttpWireFormatMarshaller(final WireFormat wireFormat) {
+        this.wireFormat = wireFormat;
+    }
+
+    @Override
+    public void marshal(final Object command, final OutputStream outputStream) throws IOException {
+        final DataOutputStream out = new DataOutputStream(outputStream);
+        wireFormat.marshal(command, out);
+        out.flush();
+    }
+
+    @Override
+    public Object unmarshal(final InputStream stream) throws IOException {
+        return wireFormat.unmarshal(new DataInputStream(stream));
+    }
+}

--- a/activemq-http/src/main/java/org/apache/activemq/transport/http/marshallers/TextWireFormatMarshallers.java
+++ b/activemq-http/src/main/java/org/apache/activemq/transport/http/marshallers/TextWireFormatMarshallers.java
@@ -1,0 +1,93 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.transport.http.marshallers;
+
+import java.io.DataInput;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.Reader;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.activemq.transport.util.TextWireFormat;
+import org.apache.activemq.wireformat.WireFormat;
+
+/**
+ * A factory for marshallers {@link HttpTransportMarshaller} that maintain compatibility with the original
+ * ActiveMQ code that used {@link TextWireFormat#marshalText(Object)} and {@link TextWireFormat#marshal(Object)} depending
+ * on the context.
+ * All text handling is done using UTF-8.
+ */
+public class TextWireFormatMarshallers {
+    private static final Charset CHARSET = StandardCharsets.UTF_8;
+
+    /**
+     * The returned marshaller uses {@link TextWireFormat#marshal(Object)} and {@link TextWireFormat#unmarshalText(Reader)}.
+     */
+    public static HttpTransportMarshaller newServletMarshaller(final WireFormat wireFormat) {
+        return new MarshalPlainUnmarshalTextMarshaller((TextWireFormat)wireFormat);
+    }
+
+    /**
+     * The returned marshaller uses {@link TextWireFormat#marshalText(Object)} and {@link TextWireFormat#unmarshal(DataInput)}
+     */
+    public static HttpTransportMarshaller newTransportMarshaller(final TextWireFormat textWireFormat) {
+        return new MarshalTextUnmarshalPlainMarshaller(textWireFormat);
+    }
+
+    private static class MarshalTextUnmarshalPlainMarshaller implements HttpTransportMarshaller {
+        private final TextWireFormat wireFormat;
+
+        private MarshalTextUnmarshalPlainMarshaller(final TextWireFormat wireFormat) {
+            this.wireFormat = wireFormat;
+        }
+
+        @Override
+        public void marshal(final Object command, final OutputStream outputStream) throws IOException {
+            final String s = wireFormat.marshalText(command);
+            outputStream.write(s.getBytes(CHARSET));
+        }
+
+        @Override
+        public Object unmarshal(final InputStream stream) throws IOException {
+            return wireFormat.unmarshal(new DataInputStream(stream));
+        }
+    }
+
+    private static class MarshalPlainUnmarshalTextMarshaller implements HttpTransportMarshaller  {
+        private final TextWireFormat wireFormat;
+
+        private MarshalPlainUnmarshalTextMarshaller(final TextWireFormat wireFormat) {
+            this.wireFormat = wireFormat;
+        }
+
+        @Override
+        public void marshal(final Object command, final OutputStream outputStream) throws IOException {
+            wireFormat.marshal(command, new DataOutputStream(outputStream));
+        }
+
+        @Override
+        public Object unmarshal(final InputStream stream) throws IOException {
+            return wireFormat.unmarshalText(new InputStreamReader(stream, CHARSET));
+        }
+    }
+}

--- a/activemq-http/src/main/java/org/apache/activemq/transport/https/HttpsClientTransport.java
+++ b/activemq-http/src/main/java/org/apache/activemq/transport/https/HttpsClientTransport.java
@@ -22,6 +22,7 @@ import java.net.URI;
 
 import org.apache.activemq.broker.SslContext;
 import org.apache.activemq.transport.http.HttpClientTransport;
+import org.apache.activemq.transport.http.marshallers.HttpTransportMarshaller;
 import org.apache.activemq.transport.util.TextWireFormat;
 import org.apache.activemq.util.IOExceptionSupport;
 import org.apache.http.conn.ClientConnectionManager;
@@ -32,8 +33,13 @@ import org.apache.http.impl.conn.PoolingClientConnectionManager;
 
 public class HttpsClientTransport extends HttpClientTransport {
 
+    @Deprecated
     public HttpsClientTransport(TextWireFormat wireFormat, URI remoteUrl) {
         super(wireFormat, remoteUrl);
+    }
+
+    public HttpsClientTransport(final HttpTransportMarshaller marshaller, URI remoteUrl) {
+        super(marshaller, remoteUrl);
     }
 
     @Override

--- a/activemq-http/src/main/java/org/apache/activemq/transport/https/HttpsTransportFactory.java
+++ b/activemq-http/src/main/java/org/apache/activemq/transport/https/HttpsTransportFactory.java
@@ -37,6 +37,12 @@ import org.apache.activemq.wireformat.WireFormat;
  */
 public class HttpsTransportFactory extends HttpTransportFactory {
 
+    public HttpsTransportFactory() {}
+
+    public HttpsTransportFactory(final String defaultWireFormatType) {
+        super(defaultWireFormatType);
+    }
+
     public TransportServer doBind(String brokerId, URI location) throws IOException {
         return doBind(location);
     }
@@ -63,6 +69,6 @@ public class HttpsTransportFactory extends HttpTransportFactory {
             cause.initCause(e);
             throw cause;
         }
-        return new HttpsClientTransport(asTextWireFormat(wf), uri);
+        return new HttpsClientTransport(createMarshaller(wf), uri);
     }
 }

--- a/activemq-http/src/test/java/org/apache/activemq/transport/http/HttpClientTransportTest.java
+++ b/activemq-http/src/test/java/org/apache/activemq/transport/http/HttpClientTransportTest.java
@@ -1,0 +1,131 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.transport.http;
+
+import java.io.ByteArrayInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.activemq.command.ConsumerInfo;
+import org.apache.activemq.transport.http.marshallers.TextWireFormatMarshallers;
+import org.apache.activemq.transport.xstream.XStreamWireFormat;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.output.ByteArrayOutputStream;
+import org.apache.http.HttpResponse;
+import org.apache.http.ProtocolVersion;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.entity.InputStreamEntity;
+import org.apache.http.message.BasicHttpResponse;
+import org.apache.http.message.BasicStatusLine;
+import org.apache.http.params.BasicHttpParams;
+import org.hamcrest.CoreMatchers;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.mockito.stubbing.Answer;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+
+public class HttpClientTransportTest {
+
+    @Rule
+    public final MockitoRule rule = MockitoJUnit.rule();
+
+    @Mock
+    private HttpClient sendHttpClient;
+
+    @Mock
+    private HttpClient receiveHttpClient;
+
+    @Test
+    public void testPreservesAsymmetricalMarshalling() throws Exception {
+        final AtomicReference<Object> unmarshalledCommand = new AtomicReference<>();
+
+        final HttpClientTransport httpClientTransport = new HttpClientTransport(TextWireFormatMarshallers.newTransportMarshaller(new XStreamWireFormat()), URI.create("http://localhost")) {
+            @Override
+            public HttpClient getSendHttpClient() {
+                return sendHttpClient;
+            }
+
+            @Override
+            public HttpClient getReceiveHttpClient() {
+                return receiveHttpClient;
+            }
+
+            @Override
+            public void doConsume(final Object command) {
+                unmarshalledCommand.set(command);
+                try {
+                    stop();
+                } catch (Exception e) {
+                }
+            }
+        };
+
+        final AtomicReference<String> marshalledCommand = new AtomicReference<>();
+
+        {
+            when(sendHttpClient.getParams()).thenReturn(new BasicHttpParams());
+            when(sendHttpClient.execute(Mockito.<HttpUriRequest>any())).thenAnswer(new Answer<HttpResponse>() {
+                @Override
+                public HttpResponse answer(final InvocationOnMock invocation) throws Throwable {
+                    final HttpPost method = invocation.getArgumentAt(0, HttpPost.class);
+                    final String entityBody = IOUtils.toString(method.getEntity().getContent());
+                    marshalledCommand.set(entityBody);
+                    return newHttpOkResponse();
+                }
+            });
+
+            httpClientTransport.oneway(new ConsumerInfo());
+            assertThat(marshalledCommand.get(), CoreMatchers.startsWith("<"));
+        }
+
+        {
+            final BasicHttpResponse httpOkResponse = newHttpOkResponse();
+            httpOkResponse.setEntity(new InputStreamEntity(new ByteArrayInputStream(toMarshalledMessage(marshalledCommand))));
+            when(receiveHttpClient.execute(Mockito.<HttpUriRequest>any())).thenReturn(httpOkResponse);
+            httpClientTransport.run();
+            assertThat(unmarshalledCommand.get(), CoreMatchers.instanceOf(ConsumerInfo.class));
+        }
+    }
+
+    private byte[] toMarshalledMessage(AtomicReference<String> marshalledCommand) throws IOException {
+        final byte[] textBytes = marshalledCommand.get().getBytes(StandardCharsets.UTF_8);
+
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        final DataOutputStream dataOutputStream = new DataOutputStream(baos);
+        dataOutputStream.writeInt(textBytes.length);
+        dataOutputStream.write(textBytes);
+        dataOutputStream.flush();
+        return baos.toByteArray();
+    }
+
+    private BasicHttpResponse newHttpOkResponse() {
+        return new BasicHttpResponse(new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), HttpURLConnection.HTTP_OK, "OK"));
+    }
+}

--- a/activemq-http/src/test/java/org/apache/activemq/transport/http/HttpTunnelServletTest.java
+++ b/activemq-http/src/test/java/org/apache/activemq/transport/http/HttpTunnelServletTest.java
@@ -1,0 +1,156 @@
+package org.apache.activemq.transport.http;
+
+import java.io.IOException;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.servlet.ReadListener;
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import javax.servlet.ServletInputStream;
+import javax.servlet.ServletOutputStream;
+import javax.servlet.WriteListener;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.activemq.command.ConsumerInfo;
+import org.apache.activemq.transport.TransportAcceptListener;
+import org.hamcrest.CoreMatchers;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class HttpTunnelServletTest {
+
+    @Rule
+    public final MockitoRule rule = MockitoJUnit.rule();
+
+    @Mock
+    private HttpServletRequest request;
+    @Mock
+    private HttpServletResponse response;
+
+    private final MockServletOutputStream servletOutputStream = new MockServletOutputStream();
+
+    @Before
+    public void setup() throws IOException {
+        when(response.getOutputStream()).thenReturn(servletOutputStream);
+    }
+
+    @Test
+    public void testPreservesAsymmetricalMarshalling() throws Exception {
+        final AtomicReference<Object> commandRef = new AtomicReference<>();
+
+        final BlockingQueueTransport transportChannel = newTransportChannel(commandRef);
+
+        final HttpTunnelServlet httpTunnelServlet = newServlet(transportChannel);
+
+        httpTunnelServlet.doGet(request, response); //marshall
+
+        final String wireFormatMessage = servletOutputStream.getContent();
+        assertThat(wireFormatMessage, not(CoreMatchers.startsWith("<")));
+
+        final String message = toTextMessage(wireFormatMessage);
+        when(request.getInputStream()).thenReturn(new MockServletInputStream(message));
+        httpTunnelServlet.doPost(request, response); //unmarshallText
+        assertThat(commandRef.get(), CoreMatchers.instanceOf(ConsumerInfo.class));
+    }
+
+    private HttpTunnelServlet newServlet(final BlockingQueueTransport transportChannel) throws ServletException {
+        final HttpTunnelServlet httpTunnelServlet = new HttpTunnelServlet() {
+            @Override
+            protected BlockingQueueTransport getTransportChannel(final HttpServletRequest request, final HttpServletResponse response) {
+                return transportChannel;
+            }
+        };
+        final ServletConfig servletConfig = mock(ServletConfig.class);
+
+        final ServletContext servletContext = mockServletContext();
+        when(servletConfig.getServletContext()).thenReturn(servletContext);
+        httpTunnelServlet.init(servletConfig);
+        return httpTunnelServlet;
+    }
+
+    private BlockingQueueTransport newTransportChannel(final AtomicReference<Object> commandRef) {
+        final BlockingQueueTransport transportChannel = new BlockingQueueTransport(new ArrayBlockingQueue<>(10)) {
+            @Override
+            public void doConsume(final Object command) {
+                commandRef.set(command);
+            }
+        };
+        transportChannel.getQueue().offer(new ConsumerInfo());
+        return transportChannel;
+    }
+
+    private ServletContext mockServletContext() {
+        final ServletContext servletContext = mock(ServletContext.class);
+        final TransportAcceptListener acceptListener = mock(TransportAcceptListener.class);
+        when(servletContext.getAttribute(eq("acceptListener"))).thenReturn(acceptListener);
+        when(servletContext.getAttribute(eq("transportFactory"))).thenReturn(new HttpTransportFactory());
+        return servletContext;
+    }
+
+    private String toTextMessage(final String message) {
+        return message.substring(message.indexOf('<'));
+    }
+
+    private static class MockServletOutputStream extends ServletOutputStream {
+        private final StringBuilder sb = new StringBuilder();
+
+        @Override
+        public boolean isReady() {
+            return false;
+        }
+
+        @Override
+        public void setWriteListener(final WriteListener writeListener) {
+        }
+
+        @Override
+        public void write(final int b) throws IOException {
+            sb.append((char)b);
+        }
+
+        public String getContent() {
+            final String s = sb.toString();
+            sb.setLength(0);
+            return s;
+        }
+    }
+
+    private class MockServletInputStream extends ServletInputStream {
+        private final String string;
+        private int pos;
+
+        private MockServletInputStream(final String message) {
+            string = message;
+        }
+
+        @Override
+        public boolean isFinished() {
+            return pos==string.length();
+        }
+
+        @Override
+        public boolean isReady() {
+            return false;
+        }
+
+        @Override
+        public void setReadListener(final ReadListener readListener) {
+        }
+
+        @Override
+        public int read() throws IOException {
+            return isFinished() ? -1 : string.charAt(pos++);
+        }
+    }
+}


### PR DESCRIPTION
I am submitting this on behalf of Atlassian, the appropriate CCLAs are in place.

We have that code running in production and we didn't have any problems reports.
I assumed rather strict backward compatibility and interoperability requirements, not sure if that's needed.  Well, at least the interoperability should be there.
In any case, it's easier to have them removed than to implement them as an afterthought.