### PR TITLE
AMQ-7149 Remove dependency activemq-http and activemq-stomp

### DIFF
--- a/activemq-client/pom.xml
+++ b/activemq-client/pom.xml
@@ -71,6 +71,12 @@
       <optional>true</optional>
     </dependency>
 
+    <dependency>
+      <groupId>com.thoughtworks.xstream</groupId>
+      <artifactId>xstream</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
     <!-- =============================== -->
     <!-- Testing Dependencies -->
     <!-- =============================== -->

--- a/activemq-client/src/main/java/org/apache/activemq/util/XStreamSupport.java
+++ b/activemq-client/src/main/java/org/apache/activemq/util/XStreamSupport.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.activemq.transport.stomp;
+package org.apache.activemq.util;
 
 import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.security.AnyTypePermission;

--- a/activemq-http/pom.xml
+++ b/activemq-http/pom.xml
@@ -46,6 +46,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>activemq-stomp</artifactId>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/activemq-http/src/main/java/org/apache/activemq/transport/xstream/XStreamWireFormat.java
+++ b/activemq-http/src/main/java/org/apache/activemq/transport/xstream/XStreamWireFormat.java
@@ -25,13 +25,12 @@ import com.thoughtworks.xstream.converters.UnmarshallingContext;
 import com.thoughtworks.xstream.io.HierarchicalStreamReader;
 import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
 
-import org.apache.activemq.command.ConsumerInfo;
 import org.apache.activemq.command.MarshallAware;
 import org.apache.activemq.command.MessageDispatch;
 import org.apache.activemq.command.TransientInitializer;
-import org.apache.activemq.transport.stomp.XStreamSupport;
 import org.apache.activemq.transport.util.TextWireFormat;
 import org.apache.activemq.util.ByteSequence;
+import org.apache.activemq.util.XStreamSupport;
 import org.apache.activemq.wireformat.WireFormat;
 
 import com.thoughtworks.xstream.XStream;

--- a/activemq-stomp/src/main/java/org/apache/activemq/transport/stomp/JmsFrameTranslator.java
+++ b/activemq-stomp/src/main/java/org/apache/activemq/transport/stomp/JmsFrameTranslator.java
@@ -39,6 +39,7 @@ import org.apache.activemq.command.DataStructure;
 import org.apache.activemq.transport.stomp.Stomp.Headers;
 import org.apache.activemq.transport.stomp.Stomp.Responses;
 import org.apache.activemq.transport.stomp.Stomp.Transformations;
+import org.apache.activemq.util.XStreamSupport;
 import org.codehaus.jettison.mapped.Configuration;
 import org.fusesource.hawtbuf.UTF8Buffer;
 

--- a/activemq-stomp/src/test/java/org/apache/activemq/transport/stomp/util/XStreamBrokerContext.java
+++ b/activemq-stomp/src/test/java/org/apache/activemq/transport/stomp/util/XStreamBrokerContext.java
@@ -23,7 +23,7 @@ import org.apache.activemq.broker.BrokerContext;
 import org.apache.activemq.transport.stomp.SamplePojo;
 
 import com.thoughtworks.xstream.XStream;
-import org.apache.activemq.transport.stomp.XStreamSupport;
+import org.apache.activemq.util.XStreamSupport;
 
 public class XStreamBrokerContext implements BrokerContext {
 


### PR DESCRIPTION
This PR moves `XStreamSupport` to `activemq-client`. 

Currently this sits in `activemq-stomp`, thus requiring the ActiveMQ HTTP client to require `activemq-stomp` module on its class path, even if the client isn't using stomp.