### PR TITLE
AMQ-7312 virtualSelectorCacheBrokerPlugin addConsumer issue

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/plugin/SubQueueSelectorCacheBroker.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/plugin/SubQueueSelectorCacheBroker.java
@@ -131,8 +131,10 @@ public class SubQueueSelectorCacheBroker extends BrokerFilter implements Runnabl
 
     @Override
     public Subscription addConsumer(ConnectionContext context, ConsumerInfo info) throws Exception {
-        // don't track selectors for advisory topics or temp destinations
-        if (!AdvisorySupport.isAdvisoryTopic(info.getDestination()) && !info.getDestination().isTemporary()) {
+		// don't track selectors for advisory topics, temp destinations or console
+		// related consumers
+		if (!AdvisorySupport.isAdvisoryTopic(info.getDestination()) && !info.getDestination().isTemporary()
+				&& !info.isBrowser()) {
             String destinationName = info.getDestination().getQualifiedName();
             LOG.debug("Caching consumer selector [{}] on  '{}'", info.getSelector(), destinationName);
 


### PR DESCRIPTION
See details on https://issues.apache.org/jira/browse/AMQ-7312

On "browse" action in AMQ console, a consumer is added on related queue.
When virtualSelectorCacheBrokerPlugin is activated, "addConsumer" method add a 'TRUE' selector on that queue that disable previous cached selector.

Could you please merge that PR on next release ?