### PR TITLE
[AMQ-7199] Replace Math.Random with Random.nextDouble

### DIFF
--- a/assembly/src/release/examples/openwire/ecommerce/src/Retailer.java
+++ b/assembly/src/release/examples/openwire/ecommerce/src/Retailer.java
@@ -24,6 +24,7 @@ import javax.jms.MessageProducer;
 import javax.jms.Session;
 import javax.jms.TemporaryQueue;
 
+import java.util.Random;
 /**
  * The Retailer orders computers from the Vendor by sending a message via
  * the VendorOrderQueue. It then syncronously receives the reponse message
@@ -58,7 +59,8 @@ public class Retailer implements Runnable {
 			for (int i = 0; i < 5; i++) {
 				MapMessage message = session.createMapMessage();
 				message.setString("Item", "Computer(s)");
-				int quantity = (int)(Math.random() * 4) + 1;
+				Random rand = new Random();
+				int quantity = (int)(rand.nextDouble() * 4) + 1;
 				message.setInt("Quantity", quantity);
 				message.setJMSReplyTo(retailerConfirmQueue);
 				producer.send(message);


### PR DESCRIPTION
[AMQ-7199](https://issues.apache.org/jira/browse/AMQ-7199) For better control over randomness and comparatively less performance overhead, Random.nextDouble can be used instead of Math.random. Such a sample instance is showed in the attached commit. 