### PR TITLE
Shebang in env

### DIFF
--- a/assembly/src/release/bin/env
+++ b/assembly/src/release/bin/env
@@ -1,4 +1,3 @@
-#!/bin/sh
 # ------------------------------------------------------------------------
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with


### PR DESCRIPTION
This patch removes the shebang from the env file. The file is – and
should always be – sourced and never be executed directly and should
thus not contain a shebang.

The file has also already no executable flag. Probably for the same
reason.