### PR TITLE
AMQ-8226 match any amount of spaces before activemq PID in bin/active…

### DIFF
--- a/assembly/src/release/bin/activemq
+++ b/assembly/src/release/bin/activemq
@@ -476,7 +476,7 @@ checkRunning(){
         return 2
        fi
        local activemq_pid="`cat "$pidfile"`"
-       local RET="`ps -o "pid,args" | grep "^$activemq_pid\s.*java"`"
+       local RET="`ps -o "pid,args" | grep "^\s*$activemq_pid\s.*java"`"
        if [ -n "$RET" ];then
          return 0;
        else


### PR DESCRIPTION
…mq startup script

### Description
- fix for [AMQ-8226](https://issues.apache.org/jira/browse/AMQ-8226). 
- added `\s*` before `$activemq_pid` to match any amount of spaces in `ps -o` command