### PR TITLE
AMQ-7130 Update AMQ doap

### DIFF
--- a/doap.rdf
+++ b/doap.rdf
@@ -25,7 +25,7 @@
 <!--
   =======================================================================
 
-   Copyright (c) 2006-2012 The Apache Software Foundation.  
+   Copyright (c) 2006-2019 The Apache Software Foundation.  
    All rights reserved.
 
   =======================================================================
@@ -34,13 +34,13 @@
     <created>2006-03-27</created>
     <license rdf:resource="http://usefulinc.com/doap/licenses/asl20" />
     <name>Apache ActiveMQ</name>
-    <homepage rdf:resource="http://activemq.apache.org/" />
-    <asfext:pmc rdf:resource="http://activemq.apache.org/" />
+    <homepage rdf:resource="https://activemq.apache.org/" />
+    <asfext:pmc rdf:resource="https://activemq.apache.org/" />
     <shortdesc>ActiveMQ is the most popular and powerful open source Message Broker.</shortdesc>
     <description>ActiveMQ is a fast and powerful Message Broker which supports many Cross Language Clients and Protocols and many advanced features while fully supporting JMS 1.1 and J2EE 1.4.</description>
-    <bug-database rdf:resource="http://issues.apache.org/activemq/browse/AMQ" />
-    <mailing-list rdf:resource="http://activemq.apache.org/mailing-lists.html" />
-    <download-page rdf:resource="http://activemq.apache.org/download.html" />
+    <bug-database rdf:resource="https://issues.apache.org/jira/browse/AMQ" />
+    <mailing-list rdf:resource="https://activemq.apache.org/contact/" />
+    <download-page rdf:resource="https://activemq.apache.org/download.html" />
 
     <programming-language>Java</programming-language>
     <programming-language>C</programming-language>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/AMQ-7130 is caused by the fact that our doap JIRA link is incorrect. Once this PR is merged then https://projects.apache.org/project.html?activemq will need to be updated to point to git instead of svn.