### PR TITLE
[AMQ-7514] Deprecate configuration that uses non-inclusive language

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/broker/BrokerService.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/BrokerService.java
@@ -153,9 +153,6 @@ public class BrokerService implements Service {
     private boolean useLoggingForShutdownErrors;
     private boolean shutdownOnMasterFailure;
     private boolean shutdownOnSlaveFailure;
-    private boolean waitForSlave;
-    private long waitForSlaveTimeout = DEFAULT_START_TIMEOUT;
-    private boolean passiveSlave;
     private String brokerName = DEFAULT_BROKER_NAME;
     private File dataDirectoryFile;
     private File tmpDataDirectory;
@@ -517,7 +514,6 @@ public class BrokerService implements Service {
         if (startDate == null) {
             return 0;
         }
-
         return new Date().getTime() - startDate.getTime();
     }
 
@@ -771,7 +767,7 @@ public class BrokerService implements Service {
      * delegates to stop, done to prevent backwards incompatible signature change
      */
     @PreDestroy
-    private void preDestroy () {
+    private void preDestroy() {
         try {
             stop();
         } catch (Exception ex) {
@@ -2905,42 +2901,6 @@ public class BrokerService implements Service {
      */
     public void setShutdownOnSlaveFailure(boolean shutdownOnSlaveFailure) {
         this.shutdownOnSlaveFailure = shutdownOnSlaveFailure;
-    }
-
-    public boolean isWaitForSlave() {
-        return waitForSlave;
-    }
-
-    /**
-     * @org.apache.xbean.Property propertyEditor="org.apache.activemq.util.BooleanEditor"
-     */
-    public void setWaitForSlave(boolean waitForSlave) {
-        this.waitForSlave = waitForSlave;
-    }
-
-    public long getWaitForSlaveTimeout() {
-        return this.waitForSlaveTimeout;
-    }
-
-    public void setWaitForSlaveTimeout(long waitForSlaveTimeout) {
-        this.waitForSlaveTimeout = waitForSlaveTimeout;
-    }
-
-    /**
-     * Get the passiveSlave
-     * @return the passiveSlave
-     */
-    public boolean isPassiveSlave() {
-        return this.passiveSlave;
-    }
-
-    /**
-     * Set the passiveSlave
-     * @param passiveSlave the passiveSlave to set
-     * @org.apache.xbean.Property propertyEditor="org.apache.activemq.util.BooleanEditor"
-     */
-    public void setPassiveSlave(boolean passiveSlave) {
-        this.passiveSlave = passiveSlave;
     }
 
     /**

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/BrokerService.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/BrokerService.java
@@ -151,8 +151,8 @@ public class BrokerService implements Service {
 
     private boolean useShutdownHook = true;
     private boolean useLoggingForShutdownErrors;
-    private boolean shutdownOnMasterFailure;
-    private boolean shutdownOnSlaveFailure;
+    private boolean shutdownOnActiveFailure;
+    private boolean shutdownOnStandbyFailure;
     private String brokerName = DEFAULT_BROKER_NAME;
     private File dataDirectoryFile;
     private File tmpDataDirectory;
@@ -482,7 +482,7 @@ public class BrokerService implements Service {
     }
 
     public void masterFailed() {
-        if (shutdownOnMasterFailure) {
+        if (shutdownOnActiveFailure) {
             LOG.error("The Master has failed ... shutting down");
             try {
                 stop();
@@ -609,7 +609,7 @@ public class BrokerService implements Service {
                 }
             }
 
-            // in jvm master slave, lets not publish over existing broker till we get the lock
+            // in jvm active standby, lets not publish over existing broker till we get the lock
             final BrokerRegistry brokerRegistry = BrokerRegistry.getInstance();
             if (brokerRegistry.lookup(getBrokerName()) == null) {
                 brokerRegistry.bind(getBrokerName(), BrokerService.this);
@@ -731,7 +731,7 @@ public class BrokerService implements Service {
         if (isUseJmx()) {
             if (getManagementContext().isCreateConnector() && !getManagementContext().isConnectorStarted()) {
                 // try to restart management context
-                // typical for slaves that use the same ports as master
+                // typical for stanbdy instances that use the same ports as the active instance
                 managementContext.stop();
                 startManagementContext();
             }
@@ -1661,18 +1661,37 @@ public class BrokerService implements Service {
     }
 
     /**
+     * @deprecated AMQ-7514 in the move to inclusive nomenclature
      * @return Returns the shutdownOnMasterFailure.
      */
+    @Deprecated
     public boolean isShutdownOnMasterFailure() {
-        return shutdownOnMasterFailure;
+        return shutdownOnActiveFailure;
     }
 
     /**
+     * Configuration `shutdownOnMasterFailure` is deprecated and will be removed in a future release. Use `shutdownOnActiveFailure` instead.
+     * @deprecated AMQ-7514 in the move to inclusive nomenclature
      * @param shutdownOnMasterFailure
-     *            The shutdownOnMasterFailure to set.
      */
+    @Deprecated
     public void setShutdownOnMasterFailure(boolean shutdownOnMasterFailure) {
-        this.shutdownOnMasterFailure = shutdownOnMasterFailure;
+        this.shutdownOnActiveFailure = shutdownOnMasterFailure;
+        LOG.warn("Configuration `shutdownOnMasterFailure` is deprecated and will be removed in a future release. Use `shutdownOnActiveFailure` instead.");
+    }
+
+    /**
+     * @return Returns the shutdownOnActiveFailure.
+     */
+    public boolean isShutdownOnActiveFailure() {
+        return shutdownOnActiveFailure;
+    }
+
+    /**
+     * @param shutdownOnActiveFailure
+     */
+    public void setShutdownOnActiveFailure(boolean shutdownOnActiveFailure) {
+        this.shutdownOnActiveFailure = shutdownOnActiveFailure;
     }
 
     public boolean isKeepDurableSubsActive() {
@@ -1682,11 +1701,11 @@ public class BrokerService implements Service {
     public void setKeepDurableSubsActive(boolean keepDurableSubsActive) {
         this.keepDurableSubsActive = keepDurableSubsActive;
     }
-    
+
     public boolean isEnableMessageExpirationOnActiveDurableSubs() {
     	return enableMessageExpirationOnActiveDurableSubs;
     }
-    
+
     public void setEnableMessageExpirationOnActiveDurableSubs(boolean enableMessageExpirationOnActiveDurableSubs) {
     	this.enableMessageExpirationOnActiveDurableSubs = enableMessageExpirationOnActiveDurableSubs;
     }
@@ -2892,15 +2911,35 @@ public class BrokerService implements Service {
         this.sslContext = sslContext;
     }
 
+    /**
+     * @deprecated AMQ-7514 in the move to inclusive nomenclature
+     */
+    @Deprecated
     public boolean isShutdownOnSlaveFailure() {
-        return shutdownOnSlaveFailure;
+        return shutdownOnStandbyFailure;
+    }
+
+    /**
+     * Configuration `shutdownOnSlaveFailure` is deprecated and will be removed in a future release. Use `shutdownOnStandbyFailure` instead.
+     * @deprecated AMQ-7514 in the move to inclusive nomenclature
+     * @param shutdownOnSlaveFailure
+     * @org.apache.xbean.Property propertyEditor="org.apache.activemq.util.BooleanEditor"
+     */
+    @Deprecated
+    public void setShutdownOnSlaveFailure(boolean shutdownOnSlaveFailure) {
+        this.shutdownOnStandbyFailure = shutdownOnSlaveFailure;
+        LOG.warn("Configuration `shutdownOnSlaveFailure` is deprecated and will be removed in a future release. Use `shutdownOnStandbyFailure` instead.");
+    }
+
+    public boolean isShutdownOnStandbyFailure() {
+        return shutdownOnStandbyFailure;
     }
 
     /**
      * @org.apache.xbean.Property propertyEditor="org.apache.activemq.util.BooleanEditor"
      */
-    public void setShutdownOnSlaveFailure(boolean shutdownOnSlaveFailure) {
-        this.shutdownOnSlaveFailure = shutdownOnSlaveFailure;
+    public void setShutdownOnStandbyFailure(boolean shutdownOnStandbyFailure) {
+        this.shutdownOnStandbyFailure = shutdownOnStandbyFailure;
     }
 
     /**

--- a/activemq-jdbc-store/src/main/java/org/apache/activemq/store/jdbc/JDBCPersistenceAdapter.java
+++ b/activemq-jdbc-store/src/main/java/org/apache/activemq/store/jdbc/JDBCPersistenceAdapter.java
@@ -632,7 +632,7 @@ public class JDBCPersistenceAdapter extends DataSourceServiceSupport implements 
      * @deprecated use {@link #setUseLock(boolean)} instead
      *
      * Sets whether or not an exclusive database lock should be used to enable
-     * JDBC Master/Slave. Enabled by default.
+     * JDBC Active/Standby. Enabled by default.
      */
     @Deprecated
     public void setUseDatabaseLock(boolean useDatabaseLock) {

--- a/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/JournalPersistenceAdapterFactory.java
+++ b/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/JournalPersistenceAdapterFactory.java
@@ -199,7 +199,7 @@ public class JournalPersistenceAdapterFactory extends DataSourceServiceSupport i
 
     /**
      * Sets whether or not an exclusive database lock should be used to enable
-     * JDBC Master/Slave. Enabled by default.
+     * JDBC Active/Standby. Enabled by default.
      */
     public void setUseDatabaseLock(boolean useDatabaseLock) {
         jdbcPersistenceAdapter.setUseLock(useDatabaseLock);


### PR DESCRIPTION
This is the first in a series of changes that are planned to phase out non-inclusive terminology throughout the config, and codebase.