### PR TITLE
Fixes AMQ-6441 where a negative value can be returned with large AWS EFS files systems when calling java.io.File.getTotalSpace()

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/broker/BrokerService.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/BrokerService.java
@@ -2048,6 +2048,10 @@ public class BrokerService implements Service {
             long storeLimit = storeUsage.getLimit();
             long storeCurrent = storeUsage.getUsage();
             long totalSpace = dir.getTotalSpace();
+            if (totalSpace < 0) {
+                totalSpace = Long.MAX_VALUE;
+                LOG.info("Total space was negative.  Setting to " + totalSpace);
+            }
             long totalUsableSpace = dir.getUsableSpace() + storeCurrent;
             //compute byte value of the percent limit
             long bytePercentLimit = totalSpace * percentLimit / 100;

--- a/activemq-unit-tests/pom.xml
+++ b/activemq-unit-tests/pom.xml
@@ -315,6 +315,31 @@
       <version>${ftpserver-version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito-common</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <reporting>

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/util/LargeFile.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/util/LargeFile.java
@@ -1,0 +1,25 @@
+package org.apache.activemq.util;
+
+import java.io.File;
+
+/**
+ * @author wcrowell
+ * 
+ * LargeFile is used to simulate a large file system (e.g. exabytes in size).
+ * The getTotalSpace() method is intentionally set to exceed the largest 
+ * value of a primitive long which is 9,223,372,036,854,775,807.  A negative
+ * number will be returned when getTotalSpace() is called.  This class is for
+ * test purposes only.  Using a mocking framework to mock the behavior of 
+ * java.io.File was a lot of work.
+ * 
+ */
+public class LargeFile extends File {
+	public LargeFile(File parent, String child) {
+		super(parent, child);
+	}
+	
+	@Override
+	public long getTotalSpace() {
+		return Long.MAX_VALUE + 4193L;
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,7 @@
     <leveldbjni-version>1.8</leveldbjni-version>
     <log4j-version>1.2.17</log4j-version>
     <mockito-version>1.10.19</mockito-version>
+    <powermock-version>1.6.5</powermock-version>
     <mqtt-client-version>1.13</mqtt-client-version>
     <openjpa-version>1.2.0</openjpa-version>
     <org-apache-derby-version>10.11.1.1</org-apache-derby-version>
@@ -1014,6 +1015,30 @@
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
         <version>${mockito-version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.powermock</groupId>
+        <artifactId>powermock-core</artifactId>
+        <version>${powermock-version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.powermock</groupId>
+        <artifactId>powermock-module-junit4</artifactId>
+        <version>${powermock-version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.powermock</groupId>
+        <artifactId>powermock-api-mockito</artifactId>
+        <version>${powermock-version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.powermock</groupId>
+        <artifactId>powermock-api-mockito-common</artifactId>
+        <version>${powermock-version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
Fixes AMQ-6441

A test, testLargeFileSystem(), was added to org.apache.activemq.broker.BrokerServiceTest for checking if the total space on a volume was too large to fit into a primitive long.  If this happens, then totalSpace is set to java.lang.Long.MAX_VALUE.
