### PR TITLE
Fix Rat header check on logo files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1410,7 +1410,7 @@
             <exclude>**/stomp.js</exclude>
             <exclude>**/__init__.py</exclude>
             <exclude>**/webapp/decorators/footer.jsp</exclude>
-            <exclude>**/docs/img/logo.svg</exclude>
+            <exclude>**/docs/img/*.svg</exclude>
             <exclude>**/testJdbcConfig/**/*</exclude>
           </excludes>
         </configuration>


### PR DESCRIPTION
The RAT plugin failed on `/docs/img/*.svg` when running `mvn apache-rat:check`