### PR TITLE
Improve activemq init JAVACMD auto detection

### DIFF
--- a/assembly/src/release/bin/activemq
+++ b/assembly/src/release/bin/activemq
@@ -245,7 +245,7 @@ if [ -z "$JAVACMD" ] || [ "$JAVACMD" = "auto" ] ; then
 fi
 
 # Hm, we still do not know the location of the java binary
-if [ ! -x "$JAVACMD" ] ; then
+if [ -z "$JAVACMD" ] || [ "$JAVACMD" = "auto" ] || [ ! -x "$JAVACMD" ] ; then
     JAVACMD=`which java 2> /dev/null `
     if [ -z "$JAVACMD" ] ; then
         JAVACMD=java


### PR DESCRIPTION
If `JAVACMD` is set to `auto` (the default from the `env` file) and the current working directory contains a directory named `auto` (and the `auto` directory is executable, which directories normally are), the `activemq` init script will incorrectly detect the `auto` directory as the `java` binary thus leaving `JAVACMD` set to `auto` which is incorrect and will fail to execute the Java VM.

To fix this, in the second attempt to detect the `java` binary, repeat the tests for a zero-length `JAVACMD` or a `JAVACMD` equal to `auto` before testing whether `JAVACMD` does not exist or is not executable.  This is necessary because when the length of `JAVA_HOME` is zero, the first attempt to detect the location of the `java` binary will not set `JAVACMD` (so it will still be `auto` when it reaches the second auto-detection attempt, and since the `auto` directory is executable, the `[ ! -x "$JAVACMD" ]` test will evaluate to false).

A real-world example is running the `activemq` init script as a `systemd` service where the current working directory for the `activemq` init script ends up being the root of the file system (i.e., `/`) and an NFS automounter is being used such that `/auto` exists and is a directory (and is executable).

To reproduce the problem from a Bourne-style shell:

```
$ unset JAVA_HOME
$ which java
/usr/bin/java
$ cd /tmp
$ mkdir activemq-javacmd-auto-test
$ cd activemq-javacmd-auto-test
$ mkdir auto
$ export ACTIVEMQ_HOME=/tmp/activemq-javacmd-auto-test
$ /usr/local/bin/activemq start | grep 'INFO: Using java'
INFO: Using java 'auto'
```

The expected result is that the `INFO` line says:

```
INFO: Using java '/usr/bin/java'
```