### PR TITLE
AMQ-7055 - Optimization on SequenceSet to prevent iterating through t…

### DIFF
--- a/activemq-kahadb-store/src/main/java/org/apache/activemq/store/kahadb/disk/util/Sequence.java
+++ b/activemq-kahadb-store/src/main/java/org/apache/activemq/store/kahadb/disk/util/Sequence.java
@@ -38,6 +38,10 @@ public class Sequence extends LinkedNode<Sequence> {
         return last + 1 == value;
     }
 
+    public boolean isBiggerButNotAdjacentToLast(long value) {
+        return last + 1 < value;
+    }
+
     public boolean isAdjacentToFirst(long value) {
         return first - 1 == value;
     }

--- a/activemq-kahadb-store/src/main/java/org/apache/activemq/store/kahadb/disk/util/SequenceSet.java
+++ b/activemq-kahadb-store/src/main/java/org/apache/activemq/store/kahadb/disk/util/SequenceSet.java
@@ -114,6 +114,13 @@ public class SequenceSet extends LinkedNodeList<Sequence> implements Iterable<Lo
             return true;
         }
 
+        // check if the value is greater than the bigger sequence value and if it's not adjacent to it
+        // in this case, we are sure that the value should be add to the tail of the sequence.
+        if (sequence.isBiggerButNotAdjacentToLast(value)) {
+            addLast(new Sequence(value));
+            return true;
+        }
+
         sequence = getHead();
         while (sequence != null) {
 

--- a/activemq-kahadb-store/src/test/java/org/apache/activemq/store/kahadb/disk/util/SequenceSetTest.java
+++ b/activemq-kahadb-store/src/test/java/org/apache/activemq/store/kahadb/disk/util/SequenceSetTest.java
@@ -86,6 +86,37 @@ public class SequenceSetTest {
     }
 
     @Test
+    public void testAddValuesToTail() {
+        SequenceSet set = new SequenceSet();
+        set.add(new Sequence(0, 10));
+        set.add(new Sequence(21, 42));
+        set.add(new Sequence(142, 512));
+
+        set.add(513);
+
+        for (int i = 600; i < 650; i++) {
+            set.add(i);
+        }
+
+        for (int i = 0; i < 10; i++) {
+            set.add(i * 100);
+        }
+
+        assertTrue(set.contains(0));
+        assertTrue(set.contains(25));
+
+        assertTrue(set.contains(513));
+        assertTrue(!set.contains(514));
+        assertFalse(set.contains(599));
+        assertTrue(set.contains(625));
+        assertFalse(set.contains(651));
+
+        for (int i = 0; i < 10; i++) {
+            assertTrue(set.contains(i * 100));
+        }
+    }
+
+    @Test
     public void testRemove() {
         SequenceSet set = new SequenceSet();
         set.add(new Sequence(0, 100));


### PR DESCRIPTION
When the index file has a huge number of free pages and the broker is starting up (loading the index) we end up in a O(n2) loop.

This was causing the broker to use 100% cpu and not being able to start up even after a long time (as i remember we had around 3 millions free page in this case)

https://github.com/apache/activemq/blob/master/activemq-kahadb-store/src/main/java/org/apache/activemq/store/kahadb/disk/page/PageFile.java#L428

https://github.com/apache/activemq/blob/master/activemq-kahadb-store/src/main/java/org/apache/activemq/store/kahadb/disk/util/SequenceSet.java#L118

I noticed that almost all the free pages was being added to the end of the sequenceSet... So for any free page the broker had to necessity iterate through  all the Set (and after doing that for nothing add . the value to the tail).

With this small change, the broker started up in less than 5 minutes.