### PR TITLE
AMQ-8184 - Re-enable NIO tests

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/broker/TransportConnector.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/TransportConnector.java
@@ -266,7 +266,7 @@ public class TransportConnector implements Connector, BrokerServiceAware {
         LOG.info("Connector {} started", getName());
     }
 
-    static Throwable getRootCause(final Throwable throwable) {
+    public static Throwable getRootCause(final Throwable throwable) {
         final List<Throwable> list = getThrowableList(throwable);
         return list.isEmpty() ? null : list.get(list.size() - 1);
     }

--- a/activemq-broker/src/main/java/org/apache/activemq/transport/auto/nio/AutoNIOSSLTransportServer.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/transport/auto/nio/AutoNIOSSLTransportServer.java
@@ -15,6 +15,7 @@ import javax.net.ssl.SSLEngine;
 
 import org.apache.activemq.broker.BrokerService;
 import org.apache.activemq.broker.BrokerServiceAware;
+import org.apache.activemq.broker.TransportConnector;
 import org.apache.activemq.transport.Transport;
 import org.apache.activemq.transport.auto.AutoTcpTransportServer;
 import org.apache.activemq.transport.nio.AutoInitNioSSLTransport;
@@ -25,6 +26,8 @@ import org.apache.activemq.transport.tcp.TcpTransportFactory;
 import org.apache.activemq.transport.tcp.TcpTransportServer;
 import org.apache.activemq.util.IntrospectionSupport;
 import org.apache.activemq.wireformat.WireFormat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -44,6 +47,7 @@ import org.apache.activemq.wireformat.WireFormat;
  */
 public class AutoNIOSSLTransportServer extends AutoTcpTransportServer {
 
+    private static final Logger LOG = LoggerFactory.getLogger(AutoNIOSSLTransportServer.class);
     private SSLContext context;
 
     public AutoNIOSSLTransportServer(SSLContext context, TcpTransportFactory transportFactory, URI location, ServerSocketFactory serverSocketFactory,
@@ -118,8 +122,11 @@ public class AutoNIOSSLTransportServer extends AutoTcpTransportServer {
             public void run() {
                 try {
                     in.start();
-                } catch (Exception e) {
-                    throw new IllegalStateException("Could not complete Transport start", e);
+                } catch (Exception error) {
+                    LOG.warn("Could not accept connection {}: {} ({})",
+                            (in.getRemoteAddress() == null ? "" : "from " + in.getRemoteAddress()), error.getMessage(),
+                            TransportConnector.getRootCause(error).getMessage());
+                    throw new IllegalStateException("Could not complete Transport start", error);
                 }
 
                 int attempts = 0;

--- a/activemq-unit-tests/pom.xml
+++ b/activemq-unit-tests/pom.xml
@@ -654,8 +654,6 @@
                 <exclude>**/SSHTunnelNetworkReconnectTest.*</exclude>
                 <!-- http://issues.apache.org/activemq/browse/AMQ-1027 -->
                 <exclude>**/FailoverConsumerTest.*</exclude>
-                <!-- The NIO implemenation is not working properly on OS X.. -->
-                <exclude>**/nio/**</exclude>
                 <exclude>**/NioQueueSubscriptionTest.*/</exclude>
                 <!-- A test used for memory profiling only. -->
                 <exclude>**/NetworkConnectionsCleanedupTest.*/**</exclude>

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/transport/nio/NIOSSLBasicTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/transport/nio/NIOSSLBasicTest.java
@@ -117,7 +117,7 @@ public class NIOSSLBasicTest {
         final DefaultTestAppender appender = new DefaultTestAppender() {
             @Override
             public void doAppend(LoggingEvent event) {
-                if (event.getLevel().equals(Level.ERROR) && event.getRenderedMessage().contains("Could not accept connection")) {
+                if (event.getLevel().equals(Level.WARN) && event.getRenderedMessage().contains("Could not accept connection")) {
                     gotLogMessage.countDown();
                     if (event.getRenderedMessage().contains("tcp")) {
                         // got remote address

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/transport/nio/NIOSSLConcurrencyTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/transport/nio/NIOSSLConcurrencyTest.java
@@ -70,7 +70,7 @@ public class NIOSSLConcurrencyTest extends TestCase {
         broker = new BrokerService();
         broker.setPersistent(false);
         broker.setUseJmx(false);
-        TransportConnector connector = broker.addConnector("nio+ssl://localhost:0?transport.needClientAuth=true&transport.enabledCipherSuites=SSL_RSA_WITH_RC4_128_SHA,SSL_DH_anon_WITH_3DES_EDE_CBC_SHA");
+        TransportConnector connector = broker.addConnector("nio+ssl://localhost:0?socket.verifyHostName=false&transport.needClientAuth=true");
         broker.start();
         broker.waitUntilStarted();
 


### PR DESCRIPTION
Re-enable the nio transport tests in activemq-unit-tests by default to
catch transport errors. Also fix broken tests