### PR TITLE
[AMQ-8279] Compiler warning cleanups

### DIFF
--- a/activemq-amqp/src/test/java/org/apache/activemq/transport/amqp/client/util/TypeConversionSupport.java
+++ b/activemq-amqp/src/test/java/org/apache/activemq/transport/amqp/client/util/TypeConversionSupport.java
@@ -151,7 +151,7 @@ public final class TypeConversionSupport {
         CONVERSION_MAP.put(new ConversionKey(Float.class, Double.class), new Converter() {
             @Override
             public Object convert(Object value) {
-                return new Double(((Number) value).doubleValue());
+                return Double.valueOf(((Number) value).doubleValue());
             }
         });
     }

--- a/activemq-amqp/src/test/java/org/apache/activemq/transport/amqp/message/MessageTransformationTest.java
+++ b/activemq-amqp/src/test/java/org/apache/activemq/transport/amqp/message/MessageTransformationTest.java
@@ -216,7 +216,7 @@ public class MessageTransformationTest {
 
         Message incomingMessage = Proton.message();
 
-        incomingMessage.setBody(new AmqpValue(new Boolean(true)));
+        incomingMessage.setBody(new AmqpValue(Boolean.TRUE));
 
         EncodedMessage encoded = encode(incomingMessage);
         InboundTransformer inboundTransformer = getInboundTransformer();

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/jmx/OpenTypeSupport.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/jmx/OpenTypeSupport.java
@@ -302,7 +302,7 @@ public final class OpenTypeSupport {
                 // In 1.6 it seems it is supported.. but until then...
                 Byte data[] = new Byte[preview.length];
                 for (int i = 0; i < data.length; i++) {
-                    data[i] = new Byte(preview[i]);
+                    data[i] = Byte.valueOf(preview[i]);
                 }
 
                 rc.put(CompositeDataConstants.BODY_PREVIEW, data);

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/region/BaseDestination.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/region/BaseDestination.java
@@ -706,9 +706,9 @@ public abstract class BaseDestination implements Destination {
                 }
 
                 if (isFlowControlLogRequired()) {
-                    getLog().warn("{}: {} (blocking for: {}s)", new Object[]{ usage, warning, new Long(((System.currentTimeMillis() - start) / 1000))});
+                    getLog().warn("{}: {} (blocking for: {}s)", new Object[]{ usage, warning, Long.valueOf(((System.currentTimeMillis() - start) / 1000))});
                 } else {
-                    getLog().debug("{}: {} (blocking for: {}s)", new Object[]{ usage, warning, new Long(((System.currentTimeMillis() - start) / 1000))});
+                    getLog().debug("{}: {} (blocking for: {}s)", new Object[]{ usage, warning, Long.valueOf(((System.currentTimeMillis() - start) / 1000))});
                 }
             }
             long finish = System.currentTimeMillis();

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/region/Queue.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/region/Queue.java
@@ -304,7 +304,7 @@ public class Queue extends BaseDestination implements Task, UsageListener, Index
             if ((recoveredAccumulator % 10000) == 0) {
                 LOG.info("cursor for {} has recovered {} messages. {}% complete",
                         getActiveMQDestination().getQualifiedName(), recoveredAccumulator,
-                        new Integer((int) (recoveredAccumulator * 100 / totalMessageCount)));
+                        Integer.valueOf((int) (recoveredAccumulator * 100 / totalMessageCount)));
             }
             // Message could have expired while it was being
             // loaded..

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/region/RegionBroker.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/region/RegionBroker.java
@@ -753,7 +753,7 @@ public class RegionBroker extends EmptyBroker {
         boolean stamped = false;
         if (message.getProperty(ORIGINAL_EXPIRATION) == null) {
             long expiration = message.getExpiration();
-            message.setProperty(ORIGINAL_EXPIRATION, new Long(expiration));
+            message.setProperty(ORIGINAL_EXPIRATION, Long.valueOf(expiration));
             stamped = true;
         }
         return stamped;

--- a/activemq-cf/src/main/java/org/apache/activemq/osgi/cf/ConnectionFactoryProvider.java
+++ b/activemq-cf/src/main/java/org/apache/activemq/osgi/cf/ConnectionFactoryProvider.java
@@ -50,9 +50,9 @@ public class ConnectionFactoryProvider {
         String jndiName = getString(config, OSGI_JNDI_SERVICE_NAME, "jms/local");
         String userName = getString(config, "userName", null);
         String password = getString(config, "password", null);
-        long expiryTimeout = new Long(getString(config, "expiryTimeout", "0"));
-        int idleTimeout = new Integer(getString(config, "idleTimeout", "30000"));
-        int maxConnections = new Integer(getString(config, "maxConnections", "8"));
+        long expiryTimeout = Long.valueOf(getString(config, "expiryTimeout", "0"));
+        int idleTimeout = Integer.valueOf(getString(config, "idleTimeout", "30000"));
+        int maxConnections = Integer.valueOf(getString(config, "maxConnections", "8"));
         ActiveMQConnectionFactory cf = new ActiveMQConnectionFactory(brokerURL);
         if (userName != null) {
             cf.setUserName(userName);

--- a/activemq-client/src/main/java/org/apache/activemq/ActiveMQConnectionConsumer.java
+++ b/activemq-client/src/main/java/org/apache/activemq/ActiveMQConnectionConsumer.java
@@ -17,10 +17,6 @@
 
 package org.apache.activemq;
 
-import java.util.Collections;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.jms.ConnectionConsumer;
@@ -30,7 +26,6 @@ import javax.jms.ServerSession;
 import javax.jms.ServerSessionPool;
 import javax.jms.Session;
 
-import org.apache.activemq.command.ConsumerId;
 import org.apache.activemq.command.ConsumerInfo;
 import org.apache.activemq.command.MessageDispatch;
 

--- a/activemq-client/src/main/java/org/apache/activemq/ActiveMQMessageConsumer.java
+++ b/activemq-client/src/main/java/org/apache/activemq/ActiveMQMessageConsumer.java
@@ -24,7 +24,6 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;

--- a/activemq-client/src/main/java/org/apache/activemq/blob/DefaultBlobUploadStrategy.java
+++ b/activemq-client/src/main/java/org/apache/activemq/blob/DefaultBlobUploadStrategy.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
 import java.net.URL;
 
 import javax.jms.JMSException;

--- a/activemq-client/src/main/java/org/apache/activemq/blob/FTPStrategy.java
+++ b/activemq-client/src/main/java/org/apache/activemq/blob/FTPStrategy.java
@@ -23,7 +23,6 @@ import java.net.URL;
 
 import javax.jms.JMSException;
 
-import org.apache.activemq.command.ActiveMQBlobMessage;
 import org.apache.commons.net.ftp.FTPClient;
 
 public class FTPStrategy {

--- a/activemq-client/src/main/java/org/apache/activemq/broker/scheduler/CronParser.java
+++ b/activemq-client/src/main/java/org/apache/activemq/broker/scheduler/CronParser.java
@@ -229,7 +229,7 @@ public class CronParser {
     }
 
     static boolean isCurrent(final CronEntry entry, final int current) throws MessageFormatException {
-        boolean result = entry.currentWhen.contains(new Integer(current));
+        boolean result = entry.currentWhen.contains(Integer.valueOf(current));
         return result;
     }
 

--- a/activemq-client/src/main/java/org/apache/activemq/command/ActiveMQMapMessage.java
+++ b/activemq-client/src/main/java/org/apache/activemq/command/ActiveMQMapMessage.java
@@ -676,7 +676,7 @@ public class ActiveMQMapMessage extends ActiveMQMessage implements MapMessage {
     @Override
     public void setFloat(String name, float value) throws JMSException {
         initializeWriting();
-        put(name, new Float(value));
+        put(name, Float.valueOf(value));
     }
 
     /**
@@ -693,7 +693,7 @@ public class ActiveMQMapMessage extends ActiveMQMessage implements MapMessage {
     @Override
     public void setDouble(String name, double value) throws JMSException {
         initializeWriting();
-        put(name, new Double(value));
+        put(name, Double.valueOf(value));
     }
 
     /**

--- a/activemq-client/src/main/java/org/apache/activemq/command/ActiveMQMessage.java
+++ b/activemq-client/src/main/java/org/apache/activemq/command/ActiveMQMessage.java
@@ -723,12 +723,12 @@ public class ActiveMQMessage extends Message implements org.apache.activemq.Mess
 
     @Override
     public void setFloatProperty(String name, float value) throws JMSException {
-        setObjectProperty(name, new Float(value));
+        setObjectProperty(name, Float.valueOf(value));
     }
 
     @Override
     public void setDoubleProperty(String name, double value) throws JMSException {
-        setObjectProperty(name, new Double(value));
+        setObjectProperty(name, Double.valueOf(value));
     }
 
     @Override

--- a/activemq-client/src/main/java/org/apache/activemq/command/ActiveMQObjectMessage.java
+++ b/activemq-client/src/main/java/org/apache/activemq/command/ActiveMQObjectMessage.java
@@ -24,10 +24,8 @@ import java.io.InputStream;
 import java.io.ObjectOutputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.zip.DeflaterOutputStream;
 import java.util.zip.InflaterInputStream;
 

--- a/activemq-client/src/main/java/org/apache/activemq/command/ActiveMQStreamMessage.java
+++ b/activemq-client/src/main/java/org/apache/activemq/command/ActiveMQStreamMessage.java
@@ -634,28 +634,28 @@ public class ActiveMQStreamMessage extends ActiveMQMessage implements StreamMess
                 return this.dataIn.readUTF();
             }
             if (type == MarshallingSupport.LONG_TYPE) {
-                return new Long(this.dataIn.readLong()).toString();
+                return Long.toString(this.dataIn.readLong());
             }
             if (type == MarshallingSupport.INTEGER_TYPE) {
-                return new Integer(this.dataIn.readInt()).toString();
+                return Integer.toString(this.dataIn.readInt());
             }
             if (type == MarshallingSupport.SHORT_TYPE) {
-                return new Short(this.dataIn.readShort()).toString();
+                return Short.toString(this.dataIn.readShort());
             }
             if (type == MarshallingSupport.BYTE_TYPE) {
-                return new Byte(this.dataIn.readByte()).toString();
+                return Byte.toString(this.dataIn.readByte());
             }
             if (type == MarshallingSupport.FLOAT_TYPE) {
-                return new Float(this.dataIn.readFloat()).toString();
+                return Float.toString(this.dataIn.readFloat());
             }
             if (type == MarshallingSupport.DOUBLE_TYPE) {
-                return new Double(this.dataIn.readDouble()).toString();
+                return Double.toString(this.dataIn.readDouble());
             }
             if (type == MarshallingSupport.BOOLEAN_TYPE) {
                 return (this.dataIn.readBoolean() ? Boolean.TRUE : Boolean.FALSE).toString();
             }
             if (type == MarshallingSupport.CHAR_TYPE) {
-                return new Character(this.dataIn.readChar()).toString();
+                return Character.toString(this.dataIn.readChar());
             } else {
                 this.dataIn.reset();
                 throw new MessageFormatException(" not a String type");
@@ -820,10 +820,10 @@ public class ActiveMQStreamMessage extends ActiveMQMessage implements StreamMess
                 return Byte.valueOf(this.dataIn.readByte());
             }
             if (type == MarshallingSupport.FLOAT_TYPE) {
-                return new Float(this.dataIn.readFloat());
+                return Float.valueOf(this.dataIn.readFloat());
             }
             if (type == MarshallingSupport.DOUBLE_TYPE) {
-                return new Double(this.dataIn.readDouble());
+                return Double.valueOf(this.dataIn.readDouble());
             }
             if (type == MarshallingSupport.BOOLEAN_TYPE) {
                 return this.dataIn.readBoolean() ? Boolean.TRUE : Boolean.FALSE;

--- a/activemq-client/src/main/java/org/apache/activemq/command/WireFormatInfo.java
+++ b/activemq-client/src/main/java/org/apache/activemq/command/WireFormatInfo.java
@@ -285,7 +285,7 @@ public class WireFormatInfo implements Command, MarshallAware {
     }
 
     public void setMaxInactivityDuration(long maxInactivityDuration) throws IOException {
-        setProperty("MaxInactivityDuration", new Long(maxInactivityDuration));
+        setProperty("MaxInactivityDuration", Long.valueOf(maxInactivityDuration));
     }
 
     public long getMaxInactivityDurationInitalDelay() throws IOException {
@@ -294,7 +294,7 @@ public class WireFormatInfo implements Command, MarshallAware {
     }
 
     public void setMaxInactivityDurationInitalDelay(long maxInactivityDurationInitalDelay) throws IOException {
-        setProperty("MaxInactivityDurationInitalDelay", new Long(maxInactivityDurationInitalDelay));
+        setProperty("MaxInactivityDurationInitalDelay", Long.valueOf(maxInactivityDurationInitalDelay));
     }
 
     public long getMaxFrameSize() throws IOException {
@@ -303,7 +303,7 @@ public class WireFormatInfo implements Command, MarshallAware {
     }
 
     public void setMaxFrameSize(long maxFrameSize) throws IOException {
-        setProperty("MaxFrameSize", new Long(maxFrameSize));
+        setProperty("MaxFrameSize", Long.valueOf(maxFrameSize));
     }
 
     /**
@@ -315,7 +315,7 @@ public class WireFormatInfo implements Command, MarshallAware {
     }
 
     public void setCacheSize(int cacheSize) throws IOException {
-        setProperty("CacheSize", new Integer(cacheSize));
+        setProperty("CacheSize", Integer.valueOf(cacheSize));
     }
 
     /**

--- a/activemq-client/src/main/java/org/apache/activemq/filter/AnyDestination.java
+++ b/activemq-client/src/main/java/org/apache/activemq/filter/AnyDestination.java
@@ -17,7 +17,6 @@
 package org.apache.activemq.filter;
 
 import java.lang.IllegalStateException;
-import javax.jms.*;
 import org.apache.activemq.command.ActiveMQDestination;
 
 /*

--- a/activemq-client/src/main/java/org/apache/activemq/filter/ArithmeticExpression.java
+++ b/activemq-client/src/main/java/org/apache/activemq/filter/ArithmeticExpression.java
@@ -122,42 +122,42 @@ public abstract class ArithmeticExpression extends BinaryExpression {
     protected Number plus(Number left, Number right) {
         switch (numberType(left, right)) {
         case INTEGER:
-            return new Integer(left.intValue() + right.intValue());
+            return Integer.valueOf(left.intValue() + right.intValue());
         case LONG:
-            return new Long(left.longValue() + right.longValue());
+            return Long.valueOf(left.longValue() + right.longValue());
         default:
-            return new Double(left.doubleValue() + right.doubleValue());
+            return Double.valueOf(left.doubleValue() + right.doubleValue());
         }
     }
 
     protected Number minus(Number left, Number right) {
         switch (numberType(left, right)) {
         case INTEGER:
-            return new Integer(left.intValue() - right.intValue());
+            return Integer.valueOf(left.intValue() - right.intValue());
         case LONG:
-            return new Long(left.longValue() - right.longValue());
+            return Long.valueOf(left.longValue() - right.longValue());
         default:
-            return new Double(left.doubleValue() - right.doubleValue());
+            return Double.valueOf(left.doubleValue() - right.doubleValue());
         }
     }
 
     protected Number multiply(Number left, Number right) {
         switch (numberType(left, right)) {
         case INTEGER:
-            return new Integer(left.intValue() * right.intValue());
+            return Integer.valueOf(left.intValue() * right.intValue());
         case LONG:
-            return new Long(left.longValue() * right.longValue());
+            return Long.valueOf(left.longValue() * right.longValue());
         default:
-            return new Double(left.doubleValue() * right.doubleValue());
+            return Double.valueOf(left.doubleValue() * right.doubleValue());
         }
     }
 
     protected Number divide(Number left, Number right) {
-        return new Double(left.doubleValue() / right.doubleValue());
+        return Double.valueOf(left.doubleValue() / right.doubleValue());
     }
 
     protected Number mod(Number left, Number right) {
-        return new Double(left.doubleValue() % right.doubleValue());
+        return Double.valueOf(left.doubleValue() % right.doubleValue());
     }
 
     private int numberType(Number left, Number right) {

--- a/activemq-client/src/main/java/org/apache/activemq/filter/ComparisonExpression.java
+++ b/activemq-client/src/main/java/org/apache/activemq/filter/ComparisonExpression.java
@@ -116,7 +116,7 @@ public abstract class ComparisonExpression extends BinaryExpression implements B
                 regexp.append(".*?"); // Do a non-greedy match
             } else if (c == '_') {
                 regexp.append("."); // match one
-            } else if (REGEXP_CONTROL_CHARS.contains(new Character(c))) {
+            } else if (REGEXP_CONTROL_CHARS.contains(Character.valueOf(c))) {
                 regexp.append("\\x");
                 regexp.append(Integer.toHexString(0xFFFF & c));
             } else {
@@ -387,9 +387,9 @@ public abstract class ComparisonExpression extends BinaryExpression implements B
                     } else if (rc == Long.class) {
                         lv = Long.valueOf(((Number)lv).longValue());
                     } else if (rc == Float.class) {
-                        lv = new Float(((Number)lv).floatValue());
+                        lv = Float.valueOf(((Number)lv).floatValue());
                     } else if (rc == Double.class) {
-                        lv = new Double(((Number)lv).doubleValue());
+                        lv = Double.valueOf(((Number)lv).doubleValue());
                     } else if (convertStringExpressions && rc == String.class) {
                         rv = Byte.valueOf((String)rv);
                     } else {
@@ -401,9 +401,9 @@ public abstract class ComparisonExpression extends BinaryExpression implements B
                     } else if (rc == Long.class) {
                         lv = Long.valueOf(((Number)lv).longValue());
                     } else if (rc == Float.class) {
-                        lv = new Float(((Number)lv).floatValue());
+                        lv = Float.valueOf(((Number)lv).floatValue());
                     } else if (rc == Double.class) {
-                        lv = new Double(((Number)lv).doubleValue());
+                        lv = Double.valueOf(((Number)lv).doubleValue());
                     } else if (convertStringExpressions && rc == String.class) {
                         rv = Short.valueOf((String)rv);
                     } else {
@@ -413,9 +413,9 @@ public abstract class ComparisonExpression extends BinaryExpression implements B
                     if (rc == Long.class) {
                         lv = Long.valueOf(((Number)lv).longValue());
                     } else if (rc == Float.class) {
-                        lv = new Float(((Number)lv).floatValue());
+                        lv = Float.valueOf(((Number)lv).floatValue());
                     } else if (rc == Double.class) {
-                        lv = new Double(((Number)lv).doubleValue());
+                        lv = Double.valueOf(((Number)lv).doubleValue());
                     } else if (convertStringExpressions && rc == String.class) {
                         rv = Integer.valueOf((String)rv);
                     } else {
@@ -425,9 +425,9 @@ public abstract class ComparisonExpression extends BinaryExpression implements B
                     if (rc == Integer.class) {
                         rv = Long.valueOf(((Number)rv).longValue());
                     } else if (rc == Float.class) {
-                        lv = new Float(((Number)lv).floatValue());
+                        lv = Float.valueOf(((Number)lv).floatValue());
                     } else if (rc == Double.class) {
-                        lv = new Double(((Number)lv).doubleValue());
+                        lv = Double.valueOf(((Number)lv).doubleValue());
                     } else if (convertStringExpressions && rc == String.class) {
                         rv = Long.valueOf((String)rv);
                     } else {
@@ -435,11 +435,11 @@ public abstract class ComparisonExpression extends BinaryExpression implements B
                     }
                 } else if (lc == Float.class) {
                     if (rc == Integer.class) {
-                        rv = new Float(((Number)rv).floatValue());
+                        rv = Float.valueOf(((Number)rv).floatValue());
                     } else if (rc == Long.class) {
-                        rv = new Float(((Number)rv).floatValue());
+                        rv = Float.valueOf(((Number)rv).floatValue());
                     } else if (rc == Double.class) {
-                        lv = new Double(((Number)lv).doubleValue());
+                        lv = Double.valueOf(((Number)lv).doubleValue());
                     } else if (convertStringExpressions && rc == String.class) {
                         rv = Float.valueOf((String)rv);
                     } else {
@@ -447,9 +447,9 @@ public abstract class ComparisonExpression extends BinaryExpression implements B
                     }
                 } else if (lc == Double.class) {
                     if (rc == Integer.class) {
-                        rv = new Double(((Number)rv).doubleValue());
+                        rv = Double.valueOf(((Number)rv).doubleValue());
                     } else if (rc == Long.class) {
-                        rv = new Double(((Number)rv).doubleValue());
+                        rv = Double.valueOf(((Number)rv).doubleValue());
                     } else if (rc == Float.class) {
                         rv = new Float(((Number)rv).doubleValue());
                     } else if (convertStringExpressions && rc == String.class) {

--- a/activemq-client/src/main/java/org/apache/activemq/filter/ConstantExpression.java
+++ b/activemq-client/src/main/java/org/apache/activemq/filter/ConstantExpression.java
@@ -57,7 +57,7 @@ public class ConstantExpression implements Expression {
 
         Number value;
         try {
-            value = new Long(text);
+            value = Long.valueOf(text);
         } catch (NumberFormatException e) {
             // The number may be too big to fit in a long.
             value = new BigDecimal(text);
@@ -89,7 +89,7 @@ public class ConstantExpression implements Expression {
     }
 
     public static ConstantExpression createFloat(String text) {
-        Number value = new Double(text);
+        Number value = Double.valueOf(text);
         return new ConstantExpression(value);
     }
 

--- a/activemq-client/src/main/java/org/apache/activemq/filter/PropertyExpression.java
+++ b/activemq-client/src/main/java/org/apache/activemq/filter/PropertyExpression.java
@@ -157,7 +157,7 @@ public class PropertyExpression implements Expression {
 
             @Override
             public Object evaluate(Message message) {
-                return new Integer(message.getGroupSequence());
+                return Integer.valueOf(message.getGroupSequence());
             }
         });
         JMS_PROPERTY_EXPRESSIONS.put("JMSXProducerTXID", new SubExpression() {

--- a/activemq-client/src/main/java/org/apache/activemq/filter/UnaryExpression.java
+++ b/activemq-client/src/main/java/org/apache/activemq/filter/UnaryExpression.java
@@ -181,13 +181,13 @@ public abstract class UnaryExpression implements Expression {
     private static Number negate(Number left) {
         Class clazz = left.getClass();
         if (clazz == Integer.class) {
-            return new Integer(-left.intValue());
+            return Integer.valueOf(-left.intValue());
         } else if (clazz == Long.class) {
-            return new Long(-left.longValue());
+            return Long.valueOf(-left.longValue());
         } else if (clazz == Float.class) {
-            return new Float(-left.floatValue());
+            return Float.valueOf(-left.floatValue());
         } else if (clazz == Double.class) {
-            return new Double(-left.doubleValue());
+            return Double.valueOf(-left.doubleValue());
         } else if (clazz == BigDecimal.class) {
             // We ussually get a big deciamal when we have Long.MIN_VALUE
             // constant in the

--- a/activemq-client/src/main/java/org/apache/activemq/openwire/OpenWireFormat.java
+++ b/activemq-client/src/main/java/org/apache/activemq/openwire/OpenWireFormat.java
@@ -520,13 +520,13 @@ public final class OpenWireFormat implements WireFormat {
         // We can only cache that item if there is space left.
         if (marshallCacheMap.size() < marshallCache.length) {
             marshallCache[i] = o;
-            Short index = new Short(i);
+            Short index = Short.valueOf(i);
             marshallCacheMap.put(o, index);
             return index;
         } else {
             // Use -1 to indicate that the value was not cached due to cache
             // being full.
-            return new Short((short)-1);
+            return Short.valueOf((short)-1);
         }
     }
 

--- a/activemq-client/src/main/java/org/apache/activemq/openwire/v1/BaseDataStreamMarshaller.java
+++ b/activemq-client/src/main/java/org/apache/activemq/openwire/v1/BaseDataStreamMarshaller.java
@@ -201,7 +201,7 @@ public abstract class BaseDataStreamMarshaller implements DataStreamMarshaller {
                                 .newInstance(new Object[] {tightUnmarshalString(dataIn, bs),
                                                            tightUnmarshalString(dataIn, bs),
                                                            tightUnmarshalString(dataIn, bs),
-                                                           new Integer(dataIn.readInt())});
+                                                           Integer.valueOf(dataIn.readInt())});
                         } catch (IOException e) {
                             throw e;
                         } catch (Throwable e) {
@@ -522,7 +522,7 @@ public abstract class BaseDataStreamMarshaller implements DataStreamMarshaller {
                                 .newInstance(new Object[] {looseUnmarshalString(dataIn),
                                                            looseUnmarshalString(dataIn),
                                                            looseUnmarshalString(dataIn),
-                                                           new Integer(dataIn.readInt())});
+                                                           Integer.valueOf(dataIn.readInt())});
                         } catch (IOException e) {
                             throw e;
                         } catch (Throwable e) {

--- a/activemq-client/src/main/java/org/apache/activemq/state/ConnectionState.java
+++ b/activemq-client/src/main/java/org/apache/activemq/state/ConnectionState.java
@@ -20,7 +20,6 @@ package org.apache.activemq.state;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;

--- a/activemq-client/src/main/java/org/apache/activemq/transport/RequestTimedOutIOException.java
+++ b/activemq-client/src/main/java/org/apache/activemq/transport/RequestTimedOutIOException.java
@@ -23,4 +23,6 @@ import java.io.IOException;
  * a reply or response is received
  */
 public class RequestTimedOutIOException extends IOException {
+
+	private static final long serialVersionUID = -5938342624821415513L;
 }

--- a/activemq-client/src/main/java/org/apache/activemq/transport/ResponseCorrelator.java
+++ b/activemq-client/src/main/java/org/apache/activemq/transport/ResponseCorrelator.java
@@ -69,7 +69,7 @@ public class ResponseCorrelator extends TransportFilter {
         synchronized (requestMap) {
             priorError = this.error;
             if (priorError == null) {
-                requestMap.put(new Integer(command.getCommandId()), future);
+                requestMap.put(Integer.valueOf(command.getCommandId()), future);
             }
         }
 

--- a/activemq-client/src/main/java/org/apache/activemq/transport/discovery/DiscoveryAgent.java
+++ b/activemq-client/src/main/java/org/apache/activemq/transport/discovery/DiscoveryAgent.java
@@ -18,8 +18,6 @@ package org.apache.activemq.transport.discovery;
 
 import java.io.IOException;
 
-import javax.jms.JMSException;
-
 import org.apache.activemq.Service;
 import org.apache.activemq.command.DiscoveryEvent;
 

--- a/activemq-client/src/main/java/org/apache/activemq/transport/failover/FailoverTransportFactory.java
+++ b/activemq-client/src/main/java/org/apache/activemq/transport/failover/FailoverTransportFactory.java
@@ -19,7 +19,6 @@ package org.apache.activemq.transport.failover;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.HashMap;
 import java.util.Map;
 import org.apache.activemq.transport.MutexTransport;
 import org.apache.activemq.transport.ResponseCorrelator;

--- a/activemq-client/src/main/java/org/apache/activemq/transport/fanout/FanoutTransport.java
+++ b/activemq-client/src/main/java/org/apache/activemq/transport/fanout/FanoutTransport.java
@@ -115,7 +115,7 @@ public class FanoutTransport implements CompositeTransport {
         public void onCommand(Object o) {
             Command command = (Command) o;
             if (command.isResponse()) {
-                Integer id = new Integer(((Response) command).getCorrelationId());
+                Integer id = Integer.valueOf(((Response) command).getCorrelationId());
                 RequestCounter rc = requestMap.get(id);
                 if (rc != null) {
                     if (rc.ackCount.decrementAndGet() <= 0) {
@@ -403,7 +403,7 @@ public class FanoutTransport implements CompositeTransport {
                 boolean fanout = isFanoutCommand(command);
                 if (stateTracker.track(command) == null && command.isResponseRequired()) {
                     int size = fanout ? minAckCount : 1;
-                    requestMap.put(new Integer(command.getCommandId()), new RequestCounter(command, size));
+                    requestMap.put(Integer.valueOf(command.getCommandId()), new RequestCounter(command, size));
                 }
 
                 // Send the message.

--- a/activemq-client/src/main/java/org/apache/activemq/transport/fanout/FanoutTransportFactory.java
+++ b/activemq-client/src/main/java/org/apache/activemq/transport/fanout/FanoutTransportFactory.java
@@ -19,7 +19,6 @@ package org.apache.activemq.transport.fanout;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.activemq.transport.MutexTransport;

--- a/activemq-client/src/main/java/org/apache/activemq/util/MarshallingSupport.java
+++ b/activemq-client/src/main/java/org/apache/activemq/util/MarshallingSupport.java
@@ -184,10 +184,10 @@ public final class MarshallingSupport {
             value = Long.valueOf(in.readLong());
             break;
         case FLOAT_TYPE:
-            value = new Float(in.readFloat());
+            value = Float.valueOf(in.readFloat());
             break;
         case DOUBLE_TYPE:
-            value = new Double(in.readDouble());
+            value = Double.valueOf(in.readDouble());
             break;
         case BYTE_ARRAY_TYPE:
             value = new byte[in.readInt()];

--- a/activemq-client/src/main/java/org/apache/activemq/util/TypeConversionSupport.java
+++ b/activemq-client/src/main/java/org/apache/activemq/util/TypeConversionSupport.java
@@ -178,7 +178,7 @@ public final class TypeConversionSupport {
         CONVERSION_MAP.put(new ConversionKey(Float.class, Double.class), new Converter() {
             @Override
             public Object convert(Object value) {
-                return new Double(((Number)value).doubleValue());
+                return Double.valueOf(((Number)value).doubleValue());
             }
         });
         CONVERSION_MAP.put(new ConversionKey(String.class, ActiveMQDestination.class), new Converter() {

--- a/activemq-client/src/test/java/org/apache/activemq/util/ClassLoadingAwareObjectInputStreamTest.java
+++ b/activemq-client/src/test/java/org/apache/activemq/util/ClassLoadingAwareObjectInputStreamTest.java
@@ -321,7 +321,7 @@ public class ClassLoadingAwareObjectInputStreamTest {
         }
 
         // Replace the filtered type and try again
-        value[3] = new Integer(20);
+        value[3] = Integer.valueOf(20);
 
         serialized = serializeObject(value);
 

--- a/activemq-client/src/test/java/org/apache/activemq/util/LRUCacheTest.java
+++ b/activemq-client/src/test/java/org/apache/activemq/util/LRUCacheTest.java
@@ -29,7 +29,7 @@ public class LRUCacheTest {
     public void testResize() throws Exception {
         LRUCache<Long, Long> underTest = new LRUCache<Long, Long>(1000);
         
-        Long count = new Long(0);
+        Long count = Long.valueOf(0);
         long max = 0;
         for (; count < 27276827; count++) {
             long start = System.currentTimeMillis();

--- a/activemq-http/src/test/java/org/apache/activemq/transport/http/HttpJMSMessagesWithCompressionTest.java
+++ b/activemq-http/src/test/java/org/apache/activemq/transport/http/HttpJMSMessagesWithCompressionTest.java
@@ -187,7 +187,7 @@ public class HttpJMSMessagesWithCompressionTest {
     @Test
     public void testObjectMessage() throws Exception {
         executeTest(new MessageCommand<ObjectMessage>() {
-            private Long value = new Long(101);
+            private Long value = Long.valueOf(101);
 
             public ObjectMessage createMessage(Session session) throws JMSException {
                 return session.createObjectMessage(value);
@@ -202,7 +202,7 @@ public class HttpJMSMessagesWithCompressionTest {
     @Test
     public void testStreamMessage() throws Exception {
         executeTest(new MessageCommand<StreamMessage>() {
-            private Long value = new Long(1013);
+            private Long value = Long.valueOf(1013);
 
             public StreamMessage createMessage(Session session) throws JMSException {
                 StreamMessage message = session.createStreamMessage();

--- a/activemq-jms-pool/src/test/java/org/apache/activemq/jms/pool/PooledConnectionFactoryMaximumActiveTest.java
+++ b/activemq-jms-pool/src/test/java/org/apache/activemq/jms/pool/PooledConnectionFactoryMaximumActiveTest.java
@@ -109,7 +109,7 @@ public class PooledConnectionFactoryMaximumActiveTest extends JmsPoolTestSupport
 
                 if (PooledConnectionFactoryMaximumActiveTest.conn == null) {
                     TASK_LOG.error("Connection not yet initialized. Aborting test.");
-                    return new Boolean(false);
+                    return Boolean.FALSE;
                 }
 
                 one = PooledConnectionFactoryMaximumActiveTest.conn.createSession(false, Session.AUTO_ACKNOWLEDGE);
@@ -118,7 +118,7 @@ public class PooledConnectionFactoryMaximumActiveTest extends JmsPoolTestSupport
                 Thread.sleep(2 * PooledConnectionFactoryMaximumActiveTest.sleepTimeout);
             } catch (Exception ex) {
                 TASK_LOG.error(ex.getMessage());
-                return new Boolean(false);
+                return Boolean.FALSE;
             } finally {
                 if (one != null)
                     try {
@@ -129,7 +129,7 @@ public class PooledConnectionFactoryMaximumActiveTest extends JmsPoolTestSupport
             }
 
             // all good, test succeeded
-            return new Boolean(true);
+            return Boolean.TRUE;
         }
     }
 }

--- a/activemq-jms-pool/src/test/java/org/apache/activemq/jms/pool/PooledConnectionFactoryTest.java
+++ b/activemq-jms-pool/src/test/java/org/apache/activemq/jms/pool/PooledConnectionFactoryTest.java
@@ -381,14 +381,14 @@ public class PooledConnectionFactoryTest extends JmsPoolTestSupport {
                     fail("seconds call to Connection.createSession() was supposed" +
                          "to raise an JMSException as internal session pool" +
                          "is exhausted. This did not happen and indiates a problem");
-                    return new Boolean(false);
+                    return Boolean.FALSE;
                 } catch (JMSException ex) {
                     if (ex.getCause().getClass() == java.util.NoSuchElementException.class) {
                         // expected, ignore but log
                         LOG.info("Caught expected " + ex);
                     } else {
                         LOG.error(ex);
-                        return new Boolean(false);
+                        return Boolean.FALSE;
                     }
                 } finally {
                     if (one != null) {
@@ -400,7 +400,7 @@ public class PooledConnectionFactoryTest extends JmsPoolTestSupport {
                 }
             } catch (Exception ex) {
                 LOG.error(ex.getMessage());
-                return new Boolean(false);
+                return Boolean.FALSE;
             } finally {
                 if (cf != null) {
                     cf.stop();
@@ -408,7 +408,7 @@ public class PooledConnectionFactoryTest extends JmsPoolTestSupport {
             }
 
             // all good, test succeeded
-            return new Boolean(true);
+            return Boolean.FALSE;
         }
     }
 }

--- a/activemq-jms-pool/src/test/java/org/apache/activemq/jms/pool/PooledConnectionFactoryTest.java
+++ b/activemq-jms-pool/src/test/java/org/apache/activemq/jms/pool/PooledConnectionFactoryTest.java
@@ -408,7 +408,7 @@ public class PooledConnectionFactoryTest extends JmsPoolTestSupport {
             }
 
             // all good, test succeeded
-            return Boolean.FALSE;
+            return Boolean.TRUE;
         }
     }
 }

--- a/activemq-kahadb-store/src/main/java/org/apache/activemq/store/kahadb/MessageDatabase.java
+++ b/activemq-kahadb-store/src/main/java/org/apache/activemq/store/kahadb/MessageDatabase.java
@@ -3866,7 +3866,7 @@ public abstract class MessageDatabase extends ServiceSupport implements BrokerSe
 
         void setBatch(Transaction tx, Long sequence) throws IOException {
             if (sequence != null) {
-                Long nextPosition = new Long(sequence.longValue() + 1);
+                Long nextPosition = Long.valueOf(sequence.longValue() + 1);
                 lastDefaultKey = sequence;
                 cursor.defaultCursorPosition = nextPosition.longValue();
                 lastHighKey = sequence;

--- a/activemq-kahadb-store/src/test/java/org/apache/activemq/store/kahadb/JournalCorruptionEofIndexRecoveryTest.java
+++ b/activemq-kahadb-store/src/test/java/org/apache/activemq/store/kahadb/JournalCorruptionEofIndexRecoveryTest.java
@@ -342,7 +342,7 @@ public class JournalCorruptionEofIndexRecoveryTest {
 
     private void corruptLocation(Location toCorrupt) throws IOException {
 
-        DataFile dataFile = ((KahaDBPersistenceAdapter) broker.getPersistenceAdapter()).getStore().getJournal().getFileMap().get(new Integer(toCorrupt.getDataFileId()));
+        DataFile dataFile = ((KahaDBPersistenceAdapter) broker.getPersistenceAdapter()).getStore().getJournal().getFileMap().get(Integer.valueOf(toCorrupt.getDataFileId()));
 
         RecoverableRandomAccessFile randomAccessFile = dataFile.openRandomAccessFile();
 

--- a/activemq-tooling/activemq-memtest-maven-plugin/src/main/java/org/apache/activemq/tool/JMSMemtest.java
+++ b/activemq-tooling/activemq-memtest-maven-plugin/src/main/java/org/apache/activemq/tool/JMSMemtest.java
@@ -82,16 +82,16 @@ public class JMSMemtest {
 
     public JMSMemtest(Properties settings) {
         url = settings.getProperty("url");
-        topic = new Boolean(settings.getProperty("topic")).booleanValue();
-        durable = new Boolean(settings.getProperty("durable")).booleanValue();
-        connectionCheckpointSize = new Integer(settings.getProperty("connectionCheckpointSize")).intValue();
-        producerCount = new Integer(settings.getProperty("producerCount")).intValue();
-        consumerCount = new Integer(settings.getProperty("consumerCount")).intValue();
-        messageCount = new Integer(settings.getProperty("messageCount")).intValue();
-        messageSize = new Integer(settings.getProperty("messageSize")).intValue();
-        prefetchSize = new Integer(settings.getProperty("prefetchSize")).intValue();
-        checkpointInterval = new Integer(settings.getProperty("checkpointInterval")).intValue() * 1000;
-        producerCount = new Integer(settings.getProperty("producerCount")).intValue();
+        topic = Boolean.parseBoolean(settings.getProperty("topic"));
+        durable = Boolean.parseBoolean(settings.getProperty("durable"));
+        connectionCheckpointSize = Integer.valueOf(settings.getProperty("connectionCheckpointSize")).intValue();
+        producerCount = Integer.valueOf(settings.getProperty("producerCount")).intValue();
+        consumerCount = Integer.valueOf(settings.getProperty("consumerCount")).intValue();
+        messageCount = Integer.valueOf(settings.getProperty("messageCount")).intValue();
+        messageSize = Integer.valueOf(settings.getProperty("messageSize")).intValue();
+        prefetchSize = Integer.valueOf(settings.getProperty("prefetchSize")).intValue();
+        checkpointInterval = Integer.valueOf(settings.getProperty("checkpointInterval")).intValue() * 1000;
+        producerCount = Integer.valueOf(settings.getProperty("producerCount")).intValue();
         reportName = settings.getProperty("reportName");
         destinationName = settings.getProperty("destinationName");
         reportDirectory = settings.getProperty("reportDirectory");
@@ -290,17 +290,17 @@ public class JMSMemtest {
         Properties settings = new Properties();
         settings.setProperty("domain", topic ? "topic" : "queue");
         settings.setProperty("durable", durable ? "durable" : "non-durable");
-        settings.setProperty("connection_checkpoint_size_kb", new Integer(connectionCheckpointSize).toString());
-        settings.setProperty("producer_count", new Integer(producerCount).toString());
-        settings.setProperty("consumer_count", new Integer(consumerCount).toString());
-        settings.setProperty("message_count", new Long(messageCount).toString());
-        settings.setProperty("message_size", new Integer(messageSize).toString());
-        settings.setProperty("prefetchSize", new Integer(prefetchSize).toString());
-        settings.setProperty("checkpoint_interval", new Integer(checkpointInterval).toString());
+        settings.setProperty("connection_checkpoint_size_kb", Integer.valueOf(connectionCheckpointSize).toString());
+        settings.setProperty("producer_count", Integer.valueOf(producerCount).toString());
+        settings.setProperty("consumer_count", Integer.valueOf(consumerCount).toString());
+        settings.setProperty("message_count", Long.valueOf(messageCount).toString());
+        settings.setProperty("message_size", Integer.valueOf(messageSize).toString());
+        settings.setProperty("prefetchSize", Integer.valueOf(prefetchSize).toString());
+        settings.setProperty("checkpoint_interval", Integer.valueOf(checkpointInterval).toString());
         settings.setProperty("destination_name", destinationName);
         settings.setProperty("report_name", reportName);
         settings.setProperty("report_directory", reportDirectory);
-        settings.setProperty("connection_checkpoint_size", new Integer(connectionCheckpointSize).toString());
+        settings.setProperty("connection_checkpoint_size", Integer.valueOf(connectionCheckpointSize).toString());
         return settings;
     }
 

--- a/activemq-tooling/activemq-memtest-maven-plugin/src/main/java/org/apache/activemq/tool/MemoryMonitoringTool.java
+++ b/activemq-tooling/activemq-memtest-maven-plugin/src/main/java/org/apache/activemq/tool/MemoryMonitoringTool.java
@@ -67,7 +67,7 @@ public class MemoryMonitoringTool implements Runnable {
     public Thread startMonitor() {
 
         String intervalStr = this.getTestSettings().getProperty("checkpoint_interval");
-        checkpointInterval = new Integer(intervalStr).intValue();
+        checkpointInterval = Integer.valueOf(intervalStr).intValue();
         this.getTestSettings().remove("checkpoint_interval");
 
         memoryBean = ManagementFactory.getMemoryMXBean();

--- a/activemq-web/src/main/java/org/apache/activemq/web/PortfolioPublishServlet.java
+++ b/activemq-web/src/main/java/org/apache/activemq/web/PortfolioPublishServlet.java
@@ -102,12 +102,12 @@ public class PortfolioPublishServlet extends MessageServletSupport {
     protected String createStockText(String stock) {
         Double value = LAST_PRICES.get(stock);
         if (value == null) {
-            value = new Double(Math.random() * 100);
+            value = Double.valueOf(Math.random() * 100);
         }
 
         // lets mutate the value by some percentage
         double oldPrice = value.doubleValue();
-        value = new Double(mutatePrice(oldPrice));
+        value = Double.valueOf(mutatePrice(oldPrice));
         LAST_PRICES.put(stock, value);
         double price = value.doubleValue();
 


### PR DESCRIPTION
 - Remove unsused imports (exept for generated classes)
 - Convert to T.valueOf on boxed primitives from new T()