### PR TITLE
Disable directory listing for the webconsole

### DIFF
--- a/activemq-web-console/src/main/webapp/WEB-INF/web.xml
+++ b/activemq-web-console/src/main/webapp/WEB-INF/web.xml
@@ -157,5 +157,10 @@
   <session-config>
   	<session-timeout>30</session-timeout>
   </session-config>
+
+  <context-param>
+    <param-name>org.eclipse.jetty.servlet.Default.dirAllowed</param-name>
+    <param-value>false</param-value>
+  </context-param>
   
 </web-app>


### PR DESCRIPTION
We should disable directory listing for the web console, as a good security practise.