### PR TITLE
Add missing runlevels to Default-Start

### DIFF
--- a/assembly/src/release/bin/activemq
+++ b/assembly/src/release/bin/activemq
@@ -4,7 +4,7 @@
 # Provides:          activemq
 # Required-Start:    $remote_fs $network $syslog
 # Required-Stop:     $remote_fs $network $syslog
-# Default-Start:     3 5
+# Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
 # Short-Description: Starts ActiveMQ
 # Description:       Starts ActiveMQ Message Broker Server


### PR DESCRIPTION
According to the manual (and the `runlevel` command), Debian starts in runlevel 2 by default:
https://www.debian.org/doc/manuals/debian-reference/ch03.en.html#_sysv_style_init

So in order for ActiveMQ to start up when a Debian VM starts, you have to add it to these runlevels.

Workaround: `insserv -v activemq,start=2`

Side-effects:
RedHat doesn't use runlevels 2 and 4, so it should be fine:
https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/3/html/Reference_Guide/s1-boot-init-shutdown-sysv.html

SLES doesn't use runlevel 4, but it does use runlevel 2 for "Local multiuser mode without remote network (NFS, etc.)":
https://www.suse.com/documentation/sles11/book_sle_admin/data/sec_boot_init.html

So the only side-effect on these systems is that SLES will try to run ActiveMQ in Local multiuser mode without remote network (and probably fail).
I think that is an acceptable side-effect since people booting Debian into runlevel 2 is a _lot_ more common due to it being the default.
