### PR TITLE
[AMQ-8104] Tests and fixes NullPointerException when pause queue if audit log is turned on

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/broker/jmx/AnnotatedMBean.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/jmx/AnnotatedMBean.java
@@ -202,6 +202,7 @@ public class AnnotatedMBean extends StandardMBean {
 
     @Override
     public Object invoke(String s, Object[] objects, String[] strings) throws MBeanException, ReflectionException {
+        objects = (objects == null) ? new Object[]{} : objects;
         JMXAuditLogEntry entry = null;
         if (audit != OFF) {
             Subject subject = Subject.getSubject(AccessController.getContext());

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/broker/jmx/MBeanWithAuditLogTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/broker/jmx/MBeanWithAuditLogTest.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.broker.jmx;
+
+
+/**
+ * A test case of the various MBeans in ActiveMQ with audit log turned on.
+ */
+public class MBeanWithAuditLogTest extends MBeanTest {
+
+    static final String requiredAuditValue = "all";
+    static final String auditKey = "org.apache.activemq.audit";
+    static final String initialAuditValue = System.getProperty("org.apache.activemq.audit");
+
+    @Override
+    protected void setUp() throws Exception {
+        System.setProperty(auditKey, requiredAuditValue);
+        super.setUp();
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        if (initialAuditValue == null) {
+            System.clearProperty(auditKey);
+        } else {
+            System.setProperty(auditKey, initialAuditValue);
+        }
+        super.tearDown();
+    }
+}


### PR DESCRIPTION
If audit log is turned on then Pause Queue doesn't work and causes `java.lang.NullPointerException`.

Steps to reproduce:
1. Start ActiveMQ normally with audit log turned on:
`./activemq start -Dorg.apache.activemq.audit=true`
2. Create a Queue normarlly: http://127.0.0.1:8161/admin/ > Queues > Enter Queue Name > Create 
3. Pause newly created queue: Click on `Pause`.

Extected result: Queue is paused normally.

Achieved result: 
- Error in web console:
	Error!
	Exception occurred while processing this request, check the log for more information!

- Error in the `activemq.log`:

```
2020-12-16 09:50:41,877 | INFO  | Starting Jetty server | org.apache.activemq.transport.WebTransportServerSupport | main
2020-12-16 09:50:41,992 | INFO  | Creating Jetty connector | org.apache.activemq.transport.WebTransportServerSupport | main
2020-12-16 09:50:42,124 | WARN  | ServletContext@o.e.j.s.ServletContextHandler@5e4bd84a{/,null,STARTING} has uncovered http methods for path: / | org.eclipse.jetty.security.SecurityHandler | main
2020-12-16 09:50:42,199 | INFO  | Listening for connections at ws://3c22fb843faa.ant.amazon.com:61614?maximumConnections=1000&wireFormat.maxFrameSize=104857600 | org.apache.activemq.transport.ws.WSTransportServer | main
2020-12-16 09:50:42,201 | INFO  | Connector ws started | org.apache.activemq.broker.TransportConnector | main
2020-12-16 09:50:42,203 | INFO  | Apache ActiveMQ 5.15.14 (localhost, ID:3c22fb843faa.ant.amazon.com-55549-1608141041704-0:1) started | org.apache.activemq.broker.BrokerService | main
2020-12-16 09:50:42,204 | INFO  | For help or more information please see: http://activemq.apache.org | org.apache.activemq.broker.BrokerService | main
2020-12-16 09:50:42,937 | INFO  | ActiveMQ WebConsole available at http://0.0.0.0:8161/ | org.apache.activemq.web.WebConsoleStarter | main
2020-12-16 09:50:42,938 | INFO  | ActiveMQ Jolokia REST API available at http://0.0.0.0:8161/api/jolokia/ | org.apache.activemq.web.WebConsoleStarter | main
2020-12-16 09:51:04,036 | WARN  | /admin/pauseDestination.action | org.eclipse.jetty.server.HttpChannel | qtp1803093683-37
javax.servlet.ServletException: javax.servlet.ServletException: org.springframework.web.util.NestedServletException: Request processing failed; nested exception is java.lang.NullPointerException
	at org.eclipse.jetty.server.handler.HandlerCollection.handle(HandlerCollection.java:162)[jetty-all-9.4.35.v20201120-uber.jar:9.4.35.v20201120]
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:127)[jetty-all-9.4.35.v20201120-uber.jar:9.4.35.v20201120]
	at org.eclipse.jetty.server.Server.handle(Server.java:516)[jetty-all-9.4.35.v20201120-uber.jar:9.4.35.v20201120]
	at org.eclipse.jetty.server.HttpChannel.lambda$handle$1(HttpChannel.java:388)[jetty-all-9.4.35.v20201120-uber.jar:9.4.35.v20201120]
	at org.eclipse.jetty.server.HttpChannel.dispatch(HttpChannel.java:633)[jetty-all-9.4.35.v20201120-uber.jar:9.4.35.v20201120]
	at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:380)[jetty-all-9.4.35.v20201120-uber.jar:9.4.35.v20201120]
	at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:273)[jetty-all-9.4.35.v20201120-uber.jar:9.4.35.v20201120]
	at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:311)[jetty-all-9.4.35.v20201120-uber.jar:9.4.35.v20201120]
	at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:105)[jetty-all-9.4.35.v20201120-uber.jar:9.4.35.v20201120]
	at org.eclipse.jetty.io.ChannelEndPoint$1.run(ChannelEndPoint.java:104)[jetty-all-9.4.35.v20201120-uber.jar:9.4.35.v20201120]
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.runTask(EatWhatYouKill.java:336)[jetty-all-9.4.35.v20201120-uber.jar:9.4.35.v20201120]
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:313)[jetty-all-9.4.35.v20201120-uber.jar:9.4.35.v20201120]
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.tryProduce(EatWhatYouKill.java:171)[jetty-all-9.4.35.v20201120-uber.jar:9.4.35.v20201120]
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.run(EatWhatYouKill.java:129)[jetty-all-9.4.35.v20201120-uber.jar:9.4.35.v20201120]
	at org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:375)[jetty-all-9.4.35.v20201120-uber.jar:9.4.35.v20201120]
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:773)[jetty-all-9.4.35.v20201120-uber.jar:9.4.35.v20201120]
	at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:905)[jetty-all-9.4.35.v20201120-uber.jar:9.4.35.v20201120]
	at java.lang.Thread.run(Thread.java:748)[:1.8.0_272]
```