### PR TITLE
AMQ-7266 - Update Jackson databind to 2.9.9.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
     <httpcore-version>4.4.11</httpcore-version>
     <insight-version>1.2.0.Beta4</insight-version>
     <jackson-version>2.9.9</jackson-version>
-    <jackson-databind-version>2.9.9.1</jackson-databind-version>
+    <jackson-databind-version>2.9.9.3</jackson-databind-version>
     <jasypt-version>1.9.2</jasypt-version>
     <jaxb-bundle-version>2.2.11_1</jaxb-bundle-version>
     <jetty9-version>9.2.26.v20180806</jetty9-version>


### PR DESCRIPTION
We should update Jackson databind to 2.9.9.3. Two new CVEs are issued for 2.9.9.2 (and a bug fix in 2.9.9.3):

https://www.cvedetails.com/cve/CVE-2019-14379

https://www.cvedetails.com/cve/CVE-2019-14439