### PR TITLE
[AMQ-8350] ActiveMQMessage.getStringProperty() should exchange equals method call objects

### DIFF
--- a/activemq-client/src/main/java/org/apache/activemq/command/ActiveMQMessage.java
+++ b/activemq-client/src/main/java/org/apache/activemq/command/ActiveMQMessage.java
@@ -674,7 +674,7 @@ public class ActiveMQMessage extends Message implements org.apache.activemq.Mess
     @Override
     public String getStringProperty(String name) throws JMSException {
         Object value = null;
-        if (name.equals("JMSXUserID")) {
+        if ("JMSXUserID".equals(name)) {
             value = getUserID();
             if (value == null) {
                 value = getObjectProperty(name);


### PR DESCRIPTION
ActiveMQMessage.getStringProperty() should exchange equals method call objects,
and let `ActiveMQMessage.getObjectProperty()` do not null check, thanks
