### PR TITLE
AMQ-3189: Postgresql with spring embedded activeMQ has "table alread created" exception

### DIFF
--- a/activemq-jdbc-store/src/main/java/org/apache/activemq/store/jdbc/adapter/DefaultJDBCAdapter.java
+++ b/activemq-jdbc-store/src/main/java/org/apache/activemq/store/jdbc/adapter/DefaultJDBCAdapter.java
@@ -93,7 +93,7 @@ public class DefaultJDBCAdapter implements JDBCAdapter {
         }
     }
 
-    private boolean messageTableAlreadyExists(TransactionContext transactionContext) {
+    protected boolean messageTableAlreadyExists(TransactionContext transactionContext) {
         boolean alreadyExists = false;
         ResultSet rs = null;
         try {
@@ -106,7 +106,7 @@ public class DefaultJDBCAdapter implements JDBCAdapter {
         return alreadyExists;
     }
 
-    private void executeStatement(TransactionContext transactionContext, String createStatement, boolean ignoreStatementExecutionFailure) throws IOException {
+    protected void executeStatement(TransactionContext transactionContext, String createStatement, boolean ignoreStatementExecutionFailure) throws IOException {
         Statement statement = null;
         try {
             LOG.debug("Executing SQL: " + createStatement);


### PR DESCRIPTION
Please review PR for AMQ-3189: Postgresql with spring embedded activeMQ has "table already created" exception


When using any JDBC adapter with createTablesOnStartup="true" a check is performed, in the method "messageTableAlreadyExists" to see if the tables already exist before attempting to create them. But in case of PostgresqlJDBCAdapter, the check always returns false even if they exist because there is an case mismatch. (Tables are created in postgres in lower case by default) The result of this is that the logs are polluted with a warning message (including SQLException stack trace), every time a broker starts. 