### PR TITLE
AMQ-7015

### DIFF
--- a/activemq-kahadb-store/src/main/java/org/apache/activemq/store/kahadb/KahaDBPersistenceAdapter.java
+++ b/activemq-kahadb-store/src/main/java/org/apache/activemq/store/kahadb/KahaDBPersistenceAdapter.java
@@ -547,6 +547,14 @@ public class KahaDBPersistenceAdapter extends LockableServiceSupport implements 
         letter.setCheckForCorruptJournalFiles(checkForCorruptJournalFiles);
     }
 
+    public boolean isPurgeRecoveredXATransactions() {
+        return letter.isPurgeRecoveredXATransactions();
+    }
+
+    public void setPurgeRecoveredXATransactions(boolean purgeRecoveredXATransactions) {
+        letter.setPurgeRecoveredXATransactions(purgeRecoveredXATransactions);
+    }
+
     @Override
     public void setBrokerService(BrokerService brokerService) {
         super.setBrokerService(brokerService);

--- a/activemq-kahadb-store/src/main/java/org/apache/activemq/store/kahadb/MessageDatabase.java
+++ b/activemq-kahadb-store/src/main/java/org/apache/activemq/store/kahadb/MessageDatabase.java
@@ -272,6 +272,7 @@ public abstract class MessageDatabase extends ServiceSupport implements BrokerSe
     private boolean ignoreMissingJournalfiles = false;
     private int indexCacheSize = 10000;
     private boolean checkForCorruptJournalFiles = false;
+    private boolean purgeRecoveredXATransactions = false;
     private boolean checksumJournalFiles = true;
     protected boolean forceRecoverIndex = false;
     private boolean archiveCorruptedIndex = false;
@@ -747,6 +748,13 @@ public abstract class MessageDatabase extends ServiceSupport implements BrokerSe
             synchronized (preparedTransactions) {
                 for (TransactionId txId : preparedTransactions.keySet()) {
                     LOG.warn("Recovered prepared XA TX: [{}]", txId);
+                }
+
+                if (purgeRecoveredXATransactions){
+                    if (!preparedTransactions.isEmpty()){
+                        LOG.warn("Purging " +  preparedTransactions.size() + " recovered prepared XA TXs" );
+                        preparedTransactions.clear();
+                    }
                 }
             }
 
@@ -3338,6 +3346,14 @@ public abstract class MessageDatabase extends ServiceSupport implements BrokerSe
 
     public void setCheckForCorruptJournalFiles(boolean checkForCorruptJournalFiles) {
         this.checkForCorruptJournalFiles = checkForCorruptJournalFiles;
+    }
+
+    public boolean isPurgeRecoveredXATransactions() {
+        return purgeRecoveredXATransactions;
+    }
+
+    public void setPurgeRecoveredXATransactions(boolean purgeRecoveredXATransactions) {
+        this.purgeRecoveredXATransactions = purgeRecoveredXATransactions;
     }
 
     public boolean isChecksumJournalFiles() {

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/broker/BrokerRestartTestSupport.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/broker/BrokerRestartTestSupport.java
@@ -58,10 +58,13 @@ public class BrokerRestartTestSupport extends BrokerTestSupport {
      * @throws URISyntaxException
      */
     protected void restartBroker() throws Exception {
-        broker.stop();
-        broker.waitUntilStopped();
-        broker = createRestartedBroker();
+        stopBroker();
         broker.start();
     }
 
+    protected void stopBroker() throws Exception {
+        broker.stop();
+        broker.waitUntilStopped();
+        broker = createRestartedBroker();
+    }
 }


### PR DESCRIPTION
Added a purgeRecoveredXATransactions property on the KahaDB adaptor to purge prepared XA messages on recovery