### PR TITLE
AMQ-5662 improve Web Console to support retry from all configured DLQs

### DIFF
--- a/activemq-web-console/src/main/java/org/apache/activemq/web/controller/RetryMessage.java
+++ b/activemq-web-console/src/main/java/org/apache/activemq/web/controller/RetryMessage.java
@@ -1,0 +1,62 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.web.controller;
+
+import org.apache.activemq.broker.jmx.QueueViewMBean;
+import org.apache.activemq.web.BrokerFacade;
+import org.apache.activemq.web.DestinationFacade;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.servlet.ModelAndView;
+import org.springframework.web.servlet.mvc.Controller;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Retry a message on a queue.
+ */
+public class RetryMessage extends DestinationFacade implements Controller {
+    private String messageId;
+    private static final Logger log = LoggerFactory.getLogger(MoveMessage.class);
+
+    public RetryMessage(BrokerFacade brokerFacade) {
+        super(brokerFacade);
+    }
+
+    public ModelAndView handleRequest(HttpServletRequest request, HttpServletResponse response) throws Exception {
+        if (messageId != null) {
+            QueueViewMBean queueView = getQueueView();
+            if (queueView != null) {
+                log.info("Retrying message " + getJMSDestination() + "(" + messageId + ")");
+                queueView.retryMessage(messageId);
+            } else {
+                log.warn("No queue named: " + getPhysicalDestinationName());
+            }
+        }
+        return redirectToDestinationView();
+    }
+
+    public String getMessageId() {
+        return messageId;
+    }
+
+    public void setMessageId(String messageId) {
+        this.messageId = messageId;
+    }
+
+}

--- a/activemq-web-console/src/main/webapp/WEB-INF/dispatcher-servlet.xml
+++ b/activemq-web-console/src/main/webapp/WEB-INF/dispatcher-servlet.xml
@@ -39,6 +39,7 @@
   <bean name="/copyMessage.action" class="org.apache.activemq.web.controller.CopyMessage" autowire="constructor"  scope="prototype"/>	
   <bean name="/moveMessage.action" class="org.apache.activemq.web.controller.MoveMessage" autowire="constructor"  scope="prototype"/>
   <bean name="/deleteJob.action" class="org.apache.activemq.web.controller.DeleteJob" autowire="constructor"  scope="prototype"/>
+  <bean name="/retryMessage.action" class="org.apache.activemq.web.controller.RetryMessage" autowire="constructor" scope="prototype"/>
 
   <!--
     - This bean resolves specific types of exception to corresponding error views.

--- a/activemq-web-console/src/main/webapp/message.jsp
+++ b/activemq-web-console/src/main/webapp/message.jsp
@@ -134,28 +134,19 @@ No message could be found for ID <c:out value="${requestContext.messageQuery.id}
                     <tr>
                         <td colspan="2"><a href="<c:out value='deleteMessage.action?JMSDestination=${requestContext.messageQuery.JMSDestination}&messageId=${row.JMSMessageID}&secret=${sessionScope["secret"]}' />" onclick="return confirm('Are you sure you want to delete the message?')" >Delete</a></td>
                     </tr>
-                    <c:set var="queueName" value="${requestContext.messageQuery.JMSDestination}"/>
-                    <c:set var="queueNameSubStr" value="${fn:substring(queueName, 0, 4)}" />
-                    <c:if test="${queueNameSubStr eq 'DLQ.' || queueNameSubStr eq 'DLT.'}">
-                        <c:if test="${queueNameSubStr eq 'DLQ.'}">
-                            <c:set var="moveToQueue" value="${fn:replace(queueName, 'DLQ.', '')}" />
-                        </c:if>
-                        <c:if test="${queueNameSubStr eq 'DLT.'}">
-                            <c:set var="moveToQueue" value="${fn:replace(queueName, 'DLT.', '')}" />
-                        </c:if>
-                        <tr>
-                            <td colspan="2">
-                                <a href="<c:url value="moveMessage.action">
-                                             <c:param name="destination" value="${moveToQueue}" />
-                                             <c:param name="JMSDestination" value="${requestContext.messageQuery.JMSDestination}" />
-                                             <c:param name="messageId" value="${row.JMSMessageID}" />
-                                             <c:param name="JMSDestinationType" value="queue" />
-                                             <c:param name="secret" value='${sessionScope["secret"]}' />
-                                         </c:url>"
-                                         onclick="return confirm('Are you sure you want to retry this message on queue://<c:out value="${moveToQueue}"/>?')"
-                                         title="Move to <c:out value="$moveToQueue" /> to attempt reprocessing">Retry</a>
+                    <c:if test="${requestContext.messageQuery.isDLQ() || requestContext.messageQuery.JMSDestination eq 'ActiveMQ.DLQ'}">
+                    	<tr>
+                    		<td>
+                    	 		<a href="<c:url value="retryMessage.action">
+                                          <c:param name="JMSDestination" value="${requestContext.messageQuery.JMSDestination}" />
+                                          <c:param name="messageId" value="${row.JMSMessageID}" />
+                                          <c:param name="JMSDestinationType" value="queue" />
+                                          <c:param name="secret" value='${sessionScope["secret"]}' />
+                                      </c:url>"
+                                      onclick="return confirm('Are you sure you want to retry this message?')"
+                                     title="Retry - attempt reprocessing on original destination">Retry</a>
                             </td>
-                        </tr>
+                       </tr>
                     </c:if>
                     <tr class="odd">
                     <td><a href="<c:out value="javascript:confirmAction('queue', 'copyMessage.action?destination=%target%&JMSDestination=${requestContext.messageQuery.JMSDestination}&messageId=${row.JMSMessageID}&JMSDestinationType=queue&secret=${sessionScope['secret']}"/>')">Copy</a></td>

--- a/activemq-web/src/main/java/org/apache/activemq/web/MessageQuery.java
+++ b/activemq-web/src/main/java/org/apache/activemq/web/MessageQuery.java
@@ -111,6 +111,10 @@ public class MessageQuery extends QueueBrowseQuery {
 
         return null;
     }
+    
+    public boolean isDLQ() throws Exception {
+    	return getQueueView().isDLQ();
+    }
 
     public Map<String, Object> getPropertiesMap() throws JMSException {
         Map<String, Object> answer = new HashMap<String, Object>();


### PR DESCRIPTION
ActiveMQ Dead letter queues are defined in runtime by individual or shared DLQ strategy. However, in the web console, the retry command is only active if a queue starts with "DLQ." or "DLT.". More, it does not really do a retry, only a move from DLQ.<queuename> to <queuename>. This is not correct, since a DLQ strategy might use other prefix/suffix to name a DLQ. The correct original destination is taken from a property of the message, not derived from the DLQ queue name.


This PR enables the retry command on configured DLQs, regardless of name. By some reason the default ActiveMQ.DLQ is not detected as a DLQ (looking at JMX properties of the queue), so this particular queue is also included to show the retry command. The retry command actually triggers the retry JMX operation.

This PR is actually more or less a duplicate of PR #73, but up to date with the rest of AMQ, hence pr #73 is closed.