### PR TITLE
Make ActiveMQConfiguration.loadClass private

### DIFF
--- a/activemq-camel/src/main/java/org/apache/activemq/camel/component/ActiveMQConfiguration.java
+++ b/activemq-camel/src/main/java/org/apache/activemq/camel/component/ActiveMQConfiguration.java
@@ -182,7 +182,7 @@ public class ActiveMQConfiguration extends JmsConfiguration {
         }
     }
 
-    public static Class<?> loadClass(String name, ClassLoader loader) throws ClassNotFoundException {
+    private static Class<?> loadClass(String name, ClassLoader loader) throws ClassNotFoundException {
         ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
         if (contextClassLoader != null) {
             try {


### PR DESCRIPTION
This is a trivial PR to make some class loading functionality private to ActiveMQConfiguration, as it's not used anywhere else.