### PR TITLE
[AMQ-6514] Adding test for activemq blueprint setup and xbean problem

### DIFF
--- a/activemq-karaf-itest/src/test/java/org/apache/activemq/karaf/itest/ActiveMQBrokerBlueprintTest.java
+++ b/activemq-karaf-itest/src/test/java/org/apache/activemq/karaf/itest/ActiveMQBrokerBlueprintTest.java
@@ -1,0 +1,63 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.karaf.itest;
+
+import static org.ops4j.pax.exam.CoreOptions.composite;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.replaceConfigurationFile;
+
+import java.io.File;
+import java.util.concurrent.Callable;
+
+import javax.jms.Connection;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+
+@RunWith(PaxExam.class)
+public class ActiveMQBrokerBlueprintTest extends AbstractJmsFeatureTest {
+
+    @Configuration
+    public Option[] configure() {
+        return new Option[] //
+        {
+         composite(super.configure("activemq", "activemq-blueprint")),
+         replaceConfigurationFile("deploy/activemq-blueprint.xml", 
+                                  new File(basedir + "/src/test/resources/org/apache/activemq/karaf/itest/activemq-blueprint.xml"))
+        };
+    }
+
+    @Test
+    public void test() throws Throwable {
+        withinReason(new Callable<Boolean>() {
+            
+            @Override
+            public Boolean call() throws Exception {
+                Connection con;
+                try {
+                    con = getConnection();
+                } catch (Throwable e) {
+                    throw new RuntimeException(e);
+                }
+                con.close();
+                return true;
+            }
+        });
+    }
+}

--- a/activemq-karaf-itest/src/test/resources/org/apache/activemq/karaf/itest/activemq-blueprint.xml
+++ b/activemq-karaf-itest/src/test/resources/org/apache/activemq/karaf/itest/activemq-blueprint.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+		   xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
+           xmlns:ext="http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.0.0">
+
+    <ext:property-placeholder placeholder-prefix="$[" placeholder-suffix="]" />
+
+	<cm:property-placeholder persistent-id="activemq.cfg" placeholder-prefix="${" placeholder-suffix="}" update-strategy="reload">
+    <cm:default-properties>
+        <cm:property name="brokerName" value="mybroker" />
+        <cm:property name="perQueueMemoryLimit" value="1mb" /> 
+    </cm:default-properties>
+    </cm:property-placeholder>
+
+    <broker xmlns="http://activemq.apache.org/schema/core"
+            dataDirectory="$[karaf.data]/activemq"
+            start="true">
+
+		<destinationPolicy>
+			<policyMap>
+				<policyEntries>
+					<!-- Testing for bug in old xbean-blueprint AMQ-6514 --> 
+					<policyEntry queue="*.OUT" memoryLimit="${perQueueMemoryLimit}">
+ 					</policyEntry>
+				</policyEntries>
+			</policyMap>
+		</destinationPolicy>
+
+		<persistenceAdapter>
+            <kahaDB directory="$[karaf.data]/activemq"/>
+		</persistenceAdapter>
+
+		<plugins>
+            <jaasAuthenticationPlugin configuration="karaf" />
+		</plugins>
+
+		<transportConnectors>
+            <transportConnector name="openwire" uri="tcp://0.0.0.0:61616"/>
+		</transportConnectors>
+
+    </broker>
+
+</blueprint>


### PR DESCRIPTION
This pull request adds a test to create a broker using a blueprint.xml file.
This test also covers the xbean problem of the above issue as it uses a config attribute in a bean.
