### PR TITLE
AMQ-7291 initialize writing to body not needed to set property

### DIFF
--- a/activemq-client/src/main/java/org/apache/activemq/command/ActiveMQBytesMessage.java
+++ b/activemq-client/src/main/java/org/apache/activemq/command/ActiveMQBytesMessage.java
@@ -913,12 +913,6 @@ public class ActiveMQBytesMessage extends ActiveMQMessage implements BytesMessag
     }
 
     @Override
-    public void setObjectProperty(String name, Object value) throws JMSException {
-        initializeWriting();
-        super.setObjectProperty(name, value);
-    }
-
-    @Override
     public String toString() {
         return super.toString() + " ActiveMQBytesMessage{ " + "bytesOut = " + bytesOut + ", dataOut = " + dataOut + ", dataIn = " + dataIn + " }";
     }


### PR DESCRIPTION
Unable to write property when readOnlyProperties=false, but readOnlyBody=true