### PR TITLE
[AMQ-8218] Installing activemq features breaks http commands

### DIFF
--- a/activemq-karaf/src/main/resources/features-core.xml
+++ b/activemq-karaf/src/main/resources/features-core.xml
@@ -20,12 +20,10 @@
 
 <features name="activemq-core-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">
 
-    <repository>mvn:org.apache.karaf.features/spring-legacy/[4,5)/xml/features</repository>
-
     <!-- Bundles needed if only client will be deployed in the container -->
     <feature name="activemq-client" description="ActiveMQ client libraries" version="${project.version}">
         <feature version="[4,5)">spring</feature>
-        <feature version="[4,5)">shell-compat</feature>
+        <feature>aries-blueprint</feature>
         <bundle dependency="true">mvn:org.apache.geronimo.specs/geronimo-annotation_1.0_spec/1.1.1</bundle>
         <bundle dependency="true">mvn:org.apache.geronimo.specs/geronimo-jta_1.1_spec/1.1.1</bundle>
         <bundle dependency="true">mvn:org.apache.geronimo.specs/geronimo-jms_1.1_spec/1.1.1</bundle>
@@ -50,10 +48,6 @@
       <feature>connector</feature>
       <feature>http</feature>
       <feature version="${project.version}">activemq-client</feature>
-      <conditional>
-          <condition>shell</condition>
-          <bundle>mvn:org.apache.activemq/activemq-karaf/${project.version}</bundle>
-      </conditional>
       <bundle dependency="true">mvn:commons-io/commons-io/${commons-io-version}</bundle>
       <bundle dependency="true">mvn:commons-collections/commons-collections/${commons-collections-version}</bundle>
       <bundle dependency="true">mvn:org.apache.commons/commons-lang3/${commons-lang-version}</bundle>

--- a/activemq-karaf/src/main/resources/features.xml
+++ b/activemq-karaf/src/main/resources/features.xml
@@ -37,6 +37,11 @@
         <feature version="${project.version}">activemq-web-console</feature>
     </feature>
 
+    <feature name="activemq-shell" version="${project.version}">
+        <feature>shell-compat</feature>
+        <bundle>mvn:org.apache.activemq/activemq-karaf/${project.version}</bundle>
+    </feature>
+
     <feature name="activemq-camel" version="${project.version}">
         <feature version="${project.version}">activemq-client</feature>
         <bundle>mvn:org.apache.activemq/activemq-camel/${project.version}</bundle>
@@ -46,6 +51,10 @@
         <feature version="${camel-version-range}">camel-blueprint</feature>
     </feature>
 
+    <!--
+        Don't forget to bind Karaf JMX server to 0.0.0.0 to have a functional webconsole:
+        In etc/org.apache.karaf.management.cfg, both rmiRegistryHost and rmiServerHost should use 0.0.0.0
+    -->
     <feature name="activemq-web-console" version="${project.version}">
       <feature>war</feature>
       <feature>eventadmin</feature>


### PR DESCRIPTION
Installing activemq feature can cause several refresh. The user should use spring-legacy from Karaf version instead of the range.