### PR TITLE
AMQ-7439: AbstractMQTTSocket#getProtocolConverter: Race condition in …

### DIFF
--- a/activemq-http/src/main/java/org/apache/activemq/transport/ws/AbstractMQTTSocket.java
+++ b/activemq-http/src/main/java/org/apache/activemq/transport/ws/AbstractMQTTSocket.java
@@ -144,8 +144,9 @@ public abstract class AbstractMQTTSocket extends TransportSupport implements MQT
         if (protocolConverter == null) {
             synchronized(this) {
                 if (protocolConverter == null) {
-                    protocolConverter = new MQTTProtocolConverter(this, brokerService);
-                    IntrospectionSupport.setProperties(protocolConverter, transportOptions);
+                    MQTTProtocolConverter newProtocolConverter = new MQTTProtocolConverter(this, brokerService);
+                    IntrospectionSupport.setProperties(newProtocolConverter, transportOptions);
+                    protocolConverter = newProtocolConverter;
                 }
             }
         }


### PR DESCRIPTION
…double-checked locking object initialization

`protocolConverter` may be visible to other threads before its properties are set.