### PR TITLE
AMQ-8012 Fix ConcurrentModifictionException in SubQueueSelectorCacheBroker

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/broker/region/virtual/SelectorAwareVirtualTopicInterceptor.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/region/virtual/SelectorAwareVirtualTopicInterceptor.java
@@ -77,7 +77,7 @@ public class SelectorAwareVirtualTopicInterceptor extends VirtualTopicIntercepto
         LOG.debug("No active consumer match found. Will try cache if configured...");
 
         if (selectorCachePlugin != null) {
-            final Set<String> selectors = selectorCachePlugin.getSelector(dest.getActiveMQDestination().getQualifiedName());
+            final Set<String> selectors = selectorCachePlugin.getSelectorsForDestination(dest.getActiveMQDestination().getQualifiedName());
             if (selectors != null) {
                 for (String selector : selectors) {
                     try {

--- a/activemq-broker/src/main/java/org/apache/activemq/plugin/SubQueueSelectorCacheBroker.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/plugin/SubQueueSelectorCacheBroker.java
@@ -249,13 +249,6 @@ public class SubQueueSelectorCacheBroker extends BrokerFilter implements Runnabl
     }
 
     /**
-     * @return The JMS selector for the specified {@code destination}
-     */
-    public Set<String> getSelector(final String destination) {
-        return subSelectorCache.get(destination);
-    }
-
-    /**
      * Persist the selector cache every {@code MAX_PERSIST_INTERVAL}ms.
      *
      * @see java.lang.Runnable#run()


### PR DESCRIPTION
AMQ-8012

 - Remove non-thread-safe method getSelectors()
 - Update all references to use the thread-safe getSelectorsForDestination() method