### PR TITLE
Remove default "secret" password from the LDAPAuthorizationMap

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/security/LDAPAuthorizationMap.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/security/LDAPAuthorizationMap.java
@@ -102,7 +102,6 @@ public class LDAPAuthorizationMap implements AuthorizationMap {
         initialContextFactory = "com.sun.jndi.ldap.LdapCtxFactory";
         connectionURL = "ldap://localhost:10389";
         connectionUsername = "uid=admin,ou=system";
-        connectionPassword = "secret";
         connectionProtocol = "s";
         authentication = "simple";
 

--- a/activemq-broker/src/main/java/org/apache/activemq/security/SimpleCachedLDAPAuthorizationMap.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/security/SimpleCachedLDAPAuthorizationMap.java
@@ -64,7 +64,7 @@ public class SimpleCachedLDAPAuthorizationMap implements AuthorizationMap {
     private final String initialContextFactory = "com.sun.jndi.ldap.LdapCtxFactory";
     private String connectionURL = "ldap://localhost:1024";
     private String connectionUsername = "uid=admin,ou=system";
-    private String connectionPassword = "secret";
+    private String connectionPassword;
     private String connectionProtocol = "s";
     private String authentication = "simple";
 

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/security/CachedLDAPAuthorizationModuleLegacyTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/security/CachedLDAPAuthorizationModuleLegacyTest.java
@@ -41,6 +41,7 @@ public class CachedLDAPAuthorizationModuleLegacyTest extends AbstractCachedLDAPA
     protected SimpleCachedLDAPAuthorizationMap createMap() {
         SimpleCachedLDAPAuthorizationMap map = super.createMap();
         map.setConnectionURL("ldap://localhost:" + getLdapServer().getPort());
+        map.setConnectionPassword("secret");
         return map;
     }
     

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/security/CachedLDAPAuthorizationModuleTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/security/CachedLDAPAuthorizationModuleTest.java
@@ -39,6 +39,7 @@ public class CachedLDAPAuthorizationModuleTest extends AbstractCachedLDAPAuthori
     protected SimpleCachedLDAPAuthorizationMap createMap() {
         SimpleCachedLDAPAuthorizationMap map = super.createMap();
         map.setConnectionURL("ldap://localhost:" + getLdapServer().getPort());
+        map.setConnectionPassword("secret");
         return map;
     }
     

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/security/LDAPAuthorizationMapTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/security/LDAPAuthorizationMapTest.java
@@ -65,6 +65,7 @@ public class LDAPAuthorizationMapTest extends AbstractLdapTestUnit {
         authMap.setQueueSearchMatchingFormat(new MessageFormat("uid={0},ou=queues,ou=destinations,o=ActiveMQ,ou=system"));
         authMap.setAdvisorySearchBase("uid=ActiveMQ.Advisory,ou=topics,ou=destinations,o=ActiveMQ,ou=system");
         authMap.setTempSearchBase("uid=ActiveMQ.Temp,ou=topics,ou=destinations,o=ActiveMQ,ou=system");
+        authMap.setConnectionPassword("secret");
     }
 
     @Test

--- a/activemq-unit-tests/src/test/resources/org/apache/activemq/security/activemq-apacheds-legacy.xml
+++ b/activemq-unit-tests/src/test/resources/org/apache/activemq/security/activemq-apacheds-legacy.xml
@@ -39,7 +39,7 @@
 
           <authorizationPlugin>
               <map>
-                <cachedLDAPAuthorizationMap connectionURL="ldap://localhost:${ldapPort}"/>
+                <cachedLDAPAuthorizationMap connectionURL="ldap://localhost:${ldapPort}" connectionPassword="secret" />
               </map>
           </authorizationPlugin>
       </plugins>

--- a/activemq-unit-tests/src/test/resources/org/apache/activemq/security/activemq-apacheds.xml
+++ b/activemq-unit-tests/src/test/resources/org/apache/activemq/security/activemq-apacheds.xml
@@ -39,7 +39,7 @@
 
           <authorizationPlugin>
               <map>
-                <cachedLDAPAuthorizationMap legacyGroupMapping="false" connectionURL="ldap://localhost:${ldapPort}" groupClass="org.apache.activemq.jaas.GroupPrincipal"/>
+                <cachedLDAPAuthorizationMap legacyGroupMapping="false" connectionURL="ldap://localhost:${ldapPort}" groupClass="org.apache.activemq.jaas.GroupPrincipal" connectionPassword="secret" />
               </map>
           </authorizationPlugin>
       </plugins>


### PR DESCRIPTION
It's not good security practice to use default passwords.