### PR TITLE
AMQ-6949: SocketTimeoutException when using HTTP transport connector

### DIFF
--- a/activemq-http/src/main/java/org/apache/activemq/transport/http/HttpClientTransport.java
+++ b/activemq-http/src/main/java/org/apache/activemq/transport/http/HttpClientTransport.java
@@ -72,7 +72,7 @@ import org.slf4j.LoggerFactory;
  */
 public class HttpClientTransport extends HttpTransportSupport {
 
-    public static final int MAX_CLIENT_TIMEOUT = 30000;
+    public static final int MAX_CLIENT_TIMEOUT = 90000;
     private static final Logger LOG = LoggerFactory.getLogger(HttpClientTransport.class);
     private static final IdGenerator CLIENT_ID_GENERATOR = new IdGenerator();
 


### PR DESCRIPTION
I reported and fixed AMQ-6949 roughly a year ago and have been running my fix without any issues ever since.
