### PR TITLE
AMQ-7489 - Update Tomcat to 9.0.35

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
     <jetty9-version>9.4.28.v20200408</jetty9-version>
     <jetty-version>${jetty9-version}</jetty-version>
     <jmdns-version>3.4.1</jmdns-version>
-    <tomcat-api-version>9.0.31</tomcat-api-version>
+    <tomcat-api-version>9.0.35</tomcat-api-version>
     <jettison-version>1.4.1</jettison-version>
     <jmock-version>2.5.1</jmock-version>
     <jolokia-version>1.6.2</jolokia-version>


### PR DESCRIPTION
We should update Tomcat to 9.0.35 due to CVE-2020-9484