### PR TITLE
[AMQ-8169] Do not unwrap in two threads concurrently

### DIFF
--- a/activemq-client/src/main/java/org/apache/activemq/transport/nio/NIOSSLTransport.java
+++ b/activemq-client/src/main/java/org/apache/activemq/transport/nio/NIOSSLTransport.java
@@ -200,17 +200,7 @@ public class NIOSSLTransport extends NIOTransport {
     final protected CountDownLatch initialized = new CountDownLatch(1);
 
     protected void doInit() throws Exception {
-        taskRunnerFactory.execute(new Runnable() {
-
-            @Override
-            public void run() {
-                //Need to start in new thread to let startup finish first
-                //We can trigger a read because we know the channel is ready since the SSL handshake
-                //already happened
-                serviceRead();
-                initialized.countDown();
-            }
-        });
+        initialized.countDown();
     }
 
     //Only used for the auto transport to abort the openwire init method early if already initialized


### PR DESCRIPTION
According to the [SSLEngine docs](https://docs.oracle.com/javase/8/docs/api/javax/net/ssl/SSLEngine.html) "two threads must not attempt to call the same method (either wrap() or unwrap()) concurrently, because there is no way to guarantee the eventual packet ordering". 

serviceRead(), the loop that calls unwrap(), was called in doInit() as well in initializeStreams() which intermittently leads to errors such as **javax.crypto.AEADBadTagException: Input too short - need tag** as described in the [associated Jira](https://issues.apache.org/jira/browse/AMQ-8169) as the two threads compete to unwrap network traffic. 
