### PR TITLE
AMQ-8116 ActiveMQWildcardPermission buggy

### DIFF
--- a/activemq-shiro/src/main/java/org/apache/activemq/shiro/authz/ActiveMQWildcardPermission.java
+++ b/activemq-shiro/src/main/java/org/apache/activemq/shiro/authz/ActiveMQWildcardPermission.java
@@ -59,18 +59,25 @@ public class ActiveMQWildcardPermission extends WildcardPermission {
             } else {
                 Set<String> thisPart = getParts().get(i);
 
-                for (String token : thisPart) {
-                    if (token.equals(WILDCARD_TOKEN)) {
-                        continue;
+                // all tokens from otherPart must pass at least one token from thisPart
+                for (String otherToken : otherPart) {
+                    if (!caseSensitive) {
+                        otherToken = otherToken.toLowerCase();
                     }
-                    for (String otherToken : otherPart) {
-                        if (!caseSensitive) {
-                            otherToken = otherToken.toLowerCase();
+                	boolean otherIsMatched = false;
+                	for (String token : thisPart) {
+                        if (token.equals(WILDCARD_TOKEN)) {
+                        	otherIsMatched = true;
+                        	break;
                         }
-                        if (!matches(token, otherToken)) {
-                            return false;
+                        if (matches(token, otherToken)) {
+                        	otherIsMatched = true;
+                        	break;
                         }
-                    }
+                	}
+                	if (!otherIsMatched) {
+                		return false;
+                	}
                 }
                 i++;
             }

--- a/activemq-shiro/src/test/java/org/apache/activemq/shiro/authz/ActiveMQWildcardPermissionTest.java
+++ b/activemq-shiro/src/test/java/org/apache/activemq/shiro/authz/ActiveMQWildcardPermissionTest.java
@@ -117,6 +117,10 @@ public class ActiveMQWildcardPermissionTest {
         assertNoMatch("*:ActiveMQ*", "topic:TEST:*");
         assertMatch("topic:ActiveMQ.Advisory*", "topic:ActiveMQ.Advisory.Connection:create");
         assertMatch("foo?ar", "foobar");
+        
+        assertMatch("queue:*:read,write", "queue:testqueue:read");
+        assertMatch("queue:*:read,write", "queue:test*:read,write");
+        assertNoMatch("queue:*:read,write", "queue:*:read,write,delete");
     }
 
     protected static void assertMatch(String pattern, String value) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/AMQ-8116
ActiveMQWildcardPermission with multiple tokens inconsistent with parent
WildcardPermission class

Update ActiveMQWildcardPermission.java

add testcase