### PR TITLE
[AMQ-6544] Create spring.schemas with schemas of activemq and spring

### DIFF
--- a/activemq-osgi/pom.xml
+++ b/activemq-osgi/pom.xml
@@ -272,27 +272,6 @@
               </resources>
             </configuration>
           </execution>
-          <execution>
-            <id>copy-spring</id>
-            <phase>validate</phase>
-            <goals>
-              <goal>copy-resources</goal>
-            </goals>
-            <configuration>
-              <outputDirectory>${basedir}/target/extra-resources/META-INF</outputDirectory>
-              <resources>
-                <resource>
-                  <directory>${basedir}/../activemq-spring/target/classes/META-INF</directory>
-                  <includes>
-                    <include>spring.*</include>
-                  </includes>
-                  <excludes>
-                      <exclude>spring.handlers</exclude>
-                  </excludes>
-                </resource>
-              </resources>
-            </configuration>
-          </execution>
         </executions>
       </plugin>
 

--- a/activemq-osgi/src/main/resources/META-INF/spring.schemas
+++ b/activemq-osgi/src/main/resources/META-INF/spring.schemas
@@ -1,0 +1,75 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+http\://activemq.org/config/1.0=activemq.xsd
+http\://activemq.org/config/1.0/1.0.xsd=activemq.xsd
+http\://activemq.apache.org/schema/core=activemq.xsd
+http\://activemq.apache.org/schema/core/activemq-core.xsd=activemq.xsd
+http\://activemq.apache.org/schema/core/activemq-core-5.0.0.xsd=activemq.xsd
+http\://activemq.apache.org/schema/core/activemq-core-5.1.0.xsd=activemq.xsd
+http\://activemq.apache.org/schema/core/activemq-core-5.2.0.xsd=activemq.xsd
+http\://activemq.apache.org/schema/core/activemq-core-5.3.0.xsd=activemq.xsd
+http\://activemq.apache.org/schema/core/activemq-core-5.3.1.xsd=activemq.xsd
+http\://activemq.apache.org/schema/core/activemq-core-5.3.2.xsd=activemq.xsd
+http\://activemq.apache.org/schema/core/activemq-core-5.4.0.xsd=activemq.xsd
+http\://activemq.apache.org/schema/core/activemq-core-5.4.1.xsd=activemq.xsd
+http\://activemq.apache.org/schema/core/activemq-core-5.4.2.xsd=activemq.xsd
+http\://activemq.apache.org/schema/core/activemq-core-5.5.0.xsd=activemq.xsd
+http\://activemq.apache.org/schema/core/activemq-core-5.5.1.xsd=activemq.xsd
+http\://activemq.apache.org/schema/core/activemq-core-5.6.0.xsd=activemq.xsd
+http\://activemq.apache.org/schema/core/activemq-core-5.7.0.xsd=activemq.xsd
+http\://activemq.apache.org/schema/core/activemq-core-5.8.0.xsd=activemq.xsd
+http\://activemq.apache.org/schema/core/activemq-core-5.9.0.xsd=activemq.xsd
+http\://activemq.apache.org/schema/core/activemq-core-5.9.1.xsd=activemq.xsd
+http\://activemq.apache.org/schema/core/activemq-core-5.10.0.xsd=activemq.xsd
+http\://activemq.apache.org/schema/core/activemq-core-5.10.1.xsd=activemq.xsd
+http\://activemq.apache.org/schema/core/activemq-core-5.11.0.xsd=activemq.xsd
+http\://activemq.apache.org/schema/core/activemq-core-5.11.1.xsd=activemq.xsd
+http\://activemq.apache.org/schema/core/activemq-core-5.11.2.xsd=activemq.xsd
+http\://activemq.apache.org/schema/core/activemq-core-5.12.0.xsd=activemq.xsd
+http\://activemq.apache.org/schema/core/activemq-core-5.12.1.xsd=activemq.xsd
+http\://activemq.apache.org/schema/core/activemq-core-5.12.2.xsd=activemq.xsd
+http\://activemq.apache.org/schema/core/activemq-core-5.13.0.xsd=activemq.xsd
+http\://activemq.apache.org/schema/core/activemq-core-5.13.1.xsd=activemq.xsd
+http\://activemq.apache.org/schema/core/activemq-core-5.13.2.xsd=activemq.xsd
+http\://activemq.apache.org/schema/core/activemq-core-5.13.3.xsd=activemq.xsd
+http\://activemq.apache.org/schema/core/activemq-core-5.13.4.xsd=activemq.xsd
+http\://activemq.apache.org/schema/core/activemq-core-5.13.5.xsd=activemq.xsd
+http\://activemq.apache.org/schema/core/activemq-core-5.14.0.xsd=activemq.xsd
+http\://activemq.apache.org/schema/core/activemq-core-5.14.1.xsd=activemq.xsd
+http\://activemq.apache.org/schema/core/activemq-core-5.14.2.xsd=activemq.xsd
+
+http\://camel.apache.org/schema/osgi/camel-osgi.xsd=camel-osgi.xsd
+http\://camel.apache.org/schema/spring/camel-spring.xsd=camel-spring.xsd
+
+http\://www.springframework.org/schema/beans/spring-beans-2.0.xsd=org/springframework/beans/factory/xml/spring-beans-2.0.xsd
+http\://www.springframework.org/schema/beans/spring-beans-2.5.xsd=org/springframework/beans/factory/xml/spring-beans-2.5.xsd
+http\://www.springframework.org/schema/beans/spring-beans-3.0.xsd=org/springframework/beans/factory/xml/spring-beans-3.0.xsd
+http\://www.springframework.org/schema/beans/spring-beans-3.1.xsd=org/springframework/beans/factory/xml/spring-beans-3.1.xsd
+http\://www.springframework.org/schema/beans/spring-beans-3.2.xsd=org/springframework/beans/factory/xml/spring-beans-3.2.xsd
+http\://www.springframework.org/schema/beans/spring-beans.xsd=org/springframework/beans/factory/xml/spring-beans-3.2.xsd
+http\://www.springframework.org/schema/tool/spring-tool-2.0.xsd=org/springframework/beans/factory/xml/spring-tool-2.0.xsd
+http\://www.springframework.org/schema/tool/spring-tool-2.5.xsd=org/springframework/beans/factory/xml/spring-tool-2.5.xsd
+http\://www.springframework.org/schema/tool/spring-tool-3.0.xsd=org/springframework/beans/factory/xml/spring-tool-3.0.xsd
+http\://www.springframework.org/schema/tool/spring-tool-3.1.xsd=org/springframework/beans/factory/xml/spring-tool-3.1.xsd
+http\://www.springframework.org/schema/tool/spring-tool-3.2.xsd=org/springframework/beans/factory/xml/spring-tool-3.2.xsd
+http\://www.springframework.org/schema/tool/spring-tool.xsd=org/springframework/beans/factory/xml/spring-tool-3.2.xsd
+http\://www.springframework.org/schema/util/spring-util-2.0.xsd=org/springframework/beans/factory/xml/spring-util-2.0.xsd
+http\://www.springframework.org/schema/util/spring-util-2.5.xsd=org/springframework/beans/factory/xml/spring-util-2.5.xsd
+http\://www.springframework.org/schema/util/spring-util-3.0.xsd=org/springframework/beans/factory/xml/spring-util-3.0.xsd
+http\://www.springframework.org/schema/util/spring-util-3.1.xsd=org/springframework/beans/factory/xml/spring-util-3.1.xsd
+http\://www.springframework.org/schema/util/spring-util-3.2.xsd=org/springframework/beans/factory/xml/spring-util-3.2.xsd
+http\://www.springframework.org/schema/util/spring-util.xsd=org/springframework/beans/factory/xml/spring-util-3.2.xsd


### PR DESCRIPTION
As spring is embedded now we also need to define the spring schema mappings to make them available when being offline. Downside is that this needs to be maintained. So the better way would be to join the files from activemq-spring and spring. 
Does anyone know how to do this?
