### PR TITLE
AMQ-6959

### DIFF
--- a/activemq-client/src/main/java/org/apache/activemq/ActiveMQSession.java
+++ b/activemq-client/src/main/java/org/apache/activemq/ActiveMQSession.java
@@ -950,7 +950,9 @@ public class ActiveMQSession implements Session, QueueSession, TopicSession, Sta
 
                             @Override
                             public void afterRollback() throws Exception {
-                                LOG.trace("rollback {}", ack, new Throwable("here"));
+                                if (LOG.isTraceEnabled()) {
+                                    LOG.trace("rollback {}", ack, new Throwable("here"));
+                                }
                                 // ensure we don't filter this as a duplicate
                                 connection.rollbackDuplicate(ActiveMQSession.this, md.getMessage());
 


### PR DESCRIPTION
We should not create a Throwable object (which will call fillInStackTrace() method) in case of non TRACE logging. For example if we have an INFO log level, message will no be created and logged, but a Throwable object will be created.