### PR TITLE
fix BrokerServiceTest by replacing powermock

### DIFF
--- a/activemq-unit-tests/pom.xml
+++ b/activemq-unit-tests/pom.xml
@@ -302,27 +302,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito-common</artifactId>
+      <artifactId>mockito-inline</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,6 @@
     <log4j-version>1.2.17</log4j-version>
     <mockito-version>3.8.0</mockito-version>
     <owasp-dependency-check-version>5.2.4</owasp-dependency-check-version>
-    <powermock-version>1.7.4</powermock-version>
     <mqtt-client-version>1.16</mqtt-client-version>
     <org-apache-derby-version>10.14.2.0</org-apache-derby-version>
     <osgi-version>6.0.0</osgi-version>
@@ -943,27 +942,9 @@
         <scope>test</scope>
       </dependency>
       <dependency>
-        <groupId>org.powermock</groupId>
-        <artifactId>powermock-core</artifactId>
-        <version>${powermock-version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.powermock</groupId>
-        <artifactId>powermock-module-junit4</artifactId>
-        <version>${powermock-version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.powermock</groupId>
-        <artifactId>powermock-api-mockito</artifactId>
-        <version>${powermock-version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.powermock</groupId>
-        <artifactId>powermock-api-mockito-common</artifactId>
-        <version>${powermock-version}</version>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-inline</artifactId>
+        <version>${mockito-version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
### Changes
- BrokerServiceTest in `activemq-unit-tests` is failing because powermock 1.7.4 doesn't work with newly updated Mockito 3.8.0. [Error Message](https://github.com/Charlie-chenchrl/activemq/runs/2216193106?check_suite_focus=true#step:9:1533)
- BrokerServiceTest used powermock to mock static functions, since Mockito start to support static mocks from 3.4.0 and this is the only place we use powermock, we can replace powermock with Mockito

### Test
- run `mvn clean test -Dtest=BrokerServiceTest`, test result in local CI: https://github.com/Charlie-chenchrl/activemq/runs/2216276748?check_suite_focus=true#step:7:195 (line 195)