### PR TITLE
AMQ-8287 - fix NIOSSLTransport deadlock with serviceRead lock

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/transport/nio/AutoInitNioSSLTransport.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/transport/nio/AutoInitNioSSLTransport.java
@@ -158,9 +158,8 @@ public class AutoInitNioSSLTransport extends NIOSSLTransport {
         return readSize;
     }
 
-    //Prevent concurrent access to SSLEngine
     @Override
-    public synchronized void serviceRead() {
+    public void serviceRead() {
         try {
             if (handshakeInProgress) {
                 doHandshake();

--- a/activemq-client/src/main/java/org/apache/activemq/transport/nio/NIOSSLTransport.java
+++ b/activemq-client/src/main/java/org/apache/activemq/transport/nio/NIOSSLTransport.java
@@ -243,9 +243,8 @@ public class NIOSSLTransport extends NIOTransport {
         }
     }
 
-    //Prevent concurrent access to SSLEngine
     @Override
-    public synchronized void serviceRead() {
+    public void serviceRead() {
         try {
             if (handshakeInProgress) {
                 doHandshake();
@@ -374,7 +373,8 @@ public class NIOSSLTransport extends NIOTransport {
         }
     }
 
-    protected int secureRead(ByteBuffer plain) throws Exception {
+    //Prevent concurrent access while reading from the channel
+    protected synchronized int secureRead(ByteBuffer plain) throws Exception {
 
         if (!(inputBuffer.position() != 0 && inputBuffer.hasRemaining()) || status == SSLEngineResult.Status.BUFFER_UNDERFLOW) {
             int bytesRead = channel.read(inputBuffer);


### PR DESCRIPTION
This narrows the lock that was added to serviceRead() to secureRead()
which prevents processing commands while locked which should solve the
deadlock issues