### PR TITLE
AMQ-7050: Allow alternate persistence mechanism with SubQueueSelectorCacheBrokerPlugin

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/plugin/PeriodicallyFlushedFileSubSelectorCache.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/plugin/PeriodicallyFlushedFileSubSelectorCache.java
@@ -126,14 +126,11 @@ public class PeriodicallyFlushedFileSubSelectorCache implements SubSelectorCache
     private void readCache() {
         if (persistFile != null && persistFile.exists()) {
             try {
-                try (FileInputStream fis = new FileInputStream(persistFile);) {
-                    ObjectInputStream in = new ObjectInputStream(fis);
-                    try {
+                try (FileInputStream fis = new FileInputStream(persistFile)) {
+                    try (ObjectInputStream in = new ObjectInputStream(fis)) {
                         subSelectorCache = (ConcurrentHashMap<String, Set<String>>) in.readObject();
                     } catch (ClassNotFoundException ex) {
                         LOG.error("Invalid selector cache data found. Please remove file.", ex);
-                    } finally {
-                        in.close();
                     }
                 }
             } catch (IOException ex) {

--- a/activemq-broker/src/main/java/org/apache/activemq/plugin/PeriodicallyFlushedFileSubSelectorCache.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/plugin/PeriodicallyFlushedFileSubSelectorCache.java
@@ -18,6 +18,12 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
+/**
+ * Simple {@link SubSelectorCache} which uses a {@link File} for persistence.
+ *
+ * <p>Cache is flushed to file periodically based on {@link #getPersistInterval()}.
+ * Failures to flush are only logged.
+ */
 public class PeriodicallyFlushedFileSubSelectorCache implements SubSelectorCache, Runnable {
     public static final long MAX_PERSIST_INTERVAL = 600000;
 

--- a/activemq-broker/src/main/java/org/apache/activemq/plugin/PeriodicallyFlushedFileSubSelectorCache.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/plugin/PeriodicallyFlushedFileSubSelectorCache.java
@@ -2,6 +2,7 @@ package org.apache.activemq.plugin;
 
 import static org.apache.activemq.plugin.SubQueueSelectorCacheBroker.MATCH_EVERYTHING;
 
+import com.google.common.collect.ImmutableSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -63,7 +64,7 @@ public class PeriodicallyFlushedFileSubSelectorCache implements SubSelectorCache
             return Collections.emptySet();
         }
 
-        return Collections.unmodifiableSet(selectors);
+        return ImmutableSet.copyOf(selectors);
     }
 
     @Override

--- a/activemq-broker/src/main/java/org/apache/activemq/plugin/PeriodicallyFlushedFileSubSelectorCache.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/plugin/PeriodicallyFlushedFileSubSelectorCache.java
@@ -1,0 +1,165 @@
+package org.apache.activemq.plugin;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+public class PeriodicallyFlushedFileSubSelectorCache implements SubSelectorCache, Runnable {
+    public static final long MAX_PERSIST_INTERVAL = 600000;
+
+    private static final Logger LOG = LoggerFactory.getLogger(PeriodicallyFlushedFileSubSelectorCache.class);
+
+    private static final String SELECTOR_CACHE_PERSIST_THREAD_NAME = "SelectorCachePersistThread";
+
+    /**
+     * The subscription's selector cache. We cache compiled expressions keyed
+     * by the target destination.
+     */
+    private ConcurrentMap<String, Set<String>> subSelectorCache = new ConcurrentHashMap<String, Set<String>>();
+
+    private long persistInterval = MAX_PERSIST_INTERVAL;
+
+    private boolean running = true;
+
+    private final Thread persistThread;
+
+    private final File persistFile;
+
+    public PeriodicallyFlushedFileSubSelectorCache(File persistFile) {
+        this.persistFile = persistFile;
+        persistThread = new Thread(this, SELECTOR_CACHE_PERSIST_THREAD_NAME);
+
+        LOG.info("Using persisted selector cache from[{}]", persistFile);
+
+        readCache();
+    }
+
+    public long getPersistInterval() {
+        return persistInterval;
+    }
+
+    public void setPersistInterval(long persistInterval) {
+        this.persistInterval = persistInterval;
+    }
+
+    @Override
+    public Set<String> selectorsForDestination(String destination) {
+        Set<String> selectors = subSelectorCache.get(destination);
+
+        if (selectors == null) {
+            return null;
+        }
+
+        return new HashSet<>(selectors);
+    }
+
+    @Override
+    public void removeSelectorsForDestination(String destination) {
+        if (subSelectorCache.containsKey(destination)) {
+            Set<String> cachedSelectors = subSelectorCache.get(destination);
+            cachedSelectors.clear();
+        }
+    }
+
+    @Override
+    public boolean removeSelector(String destination, String selector) {
+        if (subSelectorCache.containsKey(destination)) {
+            Set<String> cachedSelectors = subSelectorCache.get(destination);
+            return cachedSelectors.remove(selector);
+        }
+
+        return false;
+    }
+
+    @Override
+    public void putSelectorsForDestination(String destination, Set<String> selectors) {
+        subSelectorCache.put(destination, new HashSet<>(selectors));
+    }
+
+    @Override
+    public void start() throws Exception {
+        persistThread.start();
+    }
+
+    @Override
+    public void stop() throws InterruptedException {
+        running = false;
+        if (persistThread != null) {
+            persistThread.interrupt();
+            persistThread.join();
+        }
+    }
+
+
+    @SuppressWarnings("unchecked")
+    private void readCache() {
+        if (persistFile != null && persistFile.exists()) {
+            try {
+                try (FileInputStream fis = new FileInputStream(persistFile);) {
+                    ObjectInputStream in = new ObjectInputStream(fis);
+                    try {
+                        subSelectorCache = (ConcurrentHashMap<String, Set<String>>) in.readObject();
+                    } catch (ClassNotFoundException ex) {
+                        LOG.error("Invalid selector cache data found. Please remove file.", ex);
+                    } finally {
+                        in.close();
+                    }
+                }
+            } catch (IOException ex) {
+                LOG.error("Unable to read persisted selector cache...it will be ignored!", ex);
+            }
+        }
+    }
+
+    /**
+     * Persist the selector cache.
+     */
+    private void persistCache() {
+        LOG.debug("Persisting selector cache....");
+        try {
+            FileOutputStream fos = new FileOutputStream(persistFile);
+            try {
+                ObjectOutputStream out = new ObjectOutputStream(fos);
+                try {
+                    out.writeObject(subSelectorCache);
+                } finally {
+                    out.flush();
+                    out.close();
+                }
+            } catch (IOException ex) {
+                LOG.error("Unable to persist selector cache", ex);
+            } finally {
+                fos.close();
+            }
+        } catch (IOException ex) {
+            LOG.error("Unable to access file[{}]", persistFile, ex);
+        }
+    }
+
+    /**
+     * Persist the selector cache every {@code MAX_PERSIST_INTERVAL}ms.
+     *
+     * @see java.lang.Runnable#run()
+     */
+    @Override
+    public void run() {
+        while (running) {
+            try {
+                Thread.sleep(persistInterval);
+            } catch (InterruptedException ex) {
+            }
+
+            persistCache();
+        }
+    }
+}

--- a/activemq-broker/src/main/java/org/apache/activemq/plugin/SubQueueSelectorCacheBroker.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/plugin/SubQueueSelectorCacheBroker.java
@@ -160,7 +160,7 @@ public class SubQueueSelectorCacheBroker extends BrokerFilter {
                 String destinationName = info.getDestination().getQualifiedName();
                 Set<String> selectors = subSelectorCache.selectorsForDestination(destinationName);
                 if (info.getSelector() == null && selectors.size() > 1) {
-                    boolean removed = selectors.remove(MATCH_EVERYTHING);
+                    boolean removed = subSelectorCache.removeSelector(destinationName, MATCH_EVERYTHING);
                     LOG.debug("A non-selector consumer has dropped. Removing the catchall matching pattern 'TRUE'. Successful? " + removed);
                 }
             }

--- a/activemq-broker/src/main/java/org/apache/activemq/plugin/SubQueueSelectorCacheBroker.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/plugin/SubQueueSelectorCacheBroker.java
@@ -129,9 +129,12 @@ public class SubQueueSelectorCacheBroker extends BrokerFilter {
                     subSelectorCache.addSelectorForDestination(destinationName, selector);
                 }
 
-                Set<String> selectors = subSelectorCache.selectorsForDestination(destinationName);
                 LOG.debug("adding new selector: into cache " + selector);
-                LOG.debug("current selectors in cache: " + selectors);
+
+                if (LOG.isDebugEnabled()) {
+                    Set<String> selectors = subSelectorCache.selectorsForDestination(destinationName);
+                    LOG.debug("current selectors in cache: " + selectors);
+                }
             }
         }
 

--- a/activemq-broker/src/main/java/org/apache/activemq/plugin/SubQueueSelectorCacheBroker.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/plugin/SubQueueSelectorCacheBroker.java
@@ -186,7 +186,8 @@ public class SubQueueSelectorCacheBroker extends BrokerFilter {
 
     @SuppressWarnings("unchecked")
     public Set<String> getSelectorsForDestination(String destinationName) {
-        return subSelectorCache.selectorsForDestination(destinationName);
+        Set<String> selectors = subSelectorCache.selectorsForDestination(destinationName);
+        return selectors == null ? Collections.emptySet() : selectors;
     }
 
     public boolean deleteSelectorForDestination(String destinationName, String selector) {

--- a/activemq-broker/src/main/java/org/apache/activemq/plugin/SubQueueSelectorCacheBrokerPlugin.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/plugin/SubQueueSelectorCacheBrokerPlugin.java
@@ -17,12 +17,11 @@
 package org.apache.activemq.plugin;
 
 import static org.apache.activemq.plugin.PeriodicallyFlushedFileSubSelectorCache.MAX_PERSIST_INTERVAL;
-import static org.apache.activemq.plugin.SubQueueSelectorCacheBroker.MAX_PERSIST_INTERVAL;
-
-import java.io.File;
 
 import org.apache.activemq.broker.Broker;
 import org.apache.activemq.broker.BrokerPlugin;
+
+import java.io.File;
 
 /**
  * A plugin which allows the caching of the selector from a subscription queue.

--- a/activemq-broker/src/main/java/org/apache/activemq/plugin/SubQueueSelectorCacheBrokerPlugin.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/plugin/SubQueueSelectorCacheBrokerPlugin.java
@@ -16,6 +16,7 @@
  */
 package org.apache.activemq.plugin;
 
+import static org.apache.activemq.plugin.PeriodicallyFlushedFileSubSelectorCache.MAX_PERSIST_INTERVAL;
 import static org.apache.activemq.plugin.SubQueueSelectorCacheBroker.MAX_PERSIST_INTERVAL;
 
 import java.io.File;
@@ -43,9 +44,11 @@ public class SubQueueSelectorCacheBrokerPlugin implements BrokerPlugin {
 
     @Override
     public Broker installPlugin(Broker broker) throws Exception {
-        SubQueueSelectorCacheBroker rc = new SubQueueSelectorCacheBroker(broker, persistFile);
+        PeriodicallyFlushedFileSubSelectorCache subSelectorCache =
+                new PeriodicallyFlushedFileSubSelectorCache(persistFile);
+        subSelectorCache.setPersistInterval(persistInterval);
+        SubQueueSelectorCacheBroker rc = new SubQueueSelectorCacheBroker(broker, subSelectorCache);
         rc.setSingleSelectorPerDestination(singleSelectorPerDestination);
-        rc.setPersistInterval(persistInterval);
         rc.setIgnoreWildcardSelectors(ignoreWildcardSelectors);
         return rc;
     }

--- a/activemq-broker/src/main/java/org/apache/activemq/plugin/SubSelectorCache.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/plugin/SubSelectorCache.java
@@ -1,0 +1,26 @@
+package org.apache.activemq.plugin;
+
+import org.apache.activemq.Service;
+
+import java.util.Set;
+
+public interface SubSelectorCache extends Service {
+    /**
+     *
+     * @param destinationName Canonical destination name.
+     * @return Mutable copy of selectors. Modifications do not pass through to the cache.
+     */
+    Set<String> selectorsForDestination(String destinationName);
+
+    void removeSelectorsForDestination(String destinationName);
+
+    boolean removeSelector(String destinationName, String selector);
+
+    /**
+     *
+     * @param destinationName Canonical destination name.
+     * @param selectors Set of selectors to be copied and added to the cache. Future mutations to
+     *                  the set will <em>not</em> pass through to the cache.
+     */
+    void putSelectorsForDestination(String destinationName, Set<String> selectors);
+}

--- a/activemq-broker/src/main/java/org/apache/activemq/plugin/SubSelectorCache.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/plugin/SubSelectorCache.java
@@ -4,14 +4,48 @@ import org.apache.activemq.Service;
 
 import java.util.Set;
 
+/**
+ * Cache for set of JMS selectors used by qualified destination name.
+ *
+ * @see SubQueueSelectorCacheBroker
+ */
 public interface SubSelectorCache extends Service {
+    /**
+     * @param destinationName Qualified destination name
+     * @return Immutable copy of current known selectors for given destination
+     */
     Set<String> selectorsForDestination(String destinationName);
 
+    /**
+     * Removes all selectors from cache for destination.
+     * @param destinationName Qualified destination name
+     */
     void removeSelectorsForDestination(String destinationName);
 
+    /**
+     * Removes single selector if present from cache.
+     * @param destinationName Qualified destination name
+     * @param selector Selector expression to remove
+     * @return {@code true} if selector found and removed, {@code false} otherwise
+     */
     boolean removeSelector(String destinationName, String selector);
 
+    /**
+     * Replaces all selectors for destination, except for the
+     * {@link SubQueueSelectorCacheBroker#MATCH_EVERYTHING} selector, with provided
+     * {@code selector}.
+     * @param destinationName Qualified destination name
+     * @param selector Selector expression
+     */
     void replaceSelectorsExceptForMatchEverything(String destinationName, String selector);
 
+    /**
+     * Add {@code selector} to set of cached selectors for given destination.
+     *
+     * <p>Selector may not immediately be persisted in the cache.
+     *
+     * @param destinationName Qualified destination name
+     * @param selector Selector expression to cache
+     */
     void addSelectorForDestination(String destinationName, String selector);
 }

--- a/activemq-broker/src/main/java/org/apache/activemq/plugin/SubSelectorCache.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/plugin/SubSelectorCache.java
@@ -5,22 +5,13 @@ import org.apache.activemq.Service;
 import java.util.Set;
 
 public interface SubSelectorCache extends Service {
-    /**
-     *
-     * @param destinationName Canonical destination name.
-     * @return Mutable copy of selectors. Modifications do not pass through to the cache.
-     */
     Set<String> selectorsForDestination(String destinationName);
 
     void removeSelectorsForDestination(String destinationName);
 
     boolean removeSelector(String destinationName, String selector);
 
-    /**
-     *
-     * @param destinationName Canonical destination name.
-     * @param selectors Set of selectors to be copied and added to the cache. Future mutations to
-     *                  the set will <em>not</em> pass through to the cache.
-     */
-    void putSelectorsForDestination(String destinationName, Set<String> selectors);
+    void replaceSelectorsExceptForMatchEverything(String destinationName, String selector);
+
+    void addSelectorForDestination(String destinationName, String selector);
 }


### PR DESCRIPTION
More details in [JIRA](https://issues.apache.org/jira/browse/AMQ-7050). Had a go at this by pulling out an interface for cache interactions and including default, File-based implementation that behaves just as before.

This flexibility is designed to allow future, alternative implementations such as a JDBC-based cache (e.g. for folks using JDBC persistence).

Thanks for review!