### PR TITLE
AMQ-6826

### DIFF
--- a/activemq-jdbc-store/src/main/java/org/apache/activemq/store/jdbc/adapter/PostgresqlJDBCAdapter.java
+++ b/activemq-jdbc-store/src/main/java/org/apache/activemq/store/jdbc/adapter/PostgresqlJDBCAdapter.java
@@ -43,7 +43,7 @@ public class PostgresqlJDBCAdapter extends BytesJDBCAdapter {
     @Override
     public void setStatements(Statements statements) {
         statements.setBinaryDataType("BYTEA");
-        statements.setDropAckPKAlterStatementEnd("DROP CONSTRAINT \"" + statements.getTablePrefix().toLowerCase()+getAcksPkName() + "\"");
+        statements.setDropAckPKAlterStatementEnd("DROP CONSTRAINT \"" + statements.getTablePrefix().toLowerCase() + getAcksPkName() + "\"");
         super.setStatements(statements);
     }
 

--- a/activemq-jdbc-store/src/main/java/org/apache/activemq/store/jdbc/adapter/PostgresqlJDBCAdapter.java
+++ b/activemq-jdbc-store/src/main/java/org/apache/activemq/store/jdbc/adapter/PostgresqlJDBCAdapter.java
@@ -43,7 +43,7 @@ public class PostgresqlJDBCAdapter extends BytesJDBCAdapter {
     @Override
     public void setStatements(Statements statements) {
         statements.setBinaryDataType("BYTEA");
-        statements.setDropAckPKAlterStatementEnd("DROP CONSTRAINT \"" + getAcksPkName() + "\"");
+        statements.setDropAckPKAlterStatementEnd("DROP CONSTRAINT \"" +statements.getTablePrefix().toLowerCase()+getAcksPkName() + "\"");
         super.setStatements(statements);
     }
 

--- a/activemq-jdbc-store/src/main/java/org/apache/activemq/store/jdbc/adapter/PostgresqlJDBCAdapter.java
+++ b/activemq-jdbc-store/src/main/java/org/apache/activemq/store/jdbc/adapter/PostgresqlJDBCAdapter.java
@@ -43,7 +43,7 @@ public class PostgresqlJDBCAdapter extends BytesJDBCAdapter {
     @Override
     public void setStatements(Statements statements) {
         statements.setBinaryDataType("BYTEA");
-        statements.setDropAckPKAlterStatementEnd("DROP CONSTRAINT \"" +statements.getTablePrefix().toLowerCase()+getAcksPkName() + "\"");
+        statements.setDropAckPKAlterStatementEnd("DROP CONSTRAINT \"" + statements.getTablePrefix().toLowerCase()+getAcksPkName() + "\"");
         super.setStatements(statements);
     }
 


### PR DESCRIPTION
This fix adds the table-prefix to the activemq_acks_pkey. This is because for postgresql if we use table-prefix statement than Indexes are also created using table-prefix. This table-prefix is empty-string if not set so shouldn't affect normal scenario.

Output from postegre db.
activemq=# \d local_activemq_acks
             Table "public.local_activemq_acks"
    Column     |          Type          |     Modifiers      
---------------+------------------------+--------------------
 container     | character varying(250) | not null
 sub_dest      | character varying(250) | 
 client_id     | character varying(250) | not null
 sub_name      | character varying(250) | not null
 selector      | character varying(250) | 
 last_acked_id | bigint                 | 
 priority      | bigint                 | not null default 5
 xid           | character varying(250) | 
Indexes:
    "local_activemq_acks_pkey" PRIMARY KEY, btree (container, client_id, sub_name)
    "local_activemq_acks_xidx" btree (xid)
