### PR TITLE
[AMQ-7347] Don't log error in case of topic subscription failure (use debug)

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/broker/region/TopicRegion.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/region/TopicRegion.java
@@ -369,7 +369,7 @@ public class TopicRegion extends AbstractRegion {
             answer.init();
             return answer;
         } catch (Exception e) {
-            LOG.error("Failed to create TopicSubscription ", e);
+            LOG.debug("Failed to create TopicSubscription ", e);
             JMSException jmsEx = new JMSException("Couldn't create TopicSubscription");
             jmsEx.setLinkedException(e);
             throw jmsEx;

--- a/activemq-stomp/src/main/java/org/apache/activemq/transport/stomp/ProtocolConverter.java
+++ b/activemq-stomp/src/main/java/org/apache/activemq/transport/stomp/ProtocolConverter.java
@@ -257,7 +257,11 @@ public class ProtocolConverter {
         if (command == null) {
             LOG.warn("Exception occurred while processing a command: {}", exception.toString());
         } else {
-            LOG.warn("Exception occurred processing: {} -> {}", safeGetAction(command), exception.toString());
+            if (exception instanceof JMSException) {
+                LOG.warn("Exception occurred for client {} ({}) processing: {} -> {} ({})", connectionInfo.getClientId(), connectionInfo.getClientIp(), safeGetAction(command), exception.toString(), ((JMSException) exception).getLinkedException().toString());
+            } else {
+                LOG.warn("Exception occurred for client {} ({}) processing: {} -> {}", connectionInfo.getClientId(), connectionInfo.getClientIp(), safeGetAction(command), exception.toString());
+            }
         }
 
         if (LOG.isDebugEnabled()) {


### PR DESCRIPTION
The error log message iss useless as the JMX exception is thrown and pollute the log. I'm using debug instead.