### PR TITLE
AMQ-6301: Changed activemq-osgi so that it embeds the spring-dm bundles

### DIFF
--- a/activemq-karaf-itest/src/test/java/org/apache/activemq/karaf/itest/ObrFeatureTest.java
+++ b/activemq-karaf-itest/src/test/java/org/apache/activemq/karaf/itest/ObrFeatureTest.java
@@ -18,6 +18,7 @@ package org.apache.activemq.karaf.itest;
 
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.editConfigurationFilePut;
 
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.Configuration;
@@ -25,6 +26,8 @@ import org.ops4j.pax.exam.CoreOptions;
 import org.ops4j.pax.exam.MavenUtils;
 import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.junit.PaxExam;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.ServiceReference;
 
 
 @RunWith(PaxExam.class)
@@ -66,5 +69,57 @@ public class ObrFeatureTest extends AbstractFeatureTest {
     public void testCamel() throws Throwable {
         executeCommand("feature:repo-add " + getCamelFeatureUrl());
         installAndAssertFeature("activemq-camel");
+    }
+
+    @Test(timeout=5 * 60 * 1000)
+    public void testClientWithSpring31() throws Throwable {
+        executeCommand("feature:install spring/3.1.4.RELEASE");
+        installAndAssertFeature("activemq-client");
+        verifyBundleInstalledAndRegisteredServices("activemq-osgi", 2);
+    }
+
+    @Test(timeout=5 * 60 * 1000)
+    public void testClientWithSpring32() throws Throwable {
+        executeCommand("feature:install spring/3.2.14.RELEASE_1");
+        installAndAssertFeature("activemq-client");
+        verifyBundleInstalledAndRegisteredServices("activemq-osgi", 2);
+    }
+
+    @Test(timeout=5 * 60 * 1000)
+    public void testClientWithSpring40() throws Throwable {
+        executeCommand("feature:install spring/4.0.7.RELEASE_3");
+        installAndAssertFeature("activemq-client");
+        verifyBundleInstalledAndRegisteredServices("activemq-osgi", 2);
+    }
+
+    @Test(timeout=5 * 60 * 1000)
+    public void testClientWithSpring41() throws Throwable {
+        executeCommand("feature:install spring/4.1.7.RELEASE_2");
+        installAndAssertFeature("activemq-client");
+        verifyBundleInstalledAndRegisteredServices("activemq-osgi", 2);
+    }
+
+    @Test(timeout=5 * 60 * 1000)
+    public void testClientWithSpring42() throws Throwable {
+        executeCommand("feature:install spring/4.2.2.RELEASE_1");
+        installAndAssertFeature("activemq-client");
+        verifyBundleInstalledAndRegisteredServices("activemq-osgi", 2);
+    }
+
+    public boolean verifyBundleInstalledAndRegisteredServices(final String bundleName, final int numberOfServices) throws Exception {
+        boolean found = false;
+        for (final Bundle bundle : bundleContext.getBundles()) {
+            LOG.debug("Checking: " + bundle.getSymbolicName());
+            if (bundle.getSymbolicName().contains(bundleName)) {
+                Assert.assertEquals(Bundle.ACTIVE, bundle.getState());
+                // Assert that the bundle has registered some services via blueprint
+                Assert.assertNotNull(bundle.getRegisteredServices());
+                // Assert that the bundle has registered the correct number of services
+                Assert.assertEquals(numberOfServices, bundle.getRegisteredServices().length);
+                found = true;
+                break;
+            }
+        }
+        return found;
     }
 }

--- a/activemq-karaf/src/main/resources/features-core.xml
+++ b/activemq-karaf/src/main/resources/features-core.xml
@@ -23,7 +23,6 @@
     <!-- Bundles needed if only client will be deployed in the container -->
     <feature name="activemq-client" description="ActiveMQ client libraries" version="${project.version}" resolver="(obr)" start-level="50">
         <feature version="[3.2,4)">spring</feature>
-        <feature>spring-dm</feature>
         <bundle dependency="true">mvn:org.apache.geronimo.specs/geronimo-annotation_1.0_spec/1.1.1</bundle>
         <bundle dependency="true">mvn:org.apache.geronimo.specs/geronimo-jta_1.1_spec/1.1.1</bundle>
         <bundle dependency="true">mvn:org.apache.geronimo.specs/geronimo-jms_1.1_spec/1.1.1</bundle>

--- a/activemq-osgi/pom.xml
+++ b/activemq-osgi/pom.xml
@@ -58,7 +58,6 @@
       org.fusesource.hawtjni*;resolution:=optional,
       org.springframework*;version="[3,5)";resolution:=optional,
       org.springframework.jms*;version="[3,5)";resolution:=optional,
-      org.springframework.osgi*;version="[1,4]";resolution:=optional,
       org.springframework.transaction*;version="[3,5)";resolution:=optional,
       org.xmlpull*;resolution:=optional,
       scala*;resolution:=optional,
@@ -86,6 +85,7 @@
       org.apache.activemq.web*;version=${project.version};-noimport:=true;-split-package:=merge-first,
     </activemq.osgi.export>
     <activemq.osgi.private.pkg>
+         org.springframework.osgi*,
          org.fusesource.hawtdispatch*,
          org.fusesource.mqtt*,
          org.fusesource.hawtbuf*,
@@ -303,9 +303,9 @@
           <instructions>
             <Bundle-Activator>org.apache.activemq.util.osgi.Activator</Bundle-Activator>
             <Embed-Dependency>
-              *;
-              groupId=org.apache.activemq;inline=META-INF/services/*,
-              groupId=org.apache.qpid;inline=META-INF/services/*
+              *;groupId=org.apache.activemq;inline=META-INF/services/*,
+              *;groupId=org.apache.qpid;inline=META-INF/services/*,
+              *;groupId=org.springframework.osgi;inline=true
               <!--
               groupId=org.fusesource.leveldbjni;inline=META-INF/native/*,
               groupId=org.xerial.snappy;inline=org/xerial/snappy/*


### PR DESCRIPTION
This changes the activemq-osgi bundle so that it inline-embeds the spring-dm bundles which have been used inside the ActiveMQServiceFactory since version 5.13.0.

To write tests for this, I had to hardcode the Spring versions so that they match the version from the particular version of Karaf that is used by Pax Exam. If somebody has a way to fetch these versions dynamically, that would make it easier to maintain.

If this could also be merged for inclusion in version 5.13.x, that would be appreciated! Thanks.