### PR TITLE
Change ActiveMQTextMessage to become serializable

### DIFF
--- a/activemq-client/src/main/java/org/apache/activemq/command/ActiveMQTextMessage.java
+++ b/activemq-client/src/main/java/org/apache/activemq/command/ActiveMQTextMessage.java
@@ -43,7 +43,7 @@ import org.apache.activemq.wireformat.WireFormat;
  *
  */
 public class ActiveMQTextMessage extends ActiveMQMessage implements TextMessage, Serializable {
-
+    private static final long serialVersionUID = 6848565895011781106L;
     public static final byte DATA_STRUCTURE_TYPE = CommandTypes.ACTIVEMQ_TEXT_MESSAGE;
 
     protected String text;

--- a/activemq-client/src/main/java/org/apache/activemq/command/ActiveMQTextMessage.java
+++ b/activemq-client/src/main/java/org/apache/activemq/command/ActiveMQTextMessage.java
@@ -21,6 +21,7 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.zip.DeflaterOutputStream;
 import java.util.zip.InflaterInputStream;
@@ -41,7 +42,7 @@ import org.apache.activemq.wireformat.WireFormat;
  * @openwire:marshaller code="28"
  *
  */
-public class ActiveMQTextMessage extends ActiveMQMessage implements TextMessage {
+public class ActiveMQTextMessage extends ActiveMQMessage implements TextMessage, Serializable {
 
     public static final byte DATA_STRUCTURE_TYPE = CommandTypes.ACTIVEMQ_TEXT_MESSAGE;
 


### PR DESCRIPTION
There is a business use case which need to persist ActiveMQTextMessage (or TextMessage) into database. Required ActiveMQTextMessage to become serializable. 
TextMessage implementation by both IBM Websphere and Weblogic are serializable. 
https://www.ibm.com/support/knowledgecenter/en/SSFKSJ_7.5.0/com.ibm.mq.javadoc.doc/WMQJMSClasses/com/ibm/jms/JMSMessage.html
https://docs.oracle.com/middleware/12213/wls/WLAPI/weblogic/jms/common/TextMessageImpl.html