### PR TITLE
Fix issue where the registry lookup was a hardcoded name and didn't a…

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/broker/jmx/ManagementContext.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/jmx/ManagementContext.java
@@ -690,10 +690,17 @@ public class ManagementContext implements Service {
             super(port);
         }
 
-        @Override
+        private String getLookupName() {
+            if (getConnectorPath() == null || getConnectorPath().length() == 0) {
+                return LOOKUP_NAME;
+            }
 
+            return getConnectorPath().replaceAll("^/+", "").replaceAll("/+$", "");
+        }
+
+        @Override
         public Remote lookup(String s) throws RemoteException, NotBoundException {
-            return LOOKUP_NAME.equals(s) ? serverStub : null;
+            return getLookupName().equals(s) ? serverStub : null;
         }
 
         @Override

--- a/activemq-unit-tests/src/test/resources/org/apache/activemq/xbean/management-context-test-connector-path.xml
+++ b/activemq-unit-tests/src/test/resources/org/apache/activemq/xbean/management-context-test-connector-path.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+  
+  http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<!-- this file can only be parsed using the xbean-spring library -->
+<!-- START SNIPPET: xbean -->
+<beans 
+  xmlns="http://www.springframework.org/schema/beans" 
+  xmlns:amq="http://activemq.apache.org/schema/core"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+  http://activemq.apache.org/schema/core http://activemq.apache.org/schema/core/activemq-core.xsd">
+
+  <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer" />
+
+  <broker useJmx="true" xmlns="http://activemq.apache.org/schema/core">
+    <managementContext>
+      <managementContext createConnector="true" connectorPort="2011" jmxDomainName="test.domain" connectorPath="/activemq-jmx">
+          <property xmlns="http://www.springframework.org/schema/beans" name="environment">
+              <map xmlns="http://www.springframework.org/schema/beans">
+				<entry xmlns="http://www.springframework.org/schema/beans" key="jmx.remote.x.password.file" value="src/test/resources/jmx.password"/>
+				<entry xmlns="http://www.springframework.org/schema/beans" key="jmx.remote.x.access.file" value="src/test/resources/jmx.access"/>
+              </map>
+          </property>
+      </managementContext>
+    </managementContext>
+  </broker>
+
+</beans>
+<!-- END SNIPPET: xbean -->


### PR DESCRIPTION
…ccount for the connector path

The previous commit to ManagementContext to prevent rebinds on the RMI registry used a hardcoded lookup path, as opposed to considering the connectorPath attribute. This commit should fix that.