### PR TITLE
Remove unused activemq-leveldb test dependencies

### DIFF
--- a/activemq-leveldb-store/pom.xml
+++ b/activemq-leveldb-store/pom.xml
@@ -312,19 +312,7 @@
     <dependency>
       <groupId>commons-lang</groupId>
       <artifactId>commons-lang</artifactId>
-      <version>2.6</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>tomcat</groupId>
-      <artifactId>jasper-runtime</artifactId>
-      <version>5.5.12</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>tomcat</groupId>
-      <artifactId>jasper-compiler</artifactId>
-      <version>5.5.12</version>
+      <version>${commons-lang-version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Removing some old Tomcat dependencies. No JIRA created as it's just a change to test dependencies.