### PR TITLE
AMQ-8190 add wait time & shrink duration for CI test run

### DIFF
--- a/activemq-unit-tests/src/test/java/org/apache/activemq/usecases/DuplexAdvisoryRaceTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/usecases/DuplexAdvisoryRaceTest.java
@@ -107,7 +107,7 @@ public class DuplexAdvisoryRaceTest {
                 Subscription subscription = super.addConsumer(context, info);
                 // delay return to allow dispatch to interleave
                 if (context.isNetworkConnection()) {
-                    TimeUnit.MILLISECONDS.sleep(200);
+                    TimeUnit.MILLISECONDS.sleep(100);
                 }
                 return subscription;
             };
@@ -148,7 +148,7 @@ public class DuplexAdvisoryRaceTest {
                 LOG.info("received: " + responseReceived.get());
                 return responseReceived.get() >= numMessagesPerDest * numDests;
             }
-        }, 10*60*1000)) {
+        }, 30*60*1000)) {
 
            org.apache.activemq.TestSupport.dumpAllThreads("DD");
 


### PR DESCRIPTION
### Description
- Fix flaky test `DuplexAdvisoryRaceTest` [AMQ-8190](https://issues.apache.org/jira/browse/AMQ-8190). 
- The test is flaky because time needed for received response greater than numMessagesPerDest * numDests is more than 10 min in CI env. [Failed example](https://github.com/charlie-cyf/activemq/runs/2181716367?check_suite_focus=true#step:9:2557)

### Test
This commit is tested on my local Github Actions: https://github.com/charlie-cyf/activemq/runs/2188672418?check_suite_focus=true#step:7:1223