### PR TITLE
Enable X-XSS-Protection + X-Content-Type-Options headers for the webc…

### DIFF
--- a/assembly/src/release/conf/jetty.xml
+++ b/assembly/src/release/conf/jetty.xml
@@ -54,6 +54,16 @@
                   <property name="name" value="X-FRAME-OPTIONS"/>
                   <property name="value" value="SAMEORIGIN"/>
                 </bean>
+                <bean id="header" class="org.eclipse.jetty.rewrite.handler.HeaderPatternRule">
+                  <property name="pattern" value="*"/>
+                  <property name="name" value="X-XSS-Protection"/>
+                  <property name="value" value="1; mode=block"/>
+                </bean>
+                <bean id="header" class="org.eclipse.jetty.rewrite.handler.HeaderPatternRule">
+                  <property name="pattern" value="*"/>
+                  <property name="name" value="X-Content-Type-Options"/>
+                  <property name="value" value="nosniff"/>
+                </bean>
             </list>
         </property>
     </bean>


### PR DESCRIPTION
…onsole.

It's good security practice to set these two headers to make XSS attacks and content sniffing attacks harder.