### PR TITLE
[AMQ-6892]: Test failing unexpectedly: CamelVMTransportRoutingTest.testSendReceiveWithCamelRouteIntercepting

### DIFF
--- a/activemq-camel/src/test/java/org/apache/activemq/camel/CamelDestinationExclusiveConsumerTest.java
+++ b/activemq-camel/src/test/java/org/apache/activemq/camel/CamelDestinationExclusiveConsumerTest.java
@@ -43,5 +43,6 @@ public class CamelDestinationExclusiveConsumerTest {
     public void testMocksAreValid() throws Exception {
         expectedEndpoint.expectedMessageCount(1);
         MockEndpoint.assertIsSatisfied(camelContext);
+        camelContext.stop();
     }
 }

--- a/activemq-camel/src/test/java/org/apache/activemq/camel/CamelJmsTest.java
+++ b/activemq-camel/src/test/java/org/apache/activemq/camel/CamelJmsTest.java
@@ -66,6 +66,8 @@ public class CamelJmsTest extends CamelSpringTestSupport {
         result.assertIsSatisfied();
 
         LOG.info("Received message: " + result.getReceivedExchanges());
+
+        connection.close();
     }
 
     @Test
@@ -93,6 +95,8 @@ public class CamelJmsTest extends CamelSpringTestSupport {
         assertEquals("Message body", expectedBody, textMessage.getText());
 
         LOG.info("Received message: " + message);
+
+        connection.close();
     }
 
     protected int getExpectedRouteCount() {

--- a/activemq-camel/src/test/java/org/apache/activemq/camel/ObjectMessageTest.java
+++ b/activemq-camel/src/test/java/org/apache/activemq/camel/ObjectMessageTest.java
@@ -65,6 +65,7 @@ public class ObjectMessageTest extends CamelSpringTestSupport {
         resultEmpty.expectedMessageCount(1);
         resultEmpty.assertIsNotSatisfied();
 
+        conn.close();
     }
 
     protected void assertCorrectObjectReceived(MockEndpoint result) {


### PR DESCRIPTION
When I run the test CamelVMTransportRoutingTest.testSendReceiveWithCamelRouteIntercepting, it passes, but when I run all of the tests in activemq-camel, it fails. I am running this in Intellij.

It appears the problem is unclosed connections in some of the other tests.