### PR TITLE
AMQ-6930 Expose an environment variable to allow redirect stdout/stderr to a file

### DIFF
--- a/assembly/src/release/bin/activemq
+++ b/assembly/src/release/bin/activemq
@@ -334,7 +334,7 @@ invokeJar(){
               -Dactivemq.conf=\"${ACTIVEMQ_CONF}\" \
               -Dactivemq.data=\"${ACTIVEMQ_DATA}\" \
               $ACTIVEMQ_CYGWIN \
-              -jar \"${ACTIVEMQ_HOME}/bin/activemq.jar\" $COMMANDLINE_ARGS >/dev/null 2>&1 &
+              -jar \"${ACTIVEMQ_HOME}/bin/activemq.jar\" $COMMANDLINE_ARGS >> $ACTIVEMQ_OUT 2>&1 &
               RET=\"\$?\"; APID=\"\$!\";
               echo \$APID > "${PIDFILE}";
               echo \"INFO: pidfile created : '${PIDFILE}' (pid '\$APID')\";exit \$RET" $DOIT_POSTFIX

--- a/assembly/src/release/bin/env
+++ b/assembly/src/release/bin/env
@@ -19,7 +19,7 @@
 # Configuration file for running Apache Active MQ as standalone provider.
 #
 # This file overwrites the predefined settings of the sysv init-script.
-# You can also use alternate location for default settings -  
+# You can also use alternate location for default settings -
 # invoke the init-script without a argument an review help section "Configuration of this script"
 # /etc/default/activemq <activemq user home>/.activemqrc <activemq installation dir>/bin/env
 
@@ -35,6 +35,10 @@ ACTIVEMQ_OPTS_MEMORY="-Xms64M -Xmx1G"
 
 if [ -z "$ACTIVEMQ_OPTS" ] ; then
     ACTIVEMQ_OPTS="$ACTIVEMQ_OPTS_MEMORY -Djava.util.logging.config.file=logging.properties -Djava.security.auth.login.config=$ACTIVEMQ_CONF/login.config"
+fi
+
+if [ -z "$ACTIVEMQ_OUT" ]; then
+   ACTIVEMQ_OUT="/dev/null"
 fi
 
 # Uncomment to enable audit logging

--- a/assembly/src/test/scripts/init-script-testsuite
+++ b/assembly/src/test/scripts/init-script-testsuite
@@ -19,7 +19,7 @@
 # This script tests the activemq init script
 #
 # Authors:
-# Marc Schoechlin <ms@256bit.org>  
+# Marc Schoechlin <ms@256bit.org>
 
 STATUS_OVERVIEW=""
 OVERALL_STATUS="0"
@@ -97,7 +97,7 @@ echo "Setting HOME to $TESTDIR"
 export HOME="$TESTDIR"
 
 case "`uname`" in
-  CYGWIN*) 
+  CYGWIN*)
     echo "Set init script"
     SCRIPT="$PWD/activemq"
     CONFIG="$HOME/.activemqrc"
@@ -124,17 +124,17 @@ sleep 2
 assert ${STRATEGY} successful "${SCRIPT} stop"
 assert ${STRATEGY}     failed "${SCRIPT}"
 assert ${STRATEGY}     failed "${SCRIPT} status"
-assert ${STRATEGY} successful "${SCRIPT} browse|grep -q 'Activemq is not running.'"
-assert ${STRATEGY} successful "${SCRIPT} browse FOOBAR111111111 2>&1|grep -q 'Activemq is not running.'"
-assert ${STRATEGY} successful "${SCRIPT} browse --amqurl tcp://localhost:11111 FOOOOO 2>&1|grep -q 'java.net.ConnectException'"
+assert ${STRATEGY} successful "${SCRIPT} browse|grep -q 'No JMS destination specified.'"
+assert ${STRATEGY} successful "${SCRIPT} browse FOOBAR111111111 2>&1|grep -q 'Broker not available at:'"
+assert ${STRATEGY} successful "${SCRIPT} browse --amqurl tcp://localhost:11111 FOOOOO 2>&1|grep -q 'Broker not available at:'"
 assert ${STRATEGY} successful "${SCRIPT} encrypt --password TESTPASSWORD --input FOOBAR|grep -q 'Encrypted text: '"
 assert ${STRATEGY} successful "${SCRIPT} decrypt --input 'BkiT42A0CZfL1SanJIgxvQ==' --password asdasdasdasd|grep -q 'Decrypted text:'"
