### PR TITLE
Remove unused import of "time"

### DIFF
--- a/assembly/src/release/examples/stomp/python/stomppy/publisher.py
+++ b/assembly/src/release/examples/stomp/python/stomppy/publisher.py
@@ -6,17 +6,15 @@
 # The ASF licenses this file to You under the Apache License, Version 2.0
 # (the "License"); you may not use this file except in compliance with
 # the License.  You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ------------------------------------------------------------------------
- 
-import time
 import sys
 import os
 import stomp
@@ -37,7 +35,7 @@ conn.connect(login=user,passcode=password)
 
 for i in range(0, messages):
   conn.send(data, destination=destination, persistent='false')
-  
+
 conn.send("SHUTDOWN", destination=destination, persistent='false')
 
 conn.disconnect()

--- a/assembly/src/release/examples/stomp/python/stomppy/publisher.py
+++ b/assembly/src/release/examples/stomp/python/stomppy/publisher.py
@@ -33,8 +33,10 @@ conn = stomp.Connection(host_and_ports = [(host, port)])
 conn.start()
 conn.connect(login=user,passcode=password)
 
+
 for i in range(0, messages):
   conn.send(data, destination=destination, persistent='false')
+
 
 conn.send("SHUTDOWN", destination=destination, persistent='false')
 


### PR DESCRIPTION
Remove unused import to give readability and an easier code maintenance 

Signed-off-by: Lucca Scarano <lucca.scarano@hotmail.com>