### PR TITLE
Enable secure processing on all DocumentBuilderFactory.newInstance()

### DIFF
--- a/activemq-client/src/main/java/org/apache/activemq/filter/XPathExpression.java
+++ b/activemq-client/src/main/java/org/apache/activemq/filter/XPathExpression.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Properties;
 
 import javax.jms.JMSException;
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -59,6 +60,7 @@ public final class XPathExpression implements BooleanExpression {
                 builderFactory.setIgnoringComments(true);
                 try {
                     // set some reasonable defaults
+                    builderFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, Boolean.TRUE);
                     builderFactory.setFeature("http://xml.org/sax/features/external-general-entities", false);
                     builderFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
                     builderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);

--- a/activemq-console/src/main/java/org/apache/activemq/console/command/CreateCommand.java
+++ b/activemq-console/src/main/java/org/apache/activemq/console/command/CreateCommand.java
@@ -20,6 +20,7 @@ import org.w3c.dom.Attr;
 import org.w3c.dom.Element;
 import org.xml.sax.SAXException;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -158,7 +159,10 @@ public class CreateCommand extends AbstractCommand {
         File dest = new File(targetBase, DEFAULT_TARGET_ACTIVEMQ_CONF);
         context.print("Copying from: " + src.getCanonicalPath() + "\n          to: " + dest.getCanonicalPath());
 
-        DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, Boolean.TRUE);
+        dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        DocumentBuilder builder = dbf.newDocumentBuilder();
         Element docElem = builder.parse(src).getDocumentElement();
 
         XPath xpath = XPathFactory.newInstance().newXPath();

--- a/activemq-runtime-config/src/main/java/org/apache/activemq/plugin/RuntimeConfigurationBroker.java
+++ b/activemq-runtime-config/src/main/java/org/apache/activemq/plugin/RuntimeConfigurationBroker.java
@@ -180,6 +180,9 @@ public class RuntimeConfigurationBroker extends AbstractRuntimeConfigurationBrok
                 // skip beans and pull out the broker node to validate
                 DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
                 dbf.setNamespaceAware(true);
+                dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, Boolean.TRUE);
+                dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+
                 DocumentBuilder db = dbf.newDocumentBuilder();
                 Document doc = db.parse(configToMonitor.getInputStream());
                 Node brokerRootNode = doc.getElementsByTagNameNS("*","broker").item(0);


### PR DESCRIPTION
Good security practices say that all DocumentBuilderFactory instances should enable the secure processing feature and disable doctypes to avoid XXE attacks.