### PR TITLE
AMQ-7163 - If the broker had an unclean shutdown and number of free p…

### DIFF
--- a/activemq-kahadb-store/src/main/java/org/apache/activemq/store/kahadb/disk/page/PageFile.java
+++ b/activemq-kahadb-store/src/main/java/org/apache/activemq/store/kahadb/disk/page/PageFile.java
@@ -485,6 +485,9 @@ public class PageFile {
 
             // allow flush (with index lock held) to merge eventually
             recoveredFreeList.lazySet(newFreePages);
+        } else {
+            // If there is no free pages, set trackingFreeDuringRecovery to allow the broker to have a clean shutdown
+            trackingFreeDuringRecovery.set(null);
         }
     }
 
@@ -556,6 +559,10 @@ public class PageFile {
 
     public boolean isLoaded() {
         return loaded.get();
+    }
+
+    public boolean isCleanShutdown() {
+        return metaData != null && metaData.isCleanShutdown();
     }
 
     public void allowIOResumption() {


### PR DESCRIPTION
…ages is Zero after the recovery, the next shutdown will also be 'unclean'