### PR TITLE
Avoid potential overflow in int multiplication before it is converted…

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/broker/TransportStatusDetector.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/TransportStatusDetector.java
@@ -118,7 +118,7 @@ public class TransportStatusDetector implements Service, Runnable {
     public void stop() throws Exception {
         started.set(false);
         if (runner != null) {
-            runner.join(getSweepInterval() * 5);
+            runner.join(getSweepInterval() * 5L);
         }
     }
 }

--- a/activemq-client/src/main/java/org/apache/activemq/util/BitArrayBin.java
+++ b/activemq-client/src/main/java/org/apache/activemq/util/BitArrayBin.java
@@ -175,7 +175,7 @@ public class BitArrayBin implements Serializable {
                 last = list.get(lastBitArrayIndex);
                 if (last != null) {
                     result += last.length() -1;
-                    result += lastBitArrayIndex * BitArray.LONG_SIZE;
+                    result += lastBitArrayIndex * (long) BitArray.LONG_SIZE;
                     break;
                 }
             }

--- a/activemq-kahadb-store/src/main/java/org/apache/activemq/store/kahadb/disk/page/PageFile.java
+++ b/activemq-kahadb-store/src/main/java/org/apache/activemq/store/kahadb/disk/page/PageFile.java
@@ -1237,7 +1237,7 @@ public class PageFile {
     }
 
     private long recoveryFileSizeForPages(int pageCount) {
-        return RECOVERY_FILE_HEADER_SIZE + ((pageSize + 8) * pageCount);
+        return RECOVERY_FILE_HEADER_SIZE + ((pageSize + 8L) * pageCount);
     }
 
     private void releaseCheckpointWaiter() {

--- a/activemq-kahadb-store/src/main/java/org/apache/activemq/store/kahadb/disk/page/Transaction.java
+++ b/activemq-kahadb-store/src/main/java/org/apache/activemq/store/kahadb/disk/page/Transaction.java
@@ -726,7 +726,7 @@ public class Transaction implements Iterable<Page> {
         Long key = page.getPageId();
 
         // how much pages we have for this transaction
-        size = writes.size() * pageFile.getPageSize();
+        size = writes.size() * (long) pageFile.getPageSize();
 
         PageWrite write;
 

--- a/activemq-mqtt/src/main/java/org/apache/activemq/transport/mqtt/MQTTProtocolConverter.java
+++ b/activemq-mqtt/src/main/java/org/apache/activemq/transport/mqtt/MQTTProtocolConverter.java
@@ -694,7 +694,7 @@ public class MQTTProtocolConverter {
         // Client has sent a valid CONNECT frame, we can stop the connect checker.
         monitor.stopConnectChecker();
 
-        long keepAliveMS = keepAliveSeconds * 1000;
+        long keepAliveMS = keepAliveSeconds * 1000L;
 
         LOG.debug("MQTT Client {} requests heart beat of {} ms", getClientId(), keepAliveMS);
 

--- a/activemq-tooling/activemq-memtest-maven-plugin/src/main/java/org/apache/activemq/tool/JMSMemtest.java
+++ b/activemq-tooling/activemq-memtest-maven-plugin/src/main/java/org/apache/activemq/tool/JMSMemtest.java
@@ -95,7 +95,7 @@ public class JMSMemtest {
         reportName = settings.getProperty("reportName");
         destinationName = settings.getProperty("destinationName");
         reportDirectory = settings.getProperty("reportDirectory");
-        connectionInterval = connectionCheckpointSize * 1024;
+        connectionInterval = connectionCheckpointSize * 1024L;
     }
 
     public static void main(String[] args) {
@@ -171,7 +171,7 @@ public class JMSMemtest {
 
     protected boolean resetConnection(int counter) {
         if (connectionInterval > 0) {
-            long totalMsgSizeConsumed = counter * 1024;
+            long totalMsgSizeConsumed = counter * 1024L;
             if (connectionInterval < totalMsgSizeConsumed) {
                 return true;
             }


### PR DESCRIPTION
… to long.

Found by static code analysis: https://lgtm.com/projects/g/apache/activemq?mode=tree&ruleFocus=7900075

At least in some cases (did not check every case) this can not occur because of the range of the variables in use.

Not sure if it is worth merging this non the less. What do you think?