### PR TITLE
[AMQ-8219] fix org.apache.commons.lang.StringEscapeUtils cannot be resolved to a…

### DIFF
--- a/activemq-web-console/src/main/webapp/WEB-INF/tags/form/short.tag
+++ b/activemq-web-console/src/main/webapp/WEB-INF/tags/form/short.tag
@@ -17,8 +17,8 @@
 <%@ attribute name="text" type="java.lang.String" required="true"  %>
 <%@ attribute name="length" type="java.lang.Integer" required="false" %>
 <%
- text = org.apache.commons.lang.StringEscapeUtils.escapeHtml(text);
- text = org.apache.commons.lang.StringEscapeUtils.escapeJavaScript(text);
+ text = org.apache.commons.lang3.StringEscapeUtils.escapeHtml4(text);
+ text = org.apache.commons.lang3.StringEscapeUtils.escapeEcmaScript(text);
  if (length == null || length < 20)
     length = 20;
  if (text.length() <= length) {

--- a/activemq-web-console/src/main/webapp/WEB-INF/tags/form/text.tag
+++ b/activemq-web-console/src/main/webapp/WEB-INF/tags/form/text.tag
@@ -24,7 +24,7 @@
 	if (value == null) {
 		value = "";
 	}
-	value = org.apache.commons.lang.StringEscapeUtils.escapeHtml(value);
+	value = org.apache.commons.lang3.StringEscapeUtils.escapeHtml4(value);
 
 %>
 <input type="text" name="${name}" value="<%= value %>"/>


### PR DESCRIPTION
… type

### Changes
- this issue was caused by upgrade from commons-lang 2.6 to commons-lang 3.12 in https://github.com/apache/activemq/commit/1e2a0de5ccbff057ac0201b335ec30dc266eb0b5. The fix is to change it correct version.