### PR TITLE
replicated LevelDB fix and debugging output

### DIFF
--- a/activemq-leveldb-store/src/main/scala/org/apache/activemq/leveldb/replicated/ReplicationProtocolCodec.scala
+++ b/activemq-leveldb-store/src/main/scala/org/apache/activemq/leveldb/replicated/ReplicationProtocolCodec.scala
@@ -84,7 +84,7 @@ class ReplicationProtocolCodec extends AbstractProtocolCodec {
 
   def readReplicationFrame(action:AsciiBuffer):Action = new Action() {
     def apply = {
-      val data:Buffer = readUntil(0.toByte, 1024*64)
+      val data:Buffer = readUntil(0.toByte, 1024*64*4)
       if( data!=null ) {
         data.moveTail(-1);
         nextDecodeAction = readHeader

--- a/activemq-leveldb-store/src/main/scala/org/apache/activemq/leveldb/replicated/SlaveLevelDBStore.scala
+++ b/activemq-leveldb-store/src/main/scala/org/apache/activemq/leveldb/replicated/SlaveLevelDBStore.scala
@@ -27,7 +27,7 @@ import org.fusesource.hawtbuf.{Buffer, AsciiBuffer}
 import org.apache.activemq.leveldb.util._
 
 import FileSupport._
-import java.io.{IOException, RandomAccessFile, File}
+import java.io.{IOException, RandomAccessFile, File, StringWriter, PrintWriter}
 import scala.beans.BeanProperty
 import java.util.concurrent.{CountDownLatch, TimeUnit}
 import javax.management.ObjectName
@@ -251,6 +251,10 @@ class SlaveLevelDBStore extends LevelDBStore with ReplicatedLevelDBStoreTrait {
     override def onTransportFailure(error: IOException) {
       if( isStarted ) {
         warn("Unexpected session error: "+error)
+        debug("Stack trace:")
+        val sw = new StringWriter
+        error.printStackTrace(new PrintWriter(sw))
+        debug(sw.toString)
         queue.after(1, TimeUnit.SECONDS) {
           if( isStarted ) {
             restart_slave_connections


### PR DESCRIPTION
I know LevelDB is now deprecated, and this may not get merged because of that. I certainly don't want to become its maintainer. I had an unhealthy cluster, and did not want to try and migrate it while in that state. This is just a small change to get it healthy again after a slave encountered this error:

Unexpected session error: java.net.ProtocolException: Maximum protocol buffer length exeeded

In my case I believe this is due to having too many LevelDB log files to replicate (a separate LevelDB bug, which I intend to investigate now that this cluster is healthy again).

2 commits in this PR:

1) debugging output to track that down and make it more ... debuggable.

2) a 2-character change to increase a buffer size by 4x, to "fix" the problem.