### PR TITLE
Set the secure processing feature on the TransformerFactory

### DIFF
--- a/activemq-console/src/main/java/org/apache/activemq/console/command/CreateCommand.java
+++ b/activemq-console/src/main/java/org/apache/activemq/console/command/CreateCommand.java
@@ -209,6 +209,8 @@ public class CreateCommand extends AbstractCommand {
     // utlity method to write an xml source to file
     private void writeToFile(Source src, File file) throws TransformerException {
         TransformerFactory tFactory = TransformerFactory.newInstance();
+        tFactory.setFeature(javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING, Boolean.TRUE);
+
         Transformer fileTransformer = tFactory.newTransformer();
 
         Result res = new StreamResult(file);


### PR DESCRIPTION
It's good security practice to set the secure processing feature on TransformerFactory instances (as well).