### PR TITLE
AMQ-6808: preserve destination for browsed scheduled messages

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/broker/scheduler/SchedulerBroker.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/scheduler/SchedulerBroker.java
@@ -426,6 +426,10 @@ public class SchedulerBroker extends BrokerFilter implements JobListener {
             msg.setPersistent(false);
             msg.setType(AdvisorySupport.ADIVSORY_MESSAGE_TYPE);
             msg.setMessageId(new MessageId(this.producerId, this.messageIdGenerator.getNextSequenceId()));
+
+            // Preserve original destination
+            msg.setOriginalDestination(msg.getDestination());
+
             msg.setDestination(replyTo);
             msg.setResponseRequired(false);
             msg.setProducerId(this.producerId);

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/broker/scheduler/JobSchedulerManagementTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/broker/scheduler/JobSchedulerManagementTest.java
@@ -34,6 +34,7 @@ import javax.jms.Session;
 import javax.jms.TextMessage;
 
 import org.apache.activemq.ScheduledMessage;
+import org.apache.activemq.command.ActiveMQMessage;
 import org.apache.activemq.util.IdGenerator;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -395,6 +396,9 @@ public class JobSchedulerManagementTest extends JobSchedulerTestSupport {
         Message message = browser.receive(5000);
         assertNotNull(message);
         assertEquals(45000, message.getLongProperty(ScheduledMessage.AMQ_SCHEDULED_DELAY));
+
+        // Verify that original destination was preserved
+        assertEquals(destination, ((ActiveMQMessage) message).getOriginalDestination());
 
         // Now check if there are anymore, there shouldn't be
         message = browser.receive(5000);


### PR DESCRIPTION
Save original destination as JMS property before overwriting it when browsing scheduled messages.