### PR TITLE
 AMQ-6577: honour usePrefetchExtension in TopicSubscription.

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/broker/region/AbstractSubscription.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/region/AbstractSubscription.java
@@ -52,6 +52,7 @@ public abstract class AbstractSubscription implements Subscription {
     protected final CopyOnWriteArrayList<Destination> destinations = new CopyOnWriteArrayList<Destination>();
     protected final AtomicInteger prefetchExtension = new AtomicInteger(0);
 
+    private boolean usePrefetchExtension = true;
     private BooleanExpression selectorExpression;
     private ObjectName objectName;
     private int cursorMemoryHighWaterMark = 70;
@@ -183,6 +184,14 @@ public abstract class AbstractSubscription implements Subscription {
     @Override
     public int getPrefetchSize() {
         return info.getPrefetchSize();
+    }
+
+    public boolean isUsePrefetchExtension() {
+        return usePrefetchExtension;
+    }
+
+    public void setUsePrefetchExtension(boolean usePrefetchExtension) {
+        this.usePrefetchExtension = usePrefetchExtension;
     }
 
     public void setPrefetchSize(int newSize) {

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/region/PrefetchSubscription.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/region/PrefetchSubscription.java
@@ -56,7 +56,6 @@ public abstract class PrefetchSubscription extends AbstractSubscription {
 
     protected PendingMessageCursor pending;
     protected final List<MessageReference> dispatched = new ArrayList<MessageReference>();
-    protected boolean usePrefetchExtension = true;
     private int maxProducersToAudit=32;
     private int maxAuditDepth=2048;
     protected final SystemUsage usageManager;
@@ -263,7 +262,7 @@ public abstract class PrefetchSubscription extends AbstractSubscription {
                             registerRemoveSync(context, node);
                         }
 
-                        if (usePrefetchExtension && getPrefetchSize() != 0 && ack.isInTransaction()) {
+                        if (isUsePrefetchExtension() && getPrefetchSize() != 0 && ack.isInTransaction()) {
                             // allow transaction batch to exceed prefetch
                             while (true) {
                                 int currentExtension = prefetchExtension.get();
@@ -288,7 +287,7 @@ public abstract class PrefetchSubscription extends AbstractSubscription {
                     final MessageReference node = iter.next();
                     Destination nodeDest = (Destination) node.getRegionDestination();
                     if (ack.getLastMessageId().equals(node.getMessageId())) {
-                        if (usePrefetchExtension && getPrefetchSize() != 0) {
+                        if (isUsePrefetchExtension() && getPrefetchSize() != 0) {
                             // allow  batch to exceed prefetch
                             while (true) {
                                 int currentExtension = prefetchExtension.get();
@@ -328,7 +327,7 @@ public abstract class PrefetchSubscription extends AbstractSubscription {
                         nodeDest.getDestinationStatistics().getInflight().decrement();
 
                         if (ack.getLastMessageId().equals(messageId)) {
-                            if (usePrefetchExtension && getPrefetchSize() != 0) {
+                            if (isUsePrefetchExtension() && getPrefetchSize() != 0) {
                                 // allow  batch to exceed prefetch
                                 while (true) {
                                     int currentExtension = prefetchExtension.get();
@@ -444,7 +443,7 @@ public abstract class PrefetchSubscription extends AbstractSubscription {
 
                     @Override
                     public void beforeEnd() {
-                        if (usePrefetchExtension && getPrefetchSize() != 0) {
+                        if (isUsePrefetchExtension() && getPrefetchSize() != 0) {
                             while (true) {
                                 int currentExtension = prefetchExtension.get();
                                 int newExtension = Math.max(0, currentExtension - 1);
@@ -890,14 +889,6 @@ public abstract class PrefetchSubscription extends AbstractSubscription {
         if (this.pending != null) {
             this.pending.setMaxAuditDepth(maxAuditDepth);
         }
-    }
-
-    public boolean isUsePrefetchExtension() {
-        return usePrefetchExtension;
-    }
-
-    public void setUsePrefetchExtension(boolean usePrefetchExtension) {
-        this.usePrefetchExtension = usePrefetchExtension;
     }
 
     @Override

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/region/TopicSubscription.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/region/TopicSubscription.java
@@ -76,8 +76,6 @@ public class TopicSubscription extends AbstractSubscription {
     protected final Object dispatchLock = new Object();
     protected final List<MessageReference> dispatched = new ArrayList<MessageReference>();
 
-    private boolean usePrefetchExtension = true;
-
     public TopicSubscription(Broker broker,ConnectionContext context, ConsumerInfo info, SystemUsage usageManager) throws Exception {
         super(broker, context, info);
         this.usageManager = usageManager;
@@ -424,7 +422,7 @@ public class TopicSubscription extends AbstractSubscription {
     }
 
     private void incrementPrefetchExtension(int amount) {
-        if (!usePrefetchExtension) {
+        if (!isUsePrefetchExtension()) {
             return;
         }
         while (true) {
@@ -754,7 +752,7 @@ public class TopicSubscription extends AbstractSubscription {
     public String toString() {
         return "TopicSubscription:" + " consumer=" + info.getConsumerId() + ", destinations=" + destinations.size() + ", dispatched=" + getDispatchedQueueSize() + ", delivered="
                 + getDequeueCounter() + ", matched=" + matched() + ", discarded=" + discarded() + ", prefetchExtension=" + prefetchExtension.get()
-                + ", usePrefetchExtension=" + usePrefetchExtension;
+                + ", usePrefetchExtension=" + isUsePrefetchExtension();
     }
 
     @Override
@@ -786,10 +784,6 @@ public class TopicSubscription extends AbstractSubscription {
         } catch(Exception e) {
             LOG.trace("Caught exception on dispatch after prefetch size change.");
         }
-    }
-
-    public void setUsePrefetchExtension(boolean usePrefetchExtension) {
-        this.usePrefetchExtension = usePrefetchExtension;
     }
 
 }

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/region/TopicSubscription.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/region/TopicSubscription.java
@@ -76,6 +76,8 @@ public class TopicSubscription extends AbstractSubscription {
     protected final Object dispatchLock = new Object();
     protected final List<MessageReference> dispatched = new ArrayList<MessageReference>();
 
+    private boolean usePrefetchExtension = true;
+
     public TopicSubscription(Broker broker,ConnectionContext context, ConsumerInfo info, SystemUsage usageManager) throws Exception {
         super(broker, context, info);
         this.usageManager = usageManager;
@@ -422,6 +424,9 @@ public class TopicSubscription extends AbstractSubscription {
     }
 
     private void incrementPrefetchExtension(int amount) {
+        if (!usePrefetchExtension) {
+            return;
+        }
         while (true) {
             int currentExtension = prefetchExtension.get();
             int newExtension = Math.max(0, currentExtension + amount);
@@ -748,7 +753,8 @@ public class TopicSubscription extends AbstractSubscription {
     @Override
     public String toString() {
         return "TopicSubscription:" + " consumer=" + info.getConsumerId() + ", destinations=" + destinations.size() + ", dispatched=" + getDispatchedQueueSize() + ", delivered="
-                + getDequeueCounter() + ", matched=" + matched() + ", discarded=" + discarded() + ", prefetchExtension=" + prefetchExtension.get();
+                + getDequeueCounter() + ", matched=" + matched() + ", discarded=" + discarded() + ", prefetchExtension=" + prefetchExtension.get()
+                + ", usePrefetchExtension=" + usePrefetchExtension;
     }
 
     @Override
@@ -781,4 +787,9 @@ public class TopicSubscription extends AbstractSubscription {
             LOG.trace("Caught exception on dispatch after prefetch size change.");
         }
     }
+
+    public void setUsePrefetchExtension(boolean usePrefetchExtension) {
+        this.usePrefetchExtension = usePrefetchExtension;
+    }
+
 }

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/region/policy/PolicyEntry.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/region/policy/PolicyEntry.java
@@ -313,6 +313,7 @@ public class PolicyEntry extends DestinationMapEntry {
 
     public void configure(Broker broker, SystemUsage memoryManager, TopicSubscription subscription) {
         configurePrefetch(subscription);
+        subscription.setUsePrefetchExtension(isUsePrefetchExtension());
         subscription.setCursorMemoryHighWaterMark(getCursorMemoryHighWaterMark());
         if (pendingMessageLimitStrategy != null) {
             int value = pendingMessageLimitStrategy.getMaximumPendingMessageLimit(subscription);

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/TestSupport.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/TestSupport.java
@@ -18,7 +18,7 @@ package org.apache.activemq;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.ServerSocket;
+import java.util.List;
 import java.util.Map;
 
 import javax.jms.Connection;
@@ -28,13 +28,13 @@ import javax.jms.Message;
 import javax.jms.TextMessage;
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
-import javax.net.ServerSocketFactory;
 
 import org.apache.activemq.broker.BrokerRegistry;
 import org.apache.activemq.broker.BrokerService;
 import org.apache.activemq.broker.jmx.QueueViewMBean;
 import org.apache.activemq.broker.region.DestinationStatistics;
 import org.apache.activemq.broker.region.RegionBroker;
+import org.apache.activemq.broker.region.Subscription;
 import org.apache.activemq.command.ActiveMQDestination;
 import org.apache.activemq.command.ActiveMQMessage;
 import org.apache.activemq.command.ActiveMQQueue;
@@ -153,6 +153,15 @@ public abstract class TestSupport extends CombinationTestSupport {
         org.apache.activemq.broker.region.Destination dest = getDestination(broker, destination);
         if (dest != null) {
             result = dest.getDestinationStatistics();
+        }
+        return result;
+    }
+
+    public static List<Subscription> getDestinationConsumers(BrokerService broker, ActiveMQDestination destination) {
+        List<Subscription> result = null;
+        org.apache.activemq.broker.region.Destination dest = getDestination(broker, destination);
+        if (dest != null) {
+            result = dest.getConsumers();
         }
         return result;
     }


### PR DESCRIPTION
The current implementation of TopicSubscription always uses the prefetch extension feature, effectively ignoring any usePrefetchExtension option set in the configuration for the topic destination.

See: [AMQ-6577](https://issues.apache.org/jira/browse/AMQ-6577)
