### PR TITLE
AMQ-7322 - Add HTTPOnly flag to the webconsole + REST API Cookies

### DIFF
--- a/activemq-web-console/src/main/webapp/WEB-INF/web.xml
+++ b/activemq-web-console/src/main/webapp/WEB-INF/web.xml
@@ -155,7 +155,10 @@
   </error-page>
   
   <session-config>
-  	<session-timeout>30</session-timeout>
+    <session-timeout>30</session-timeout>
+    <cookie-config>
+      <http-only>true</http-only>
+    </cookie-config>
   </session-config>
 
   <context-param>

--- a/assembly/src/release/webapps/api/WEB-INF/web.xml
+++ b/assembly/src/release/webapps/api/WEB-INF/web.xml
@@ -71,4 +71,10 @@
         <url-pattern>/jolokia/*</url-pattern>
     </servlet-mapping>
 
+    <session-config>
+        <cookie-config>
+            <http-only>true</http-only>
+        </cookie-config>
+    </session-config>
+
 </web-app>


### PR DESCRIPTION
We should add the HTTPOnly flag to the webconsole + REST API Cookies