### PR TITLE
Move directory variables up

### DIFF
--- a/assembly/src/release/bin/env
+++ b/assembly/src/release/bin/env
@@ -23,6 +23,13 @@
 # invoke the init-script without a argument an review help section "Configuration of this script"
 # /etc/default/activemq <activemq user home>/.activemqrc <activemq installation dir>/bin/env
 
+# Active MQ installation dirs
+# ACTIVEMQ_HOME="<Installationdir>/"
+# ACTIVEMQ_BASE="$ACTIVEMQ_HOME"
+# ACTIVEMQ_CONF="$ACTIVEMQ_BASE/conf"
+# ACTIVEMQ_DATA="$ACTIVEMQ_BASE/data"
+# ACTIVEMQ_TMP="$ACTIVEMQ_BASE/tmp"
+
 # Set jvm memory configuration (minimal/maximum amount of memory)
 ACTIVEMQ_OPTS_MEMORY="-Xms64M -Xmx1G"
 
@@ -86,13 +93,6 @@ ACTIVEMQ_SSL_OPTS=""
 if [ -z "$ACTIVEMQ_KILL_MAXSECONDS" ]; then
     ACTIVEMQ_KILL_MAXSECONDS=30
 fi
-
-# Active MQ installation dirs
-# ACTIVEMQ_HOME="<Installationdir>/"
-# ACTIVEMQ_BASE="$ACTIVEMQ_HOME"
-# ACTIVEMQ_CONF="$ACTIVEMQ_BASE/conf"
-# ACTIVEMQ_DATA="$ACTIVEMQ_BASE/data"
-# ACTIVEMQ_TMP="$ACTIVEMQ_BASE/tmp"
 
 # Configure a user with non root privileges, if no user is specified do not change user
 # (the entire activemq installation should be owned by this user)


### PR DESCRIPTION
Setting ACTIVEMQ_CONF to a different value and not moving it up will result in login.config being taken from the old location.
This commit fixes this by moving these variables above all places they are used in.

Fixes AMQ-6189
https://issues.apache.org/jira/browse/AMQ-6189