-assert ${STRATEGY} successful "${SCRIPT} bstat 2>&1|grep -q 'Activemq is not running.'"
-assert ${STRATEGY} successful "${SCRIPT} bstat --jmxurl service:jmx:rmi:///jndi/rmi://127.0.0.1:11098/jmxrmi --jmxuser controlRole --jmxpassword abcd1234 2>&1|grep -q 'java.net.ConnectException'"
-assert ${STRATEGY} successful "${SCRIPT} dstat 2>&1|grep -q 'Activemq is not running.'"
-assert ${STRATEGY} successful "${SCRIPT} dstat --jmxurl service:jmx:rmi:///jndi/rmi://127.0.0.1:11098/jmxrmi --jmxuser controlRole --jmxpassword abcd1234 2>&1|grep -q 'java.net.ConnectException'"
-assert ${STRATEGY} successful "${SCRIPT} query 2>&1|grep -q 'Activemq is not running.'"
-assert ${STRATEGY} successful "${SCRIPT} query --jmxurl service:jmx:rmi:///jndi/rmi://127.0.0.1:11098/jmxrmi --jmxuser controlRole --jmxpassword abcd1234 2>&1|grep -q 'java.net.ConnectException'"
+assert ${STRATEGY} successful "${SCRIPT} bstat 2>&1|grep -q 'Broker not available at:'"
+assert ${STRATEGY} successful "${SCRIPT} bstat --jmxurl service:jmx:rmi:///jndi/rmi://127.0.0.1:11098/jmxrmi --jmxuser controlRole --jmxpassword abcd1234 2>&1|grep -q 'Broker not available at:'"
+assert ${STRATEGY} successful "${SCRIPT} dstat 2>&1|grep -q 'Broker not available at:'"
+assert ${STRATEGY} successful "${SCRIPT} dstat --jmxurl service:jmx:rmi:///jndi/rmi://127.0.0.1:11098/jmxrmi --jmxuser controlRole --jmxpassword abcd1234 2>&1|grep -q 'Broker not available at:'"
+assert ${STRATEGY} successful "${SCRIPT} query 2>&1|grep -q 'Broker not available at:'"
+assert ${STRATEGY} successful "${SCRIPT} query --jmxurl service:jmx:rmi:///jndi/rmi://127.0.0.1:11098/jmxrmi --jmxuser controlRole --jmxpassword abcd1234 2>&1|grep -q 'Broker not available at:'"
 assert ${STRATEGY} successful "${SCRIPT} restart"
 assert ${STRATEGY} successful "${SCRIPT} stop"
 
@@ -170,8 +170,18 @@ assert ${STRATEGY} successful "${SCRIPT} query|grep brokerName"
 # assert ${STRATEGY} successful "${SCRIPT} create"
 # assert ${STRATEGY} successful "${SCRIPT} export"
 
-echo 
-echo 
+#ActiveMQ start with custom ACTIVEMQ_OUT
+TEST_ACTIVEMQ_OUT=$TESTDIR/activemq.out
+export ACTIVEMQ_OUT=$TEST_ACTIVEMQ_OUT
+assert ${STRATEGY} successful "${SCRIPT} restart && test -f $TEST_ACTIVEMQ_OUT"
+assert ${STRATEGY} successful "${SCRIPT} stop"
+rm $TEST_ACTIVEMQ_OUT
+unset ACTIVEMQ_OUT
+assert ${STRATEGY} successful "${SCRIPT} restart && test ! -f $TEST_ACTIVEMQ_OUT"
+assert ${STRATEGY} successful "${SCRIPT} stop"
+
+echo
+echo
 
 trap "" INT TERM
 finalize


### PR DESCRIPTION
This change does not modify the default behavior, the default behavior is still to pipe stdout/stderr to /dev/null. User can specify a file using an environment variable called `ACTIVEMQ_OUT` to  redirect stdout/stderr to the file. 

This change also added and fixed some tests in `assembly/src/test/scripts/init-script-testsuite`.