### PR TITLE
https://issues.apache.org/jira/browse/AMQ-6210

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/plugin/SubQueueSelectorCacheBroker.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/plugin/SubQueueSelectorCacheBroker.java
@@ -133,7 +133,7 @@ public class SubQueueSelectorCacheBroker extends BrokerFilter implements Runnabl
     @Override
     public Subscription addConsumer(ConnectionContext context, ConsumerInfo info) throws Exception {
         // don't track selectors for advisory topics
-        if (!AdvisorySupport.isAdvisoryTopic(info.getDestination())) {
+        if (!ignoredConsumer(info)) {
             String destinationName = info.getDestination().getQualifiedName();
             LOG.debug("Caching consumer selector [{}] on  '{}'", info.getSelector(), destinationName);
 
@@ -167,6 +167,11 @@ public class SubQueueSelectorCacheBroker extends BrokerFilter implements Runnabl
         return super.addConsumer(context, info);
     }
 
+    
+    private boolean ignoredConsumer(ConsumerInfo info) {
+        return AdvisorySupport.isAdvisoryTopic(info.getDestination())
+                || info.getDestination().isTemporary();
+    }
 
     static boolean hasWildcards(String selector) {
         return WildcardFinder.hasWildcards(selector);


### PR DESCRIPTION
Do not store selector information of temporary destinations.

Since the selector information is not cleared after the destination is removed, the cache grows with every temporary destinations, and a use case where a consumer would ever reconnect to a temporary queue for reception is hard to imagine.