### PR TITLE
AMQ-8169: Synchronize on serviceRead inside NIOSSLTransport

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/transport/nio/AutoInitNioSSLTransport.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/transport/nio/AutoInitNioSSLTransport.java
@@ -158,8 +158,9 @@ public class AutoInitNioSSLTransport extends NIOSSLTransport {
         return readSize;
     }
 
+    //Prevent concurrent access to SSLEngine
     @Override
-    public void serviceRead() {
+    public synchronized void serviceRead() {
         try {
             if (handshakeInProgress) {
                 doHandshake();

--- a/activemq-client/src/main/java/org/apache/activemq/transport/nio/NIOSSLTransport.java
+++ b/activemq-client/src/main/java/org/apache/activemq/transport/nio/NIOSSLTransport.java
@@ -243,8 +243,9 @@ public class NIOSSLTransport extends NIOTransport {
         }
     }
 
+    //Prevent concurrent access to SSLEngine
     @Override
-    public void serviceRead() {
+    public synchronized void serviceRead() {
         try {
             if (handshakeInProgress) {
                 doHandshake();


### PR DESCRIPTION
This is needed to prevent concurrent access to the SSLEngine during
initialization. This is a regression from when auto+nio+ssl was added.