### PR TITLE
maven-compiler-plugin 3.8.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,7 @@
     <maven-release-plugin-version>2.4.1</maven-release-plugin-version>
     <maven-eclipse-plugin-version>2.10</maven-eclipse-plugin-version>
     <maven-war-plugin-version>2.4</maven-war-plugin-version>
-    <maven-compiler-plugin-version>3.3</maven-compiler-plugin-version>
+    <maven-compiler-plugin-version>3.8.1</maven-compiler-plugin-version>
     <maven-jar-plugin-version>2.4</maven-jar-plugin-version>
     <maven-archiver-version>2.5</maven-archiver-version>
     <maven-source-plugin-version>2.2.1</maven-source-plugin-version>


### PR DESCRIPTION
Release notes about version 3.8.1:
https://blogs.apache.org/maven/entry/apache-maven-compiler-plugin-version1

Release notes about version 3.8.0:
https://blogs.apache.org/maven/entry/apache-maven-compiler-plugin-version
