### PR TITLE
AMQ-6894: limit poison exception message to 1024

### DIFF
--- a/activemq-client/src/main/java/org/apache/activemq/openwire/v1/BaseDataStreamMarshaller.java
+++ b/activemq-client/src/main/java/org/apache/activemq/openwire/v1/BaseDataStreamMarshaller.java
@@ -30,6 +30,7 @@ import org.apache.activemq.util.ByteSequence;
 public abstract class BaseDataStreamMarshaller implements DataStreamMarshaller {
 
     public static final Constructor STACK_TRACE_ELEMENT_CONSTRUCTOR;
+    private static final int MAX_EXCEPTION_MESSAGE_SIZE = 1024;
 
     static {
         Constructor constructor = null;
@@ -244,7 +245,7 @@ public abstract class BaseDataStreamMarshaller implements DataStreamMarshaller {
             int rc = 0;
             bs.writeBoolean(true);
             rc += tightMarshalString1(o.getClass().getName(), bs);
-            rc += tightMarshalString1(o.getMessage(), bs);
+            rc += tightMarshalString1(cutMessageIfNeeded(o.getMessage()), bs);
             if (wireFormat.isStackTraceEnabled()) {
                 rc += 2;
                 StackTraceElement[] stackTrace = o.getStackTrace();
@@ -265,7 +266,7 @@ public abstract class BaseDataStreamMarshaller implements DataStreamMarshaller {
                                           BooleanStream bs) throws IOException {
         if (bs.readBoolean()) {
             tightMarshalString2(o.getClass().getName(), dataOut, bs);
-            tightMarshalString2(o.getMessage(), dataOut, bs);
+            tightMarshalString2(cutMessageIfNeeded(o.getMessage()), dataOut, bs);
             if (wireFormat.isStackTraceEnabled()) {
                 StackTraceElement[] stackTrace = o.getStackTrace();
                 dataOut.writeShort(stackTrace.length);
@@ -551,7 +552,7 @@ public abstract class BaseDataStreamMarshaller implements DataStreamMarshaller {
         dataOut.writeBoolean(o != null);
         if (o != null) {
             looseMarshalString(o.getClass().getName(), dataOut);
-            looseMarshalString(o.getMessage(), dataOut);
+            looseMarshalString(cutMessageIfNeeded(o.getMessage()), dataOut);
             if (wireFormat.isStackTraceEnabled()) {
                 StackTraceElement[] stackTrace = o.getStackTrace();
                 dataOut.writeShort(stackTrace.length);
@@ -641,5 +642,11 @@ public abstract class BaseDataStreamMarshaller implements DataStreamMarshaller {
             rc = new ByteSequence(t, 0, size);
         }
         return rc;
+    }
+
+    protected String cutMessageIfNeeded(final String message) {
+        return (message.length() > MAX_EXCEPTION_MESSAGE_SIZE)?
+            message.substring(0, MAX_EXCEPTION_MESSAGE_SIZE - 3) + "..." : message;
+            
     }
 }

--- a/activemq-client/src/test/java/org/apache/activemq/openwire/v1/BaseDataStreamMarshallerTest.java
+++ b/activemq-client/src/test/java/org/apache/activemq/openwire/v1/BaseDataStreamMarshallerTest.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.openwire.v1;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+
+import javax.jms.MessageFormatException;
+
+import org.junit.Test;
+
+public class BaseDataStreamMarshallerTest {
+
+    private static final int MAX_MESSAGE_LENGTH = 1024;
+
+    @Test
+    public void cutMessageIfNeeded() throws MessageFormatException {
+        char[] message = new char[2056];
+        Arrays.fill(message, '1');
+        String cutMessage = (new WireFormatInfoMarshaller()).cutMessageIfNeeded(String.valueOf(message));
+        assertEquals("Expected length " + MAX_MESSAGE_LENGTH, MAX_MESSAGE_LENGTH, cutMessage.length());
+        assertTrue("Expected message tail ...", cutMessage.endsWith("..."));
+    }
+}

--- a/activemq-client/src/test/java/org/apache/activemq/openwire/v10/BaseDataStreamMarshallerTest.java
+++ b/activemq-client/src/test/java/org/apache/activemq/openwire/v10/BaseDataStreamMarshallerTest.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.openwire.v10;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+
+import javax.jms.MessageFormatException;
+
+import org.junit.Test;
+
+public class BaseDataStreamMarshallerTest {
+
+    private static final int MAX_MESSAGE_LENGTH = 1024;
+
+    @Test
+    public void cutMessageIfNeeded() throws MessageFormatException {
+        char[] message = new char[2056];
+        Arrays.fill(message, '1');
+        String cutMessage = (new WireFormatInfoMarshaller()).cutMessageIfNeeded(String.valueOf(message));
+        assertEquals("Expected length " + MAX_MESSAGE_LENGTH, MAX_MESSAGE_LENGTH, cutMessage.length());
+        assertTrue("Expected message tail ...", cutMessage.endsWith("..."));
+    }
+}


### PR DESCRIPTION
AMQ-6894: Limit poison exception message to 1024 to avoid IOException be encoding