### PR TITLE
AMQ-8189 add wait time to CachedLDAPAuthorizationModuleTest

### DIFF
--- a/activemq-unit-tests/src/test/java/org/apache/activemq/security/AbstractCachedLDAPAuthorizationMapLegacyTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/security/AbstractCachedLDAPAuthorizationMapLegacyTest.java
@@ -312,7 +312,7 @@ public abstract class AbstractCachedLDAPAuthorizationMapLegacyTest extends Abstr
         getLdapServer().stop();
 
         // wait for the context to be closed
-        // as we can't rely on ldar server isStarted()
+        // as we can't rely on ldap server isStarted()
         Wait.waitFor(new Wait.Condition() {
             @Override
             public boolean isSatisified() throws Exception {
@@ -322,7 +322,7 @@ public abstract class AbstractCachedLDAPAuthorizationMapLegacyTest extends Abstr
                     return map.context == null;
                 }
             }
-        });
+        }, 5*60*1000);
 
         failedACLs = map.getReadACLs(new ActiveMQQueue("TEST.FOO"));
         assertEquals("set size: " + failedACLs, 2, failedACLs.size());
@@ -347,7 +347,7 @@ public abstract class AbstractCachedLDAPAuthorizationMapLegacyTest extends Abstr
             public boolean isSatisified() throws Exception {
                 return map.getReadACLs(new ActiveMQQueue("FAILED")).size() == 2;
             }
-        }));
+        }, 5*60*1000));
     }
 
     protected SimpleCachedLDAPAuthorizationMap createMap() {


### PR DESCRIPTION
### Description
- This test is flaky because default 30s wait time is not enough for test run in CI env. [failed example](https://github.com/charlie-cyf/activemq/runs/2181716367?check_suite_focus=true#step:9:2214)
- changed wait time to maximum 5 min to fix this issue
### Testing
Tested on my local Github Actions CI run: https://github.com/charlie-cyf/activemq/runs/2190121520?check_suite_focus=true#step:7:870