### PR TITLE
Fix STOMP header escaping when using WebSocket.

### DIFF
--- a/activemq-http/src/main/java/org/apache/activemq/transport/ws/StompWSConnection.java
+++ b/activemq-http/src/main/java/org/apache/activemq/transport/ws/StompWSConnection.java
@@ -16,9 +16,7 @@
  */
 package org.apache.activemq.transport.ws;
 
-import java.io.DataOutputStream;
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingDeque;
@@ -26,7 +24,6 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.activemq.transport.stomp.StompFrame;
 import org.apache.activemq.transport.stomp.StompWireFormat;
-import org.apache.activemq.util.ByteArrayOutputStream;
 import org.eclipse.jetty.websocket.api.Session;
 import org.eclipse.jetty.websocket.api.WebSocketAdapter;
 import org.eclipse.jetty.websocket.api.WebSocketListener;
@@ -73,12 +70,7 @@ public class StompWSConnection extends WebSocketAdapter implements WebSocketList
 
     public synchronized void sendFrame(StompFrame frame) throws Exception {
         checkConnected();
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        DataOutputStream dos = new DataOutputStream(baos);
-        wireFormat.marshal(frame, dos);
-        dos.close();
-        ByteBuffer byteBuffer = ByteBuffer.wrap(baos.toByteArray());
-        connection.getRemote().sendBytes(byteBuffer);
+        connection.getRemote().sendString(wireFormat.marshalToString(frame));
     }
 
     public synchronized void keepAlive() throws Exception {

--- a/activemq-http/src/main/java/org/apache/activemq/transport/ws/jetty9/StompSocket.java
+++ b/activemq-http/src/main/java/org/apache/activemq/transport/ws/jetty9/StompSocket.java
@@ -16,15 +16,12 @@
  */
 package org.apache.activemq.transport.ws.jetty9;
 
-import java.io.DataOutputStream;
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.activemq.transport.stomp.Stomp;
 import org.apache.activemq.transport.stomp.StompFrame;
 import org.apache.activemq.transport.ws.AbstractStompSocket;
-import org.apache.activemq.util.ByteArrayOutputStream;
 import org.apache.activemq.util.IOExceptionSupport;
 import org.eclipse.jetty.websocket.api.Session;
 import org.eclipse.jetty.websocket.api.WebSocketListener;
@@ -49,13 +46,8 @@ public class StompSocket extends AbstractStompSocket implements WebSocketListene
     @Override
     public void sendToStomp(StompFrame command) throws IOException {
         try {
-            ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            DataOutputStream dos = new DataOutputStream(baos);
-            getWireFormat().marshal(command, dos);
-            dos.close();
-            ByteBuffer byteBuffer = ByteBuffer.wrap(baos.toByteArray());
             //timeout after a period of time so we don't wait forever and hold the protocol lock
-            session.getRemote().sendBytesByFuture(byteBuffer).get(getDefaultSendTimeOut(), TimeUnit.SECONDS);
+            session.getRemote().sendStringByFuture(getWireFormat().marshalToString(command)).get(getDefaultSendTimeOut(), TimeUnit.SECONDS);
         } catch (Exception e) {
             throw IOExceptionSupport.create(e);
         }

--- a/activemq-stomp/src/main/java/org/apache/activemq/transport/stomp/StompWireFormat.java
+++ b/activemq-stomp/src/main/java/org/apache/activemq/transport/stomp/StompWireFormat.java
@@ -120,8 +120,8 @@ public class StompWireFormat implements WireFormat {
         if (stomp.getContent() != null) {
             String contentString = new String(stomp.getContent(), "UTF-8");
             buffer.append(contentString);
-            buffer.append('\u0000');
         }
+        buffer.append('\u0000');
         return buffer.toString();
     }
 

--- a/activemq-stomp/src/main/java/org/apache/activemq/transport/stomp/StompWireFormat.java
+++ b/activemq-stomp/src/main/java/org/apache/activemq/transport/stomp/StompWireFormat.java
@@ -74,16 +74,7 @@ public class StompWireFormat implements WireFormat {
         return unmarshal(dis);
     }
 
-    @Override
-    public void marshal(Object command, DataOutput os) throws IOException {
-        StompFrame stomp = (org.apache.activemq.transport.stomp.StompFrame)command;
-
-        if (stomp.getAction().equals(Stomp.Commands.KEEPALIVE)) {
-            os.write(Stomp.BREAK);
-            return;
-        }
-
-        StringBuilder buffer = new StringBuilder();
+    private void marshalHeaders(StompFrame stomp, StringBuilder buffer) throws IOException {
         buffer.append(stomp.getAction());
         buffer.append(Stomp.NEWLINE);
 
@@ -97,10 +88,41 @@ public class StompWireFormat implements WireFormat {
 
         // Add a newline to seperate the headers from the content.
         buffer.append(Stomp.NEWLINE);
+    }
 
-        os.write(buffer.toString().getBytes("UTF-8"));
+    private String marshalHeaders(StompFrame stomp) throws IOException {
+        StringBuilder buffer = new StringBuilder();
+        marshalHeaders(stomp, buffer);
+        return buffer.toString();
+    }
+
+    @Override
+    public void marshal(Object command, DataOutput os) throws IOException {
+        StompFrame stomp = (org.apache.activemq.transport.stomp.StompFrame)command;
+
+        if (stomp.getAction().equals(Stomp.Commands.KEEPALIVE)) {
+            os.write(Stomp.BREAK);
+            return;
+        }
+
+        StringBuilder buffer = new StringBuilder();
+        os.write(marshalHeaders(stomp).getBytes("UTF-8"));
         os.write(stomp.getContent());
         os.write(END_OF_FRAME);
+    }
+
+    public String marshalToString(StompFrame stomp) throws IOException {
+        if (stomp.getAction().equals(Stomp.Commands.KEEPALIVE)) {
+            return String.valueOf((char)Stomp.BREAK);
+        }
+        StringBuilder buffer = new StringBuilder();
+        marshalHeaders(stomp, buffer);
+        if (stomp.getContent() != null) {
+            String contentString = new String(stomp.getContent(), "UTF-8");
+            buffer.append(contentString);
+            buffer.append('\u0000');
+        }
+        return buffer.toString();
     }
 
     @Override


### PR DESCRIPTION
Use wire format class to marshal frames, because method
StompFrame.format() does not escape disallowed characters in STOMP
headers and can cause invalid STOMP messages to be sent, as newline and
colon characters in headers are sent as is.