### PR TITLE
AMQ-8048 ActiveMQ broker doesn't start with the error : Keystores with multiple certificates are not supported on the base class org.eclipse.jetty.util.ssl.SslContextFactory

### DIFF
--- a/assembly/src/release/examples/conf/jetty-demo.xml
+++ b/assembly/src/release/examples/conf/jetty-demo.xml
@@ -143,19 +143,19 @@
                     <property name="port" value="#{systemProperties['jetty.port']}" />
                 </bean>
                 <!--
-                    Enable this connector if you wish to use https with web console
+                    Enable this connector to use https with web console
                 -->
-                <!-- bean id="SecureConnector" class="org.eclipse.jetty.server.ServerConnector">
+                <bean id="SecureConnector" class="org.eclipse.jetty.server.ServerConnector">
 					<constructor-arg ref="Server" />
 					<constructor-arg>
-						<bean id="handlers" class="org.eclipse.jetty.util.ssl.SslContextFactory">
+						<bean id="handlers" class="org.eclipse.jetty.util.ssl.SslContextFactory$Server">
 						
 							<property name="keyStorePath" value="${activemq.conf}/broker.ks" />
 							<property name="keyStorePassword" value="password" />
 						</bean>
 					</constructor-arg>
 					<property name="port" value="8162" />
-				</bean -->
+				</bean>
             </list>
     	</property>
     </bean>

--- a/assembly/src/test/java/org/apache/activemq/config/BrokerXmlConfigStartTest.java
+++ b/assembly/src/test/java/org/apache/activemq/config/BrokerXmlConfigStartTest.java
@@ -20,10 +20,12 @@ import java.io.File;
 import java.io.FileFilter;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -142,10 +144,24 @@ public class BrokerXmlConfigStartTest {
         System.setProperty("activemq.conf", "target/conf");
         secProps = new Properties();
         secProps.load(new FileInputStream(new File("target/conf/credentials.properties")));
+        setEnv("ACTIVEMQ_ENCRYPTION_PASSWORD", "activemq");
     }
 
     @After
     public void tearDown() throws Exception {
         TimeUnit.SECONDS.sleep(1);
+    }
+
+    private void setEnv(String key, String value) {
+        try {
+            Map<String, String> env = System.getenv();
+            Class<?> cl = env.getClass();
+            Field field = cl.getDeclaredField("m");
+            field.setAccessible(true);
+            Map<String, String> writableEnv = (Map<String, String>) field.get(env);
+            writableEnv.put(key, value);
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to set environment variable", e);
+        }
     }
 }


### PR DESCRIPTION
Changes:
- broker doesn't start because Jetty 9.4.31.v20200723 deprecated SslContextFactory with SslContextFactory$Server, similar issue: https://issues.apache.org/jira/browse/CALCITE-4095
- replace replace SslContextFactory with SslContextFactory$Server in jetty-demo.xml
- uncommented SecureConnector part to allow unit tests in BrokerXmlConfigStartTest test this part of configuration and catch regressions
- fix test BrokerXmlConfigStartTest for activemq-security.xml