### PR TITLE
Removing a deprecated dependency ant:ant:1.6.2

### DIFF
--- a/activemq-openwire-generator/pom.xml
+++ b/activemq-openwire-generator/pom.xml
@@ -43,11 +43,6 @@
       <groupId>annogen</groupId>
       <artifactId>annogen</artifactId>
     </dependency>
-    <dependency>
-      <groupId>ant</groupId>
-      <artifactId>ant</artifactId>
-      <version>1.6.2</version>
-    </dependency>
   </dependencies>
 
   <profiles>


### PR DESCRIPTION
- Removing `ant:ant:1.6.2` from `org.apache.activemq:activemq-openwire-generator` `pom.xml`

This fixes #AMQ-7448