### PR TITLE
Bumped up much needed versions

### DIFF
--- a/activemq-amqp/src/main/java/org/apache/activemq/transport/amqp/AmqpSupport.java
+++ b/activemq-amqp/src/main/java/org/apache/activemq/transport/amqp/AmqpSupport.java
@@ -223,7 +223,7 @@ public class AmqpSupport {
      * @param destination
      *      The ActiveMQDestination whose capability is being requested.
      *
-     * @return a Symbol that matches the defined Capability value for the ActiveMQDestiantion.
+     * @return a Symbol that matches the defined Capability value for the ActiveMQDestination.
      */
     public static Symbol getDestinationTypeSymbol(ActiveMQDestination destination) {
         if (destination.isQueue()) {

--- a/activemq-karaf/pom.xml
+++ b/activemq-karaf/pom.xml
@@ -42,12 +42,18 @@
     <dependency>
       <groupId>org.ops4j.pax.logging</groupId>
       <artifactId>pax-logging-api</artifactId>
-      <version>1.8.3</version>
+      <version>${pax-logging-version}</version>
     </dependency>
     <dependency>
       <groupId>org.ops4j.pax.logging</groupId>
       <artifactId>pax-logging-service</artifactId>
-      <version>1.8.3</version>
+      <version>${pax-logging-version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>apache-log4j-extras</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/activemq-leveldb-store/pom.xml
+++ b/activemq-leveldb-store/pom.xml
@@ -77,6 +77,11 @@
       <artifactId>leveldbjni</artifactId>
       <version>${leveldbjni-version}</version>
     </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${guava-version}</version>
+    </dependency>
     
     <!-- Lets not include the JNI libs for now so that we can harden the pure java driver more -->
     <!--

--- a/activemq-partition/pom.xml
+++ b/activemq-partition/pom.xml
@@ -69,6 +69,12 @@
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper</artifactId>
       <version>${zookeeper-version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- For Optional Snappy Compression -->

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -100,6 +100,12 @@
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper</artifactId>
       <version>${zookeeper-version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/assembly/src/release/lib/activemq-rar.txt
+++ b/assembly/src/release/lib/activemq-rar.txt
@@ -17,4 +17,4 @@
 
 ActiveMQ RAR is no longer included in the distribution.
 
-Please download it separately from: http://repo1.maven.org/maven2/org/apache/activemq/activemq-rar/
+Please download it separately from: https://repo1.maven.org/maven2/org/apache/activemq/activemq-rar/

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
     <ecj.version>3.17.0</ecj.version>
     <ftpserver-version>1.1.1</ftpserver-version>
     <geronimo-version>1.0</geronimo-version>
-    <guava-version>28.0-jre</guava-version>
+    <guava-version>28.2-jre</guava-version>
     <hadoop-version>1.0.4</hadoop-version>
     <hawtbuf-version>1.11</hawtbuf-version>
     <hawtdispatch-version>1.22</hawtdispatch-version>
@@ -74,10 +74,10 @@
     <httpcore-version>4.4.13</httpcore-version>
     <insight-version>1.2.0.Beta4</insight-version>
     <jackson-version>2.9.10</jackson-version>
-    <jackson-databind-version>2.9.10.1</jackson-databind-version>
+    <jackson-databind-version>2.9.10.2</jackson-databind-version>
     <jasypt-version>1.9.3</jasypt-version>
     <jaxb-bundle-version>2.2.11_1</jaxb-bundle-version>
-    <jetty9-version>9.4.22.v20191022</jetty9-version>
+    <jetty9-version>9.4.26.v20200117</jetty9-version>
     <jetty-version>${jetty9-version}</jetty-version>
     <jmdns-version>3.4.1</jmdns-version>
     <tomcat-api-version>9.0.30</tomcat-api-version>
@@ -96,7 +96,7 @@
     <leveldbjni-version>1.8</leveldbjni-version>
     <log4j-version>1.2.17</log4j-version>
     <mockito-version>1.10.19</mockito-version>
-    <owasp-dependency-check-version>5.2.2</owasp-dependency-check-version>
+    <owasp-dependency-check-version>5.2.4</owasp-dependency-check-version>
     <powermock-version>1.6.5</powermock-version>
     <mqtt-client-version>1.15</mqtt-client-version>
     <openjpa-version>1.2.0</openjpa-version>
@@ -115,20 +115,17 @@
     <saxon-version>9.5.1-5</saxon-version>
     <saxon-bundle-version>9.5.1-5_1</saxon-bundle-version>
     <scala-plugin-version>3.1.0</scala-plugin-version>
-    <scala-version>2.11.0</scala-version>
+    <scala-version>2.11.12</scala-version>
     <shiro-version>1.5.0</shiro-version>
-    <scalatest-version>2.1.5</scalatest-version>
+    <scalatest-version>3.1.0</scalatest-version>
     <slf4j-version>1.7.25</slf4j-version>
     <snappy-version>1.1.2</snappy-version>
     <spring-version>4.3.26.RELEASE</spring-version>
-    <stax2-api-version>3.0.2</stax2-api-version>
     <taglibs-version>1.2.5</taglibs-version>
     <velocity-version>2.1</velocity-version>
-    <woodstox-core-asl-version>4.2.0</woodstox-core-asl-version>
     <xalan-version>2.7.2</xalan-version>
     <xmlbeans-version>2.6.0</xmlbeans-version>
     <xmlbeans-bundle-version>2.6.0_2</xmlbeans-bundle-version>
-    <xmlresolver-bundle-version>1.2_5</xmlresolver-bundle-version>
     <xpp3-version>1.1.4c</xpp3-version>
     <xstream-version>1.4.11.1</xstream-version>
     <xbean-version>4.16</xbean-version>
@@ -137,10 +134,8 @@
     <stompjms-version>1.19</stompjms-version>
 
     <pax-exam-version>4.13.1</pax-exam-version>
-    <paxexam-karaf-container-version>1.0.0</paxexam-karaf-container-version>
-    <pax-runner-version>1.8.6</pax-runner-version>
     <pax-url-version>2.6.2</pax-url-version>
-    <felix-configadmin-version>1.8.0</felix-configadmin-version>
+    <pax-logging-version>1.11.5</pax-logging-version>
     <felix-framework-version>5.0.1</felix-framework-version>
 
     <site-repo-url>scpexe://people.apache.org/www/activemq.apache.org/maven/</site-repo-url>


### PR DESCRIPTION
Bumped up versions of ops4j.pax.logging, google guava, jackson databind, jetty9, scala, owasp and removed unused version declarations, excluded unneeded io.netty and minor typo fixes.

![image](https://user-images.githubusercontent.com/30496180/74654003-5c6d1200-51af-11ea-92d0-174d5ea13074.png)

I ran all "smoke" tests and they ran just fine.