### PR TITLE
AMQ-7442 - Adding build support for JDK 11

### DIFF
--- a/activemq-broker/pom.xml
+++ b/activemq-broker/pom.xml
@@ -46,6 +46,10 @@
       <groupId>org.apache.activemq</groupId>
       <artifactId>activemq-openwire-legacy</artifactId>
     </dependency>
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+    </dependency>
 
     <!-- =============================== -->
     <!-- Optional Dependencies -->

--- a/activemq-broker/src/main/java/org/apache/activemq/filter/JAXPXPathEvaluator.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/filter/JAXPXPathEvaluator.java
@@ -16,10 +16,7 @@
  */
 package org.apache.activemq.filter;
 
-import org.apache.activemq.command.Message;
-import org.apache.activemq.util.ByteArrayInputStream;
-import org.w3c.dom.Document;
-import org.xml.sax.InputSource;
+import java.io.StringReader;
 
 import javax.jms.BytesMessage;
 import javax.jms.JMSException;
@@ -28,7 +25,11 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathFactory;
-import java.io.StringReader;
+
+import org.apache.activemq.command.Message;
+import org.apache.activemq.util.ByteArrayInputStream;
+import org.w3c.dom.Document;
+import org.xml.sax.InputSource;
 
 public class JAXPXPathEvaluator implements XPathExpression.XPathEvaluator {
 

--- a/activemq-cf/pom.xml
+++ b/activemq-cf/pom.xml
@@ -57,7 +57,6 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>3.2.0</version>
                 <configuration>
                     <instructions>
                     	<Export-Package>

--- a/activemq-client/src/main/java/org/apache/activemq/filter/DestinationMapEntry.java
+++ b/activemq-client/src/main/java/org/apache/activemq/filter/DestinationMapEntry.java
@@ -16,19 +16,24 @@
  */
 package org.apache.activemq.filter;
 
-import org.apache.activemq.command.*;
+import org.apache.activemq.command.ActiveMQDestination;
+import org.apache.activemq.command.ActiveMQQueue;
+import org.apache.activemq.command.ActiveMQTempQueue;
+import org.apache.activemq.command.ActiveMQTempTopic;
+import org.apache.activemq.command.ActiveMQTopic;
 
 /**
  * A base class for entry objects used to construct a destination based policy
  * map.
- * 
- * 
+ *
+ *
  * @org.apache.xbean.XBean
  */
 public abstract class DestinationMapEntry<T> implements Comparable<T> {
 
     protected ActiveMQDestination destination;
 
+    @Override
     public int compareTo(Object that) {
         if (that instanceof DestinationMapEntry) {
             DestinationMapEntry<?> thatEntry = (DestinationMapEntry<?>)that;
@@ -57,7 +62,7 @@ public abstract class DestinationMapEntry<T> implements Comparable<T> {
     public void setTempTopic(boolean flag){
         setDestination(new ActiveMQTempTopic(">"));
     }
-    
+
     public void setTempQueue(boolean flag){
         setDestination(new ActiveMQTempQueue(">"));
     }

--- a/activemq-jdbc-store/pom.xml
+++ b/activemq-jdbc-store/pom.xml
@@ -49,6 +49,11 @@
       <artifactId>activeio-core</artifactId>
       <optional>true</optional>
     </dependency>
+      
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+    </dependency>
 
     <!-- =============================== -->
     <!-- Testing Dependencies -->

--- a/activemq-leveldb-store/pom.xml
+++ b/activemq-leveldb-store/pom.xml
@@ -83,6 +83,11 @@
       <version>${guava-version}</version>
     </dependency>
     
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+    </dependency>
+    
     <!-- Lets not include the JNI libs for now so that we can harden the pure java driver more -->
     <!--
     <dependency>
@@ -371,6 +376,7 @@
           <scalaVersion>${scala-version}</scalaVersion>
           <args>
             <arg>-deprecation</arg>
+            <arg>-nobootcp</arg>
           </args>
           <compilerPlugins>
             <!-- <compilerPlugin>

--- a/activemq-leveldb-store/src/main/scala/org/apache/activemq/leveldb.scala
+++ b/activemq-leveldb-store/src/main/scala/org/apache/activemq/leveldb.scala
@@ -91,7 +91,7 @@ package object leveldb  {
 
     def uncompress(compressed: ByteBuffer, uncompressed: ByteBuffer): Int = {
       val input = if (compressed.hasArray) {
-        new Buffer(compressed.array, compressed.arrayOffset + compressed.position, compressed.remaining)
+        new Buffer(compressed.array, compressed.arrayOffset + compressed.position(), compressed.remaining)
       } else {
         val t = new Buffer(compressed.remaining)
         compressed.mark
@@ -101,7 +101,7 @@ package object leveldb  {
       }
 
       val output = if (uncompressed.hasArray) {
-        new Buffer(uncompressed.array, uncompressed.arrayOffset + uncompressed.position, uncompressed.capacity()-uncompressed.position)
+        new Buffer(uncompressed.array, uncompressed.arrayOffset + uncompressed.position(), uncompressed.capacity()-uncompressed.position())
       } else {
         new Buffer(uncompressed_length(input))
       }
@@ -109,9 +109,9 @@ package object leveldb  {
       output.length = uncompress(input, output)
 
       if (uncompressed.hasArray) {
-        uncompressed.limit(uncompressed.position + output.length)
+        uncompressed.limit(uncompressed.position() + output.length)
       } else {
-        val p = uncompressed.position
+        val p = uncompressed.position()
         uncompressed.limit(uncompressed.capacity)
         uncompressed.put(output.data, output.offset, output.length)
         uncompressed.flip.position(p)

--- a/activemq-leveldb-store/src/main/scala/org/apache/activemq/leveldb/util/FileSupport.scala
+++ b/activemq-leveldb-store/src/main/scala/org/apache/activemq/leveldb/util/FileSupport.scala
@@ -23,6 +23,7 @@ import org.apache.activemq.leveldb.LevelDBClient
 import org.fusesource.leveldbjni.internal.Util
 import org.apache.activemq.leveldb.util.ProcessSupport._
 import java.util.zip.CRC32
+import java.util.function.Consumer
 
 object FileSupport {
 
@@ -306,8 +307,10 @@ object ProcessSupport {
   def launch(p:ProcessBuilder, in:InputStream=null)(func: (Int, Array[Byte], Array[Byte]) => Unit):Unit = {
     val out = new ByteArrayOutputStream
     val err = new ByteArrayOutputStream
-    p.start(out, err, in).onExit { code=>
-      func(code, out.toByteArray, err.toByteArray)
+    val process = p.start(out, err, in)
+    LevelDBClient.THREAD_POOL {
+       process.waitFor
+   	   (process.exitValue, out.toByteArray, err.toByteArray)
     }
   }
 
@@ -319,5 +322,4 @@ object ProcessSupport {
     process.waitFor
     (process.exitValue, out.toByteArray, err.toByteArray)
   }
-
 }

--- a/activemq-openwire-generator/pom.xml
+++ b/activemq-openwire-generator/pom.xml
@@ -50,27 +50,6 @@
     </dependency>
   </dependencies>
 
-  <profiles>
-    <profile>
-      <id>default-tools.jar</id>
-      <activation>
-        <property>
-          <name>java.vendor</name>
-          <value>Oracle Corporation</value>
-        </property>
-      </activation>
-      <dependencies>
-        <dependency>
-          <groupId>com.sun</groupId>
-          <artifactId>tools</artifactId>
-          <version>1.5</version>
-          <scope>system</scope>
-          <systemPath>${java.home}/../lib/tools.jar</systemPath>
-        </dependency>
-      </dependencies>
-    </profile>
-  </profiles>
-
   <build>
     <plugins>
       <plugin>

--- a/activemq-runtime-config/pom.xml
+++ b/activemq-runtime-config/pom.xml
@@ -68,6 +68,10 @@
       <artifactId>spring-context</artifactId>
     </dependency>
     <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.jvnet.jaxb2_commons</groupId>
       <artifactId>jaxb2-basics-runtime</artifactId>
       <version>${jaxb-basics-version}</version>
@@ -102,7 +106,7 @@
       <plugin>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-xjc-plugin</artifactId>
-        <version>3.0.1</version>
+        <version>3.2.3</version>
         <executions>
           <execution>
             <id>compile-xsd</id>

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/store/jdbc/JDBCIOExceptionHandlerTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/store/jdbc/JDBCIOExceptionHandlerTest.java
@@ -16,51 +16,32 @@
  */
 package org.apache.activemq.store.jdbc;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.ObjectInputStream;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import java.io.PrintWriter;
-import java.net.Socket;
-import java.rmi.registry.Registry;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import javax.jms.Connection;
-import javax.management.*;
-import javax.management.loading.ClassLoaderRepository;
-import javax.management.remote.JMXConnectorServer;
-import javax.management.remote.JMXConnectorServerFactory;
-import javax.management.remote.JMXServiceURL;
 
-import com.sun.jndi.rmi.registry.RegistryContext;
-import com.sun.jndi.rmi.registry.RegistryContextFactory;
 import org.apache.activemq.ActiveMQConnectionFactory;
 import org.apache.activemq.broker.BrokerService;
 import org.apache.activemq.broker.ft.SyncCreateDataSource;
-import org.apache.activemq.broker.jmx.ManagementContext;
 import org.apache.activemq.bugs.embedded.ThreadExplorer;
 import org.apache.activemq.util.DefaultTestAppender;
-import org.apache.activemq.util.IOHelper;
 import org.apache.activemq.util.LeaseLockerIOExceptionHandler;
 import org.apache.activemq.util.Wait;
 import org.apache.derby.jdbc.EmbeddedDataSource;
 import org.apache.log4j.Level;
 import org.apache.log4j.spi.LoggingEvent;
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 /**
  * Test to see if the JDBCExceptionIOHandler will restart the transport connectors correctly after
@@ -228,6 +209,7 @@ public class JDBCIOExceptionHandlerTest {
         final AtomicReference<BrokerService> slave = new AtomicReference<BrokerService>();
 
         Thread slaveThread = new Thread() {
+            @Override
             public void run() {
                 try {
                     BrokerService broker = new BrokerService();
@@ -420,6 +402,7 @@ public class JDBCIOExceptionHandlerTest {
             }
         }
 
+        @Override
         public java.util.logging.Logger getParentLogger() throws SQLFeatureNotSupportedException {
             return null;
         }

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -536,6 +536,7 @@
               <descriptors>
                  <descriptor>src/main/descriptors/unix-bin.xml</descriptor>
               </descriptors>
+              <tarLongFileMode>posix</tarLongFileMode>
             </configuration>
           </execution>
           <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -114,8 +114,8 @@
     <rome-version>1.12.2</rome-version>
     <saxon-version>9.5.1-5</saxon-version>
     <saxon-bundle-version>9.5.1-5_1</saxon-bundle-version>
-    <scala-plugin-version>3.1.0</scala-plugin-version>
-    <scala-version>2.11.11</scala-version>
+    <scala-plugin-version>3.4.2</scala-plugin-version>
+    <scala-version>2.11.12</scala-version>
     <shiro-version>1.5.1</shiro-version>
     <scalatest-version>3.0.8</scalatest-version>
     <slf4j-version>1.7.25</slf4j-version>
@@ -147,15 +147,15 @@
     <!-- Maven Plugin Version for this Project -->
     <maven-bundle-plugin-version>2.3.7</maven-bundle-plugin-version>
     <maven-surefire-plugin-version>2.22.1</maven-surefire-plugin-version>
-    <maven-antrun-plugin-version>1.3</maven-antrun-plugin-version>
-    <maven-assembly-plugin-version>2.4</maven-assembly-plugin-version>
+    <maven-antrun-plugin-version>1.8</maven-antrun-plugin-version>
+    <maven-assembly-plugin-version>2.6</maven-assembly-plugin-version>
     <maven-release-plugin-version>2.4.1</maven-release-plugin-version>
     <maven-eclipse-plugin-version>2.10</maven-eclipse-plugin-version>
-    <maven-war-plugin-version>2.4</maven-war-plugin-version>
+    <maven-war-plugin-version>3.2.2</maven-war-plugin-version>
     <maven-compiler-plugin-version>3.8.1</maven-compiler-plugin-version>
-    <maven-jar-plugin-version>2.4</maven-jar-plugin-version>
+    <maven-jar-plugin-version>3.1.0</maven-jar-plugin-version>
     <maven-archiver-version>2.5</maven-archiver-version>
-    <maven-source-plugin-version>2.2.1</maven-source-plugin-version>
+    <maven-source-plugin-version>2.4</maven-source-plugin-version>
     <maven-javadoc-plugin-version>2.9.1</maven-javadoc-plugin-version>
     <maven-install-plugin-version>2.4</maven-install-plugin-version>
     <maven-shade-plugin-version>2.1</maven-shade-plugin-version>
@@ -171,6 +171,7 @@
     <maven-project-info-reports-plugin-version>2.7</maven-project-info-reports-plugin-version>
     <maven-graph-plugin-version>1.30</maven-graph-plugin-version>
     <maven-plugin-plugin-version>3.6.0</maven-plugin-plugin-version>
+    <maven-plugin-api-version>3.6.0</maven-plugin-api-version>
     <maven-core-version>3.6.1</maven-core-version>
     <!-- OSGi bundles properties -->
     <activemq.osgi.import.pkg>*</activemq.osgi.import.pkg>
@@ -1149,6 +1150,26 @@
         <groupId>org.apache.servicemix.bundles</groupId>
         <artifactId>org.apache.servicemix.bundles.josql</artifactId>
         <version>${josql-version}</version>
+      </dependency>
+      <dependency>
+        <groupId>javax.xml.bind</groupId>
+        <artifactId>jaxb-api</artifactId>
+        <version>2.2.12</version>
+      </dependency>
+      <dependency>
+        <groupId>com.sun.xml.bind</groupId>
+        <artifactId>jaxb-impl</artifactId>
+        <version>2.2.11</version>
+      </dependency>
+      <dependency>
+        <groupId>javax.annotation</groupId>
+        <artifactId>javax.annotation-api</artifactId>
+        <version>1.3.2</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven</groupId>
+        <artifactId>maven-plugin-api</artifactId>
+        <version>${maven-plugin-api-version}</version>
       </dependency>
 
     </dependencies>


### PR DESCRIPTION
This is the initial work to allow the broker to be compiled and build
with JDK 11 while keeping the source/target Java version at 8 so it
will also run on JDK 8+