### PR TITLE
ActiveMQMessageConsumer - do not log whole message including headers in WARN

### DIFF
--- a/activemq-client/src/main/java/org/apache/activemq/ActiveMQMessageConsumer.java
+++ b/activemq-client/src/main/java/org/apache/activemq/ActiveMQMessageConsumer.java
@@ -1457,7 +1457,7 @@ public class ActiveMQMessageConsumer implements MessageAvailableConsumer, StatsC
                             session.getConnection().rollbackDuplicate(this, md.getMessage());
                             dispatch(md);
                         } else {
-                            LOG.warn("{} suppressing duplicate delivery on connection, poison acking: {}", getConsumerId(), md);
+                            LOG.warn("{} suppressing duplicate delivery on connection, poison acking: {}", getConsumerId(), md.getMessage());
                             posionAck(md, "Suppressing duplicate delivery on connection, consumer " + getConsumerId());
                         }
                     }


### PR DESCRIPTION
Message can contain large number of headers, logging them in warning drastically increases log size. 