### PR TITLE
[AMQ-8372] Allow custom delimiter when sending TextMessages via MBean

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/broker/jmx/DestinationView.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/jmx/DestinationView.java
@@ -336,7 +336,22 @@ public class DestinationView implements DestinationViewMBean {
 
     @Override
     public String sendTextMessageWithProperties(String properties) throws Exception {
-        String[] kvs = properties.split(",");
+        Map<String, String> props = parseProps(properties, ",");
+        return sendTextMessage(props, props.remove("body"), props.remove("username"), props.remove("password"));
+    }
+
+    @Override
+    public String sendTextMessageWithProperties(String properties, String delimiter) throws Exception {
+        if (delimiter == null || delimiter.isEmpty()) {
+            return sendTextMessageWithProperties(properties);
+        } else {
+            Map<String, String> props = parseProps(properties, delimiter);
+            return sendTextMessage(props, props.remove("body"), props.remove("username"), props.remove("password"));
+        }
+    }
+
+    private Map<String, String> parseProps(String properties, String delimiter) {
+        String[] kvs = properties.split(delimiter);
         Map<String, String> props = new HashMap<String, String>();
         for (String kv : kvs) {
             String[] it = kv.split("=");
@@ -344,7 +359,7 @@ public class DestinationView implements DestinationViewMBean {
                 props.put(it[0],it[1]);
             }
         }
-        return sendTextMessage(props, props.remove("body"), props.remove("username"), props.remove("password"));
+        return props;
     }
 
     @Override

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/jmx/DestinationViewMBean.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/jmx/DestinationViewMBean.java
@@ -168,13 +168,30 @@ public interface DestinationViewMBean {
     /**
      * Sends a TextMessage to the destination.
      *
-     * @param properties the message properties to set as a comma sep name=value list. Can only
-     *                contain Strings maped to primitive types or JMS properties. eg: body=hi,JMSReplyTo=Queue2
+     * @param properties the message properties to set as name=value list separated
+     *                   by a comma. Can only contain Strings mapped to primitive
+     *                   types or JMS properties. eg: body=hi,JMSReplyTo=Queue2
      * @return the message id of the message sent.
      * @throws Exception
      */
-    @MBeanInfo("Sends a TextMessage to the destination.")
-    public String sendTextMessageWithProperties(String properties) throws Exception;
+    @MBeanInfo("Sends a TextMessage to the destination using comma separeted properties list. Example properties: body=value,header=value")
+    public String sendTextMessageWithProperties(@MBeanInfo("properties") String properties) throws Exception;
+
+    /**
+     * Sends a TextMessage to the destination.
+     *
+     * @param properties the message properties to set as name=value list separated
+     *                   by a custom delimiter. Can only contain Strings mapped to
+     *                   primitive types or JMS properties. eg:
+     *                   body=hi,JMSReplyTo=Queue2
+     * @param delimiter  The delimiter that separates each property. Defaults to
+     *                   comma if none is provided.
+     * @return the message id of the message sent.
+     * @throws Exception
+     */
+    @MBeanInfo("Sends a TextMessage to the destination using properties separeted by arbetrary delimiter. Example properties: body=value;header=value")
+    public String sendTextMessageWithProperties(@MBeanInfo("properties") String properties,
+            @MBeanInfo("delimiter") String delimiter) throws Exception;
 
     /**
      * Sends a TextMesage to the destination.


### PR DESCRIPTION
### Problem
It is possible today through functionality of ```sendTextMessageWithProperties(...)``` to send a 
```TextMessage``` with jconsole containing properties. 

Input ```body=Hello World!,JMSCorrelationID=MyCorrId``` will result in message:

![image](https://user-images.githubusercontent.com/8479582/132107802-2ff04722-c694-4967-aa12-22551ffad2f0.png)

Given input of ```body=Hello, World!,JMSCorrelationID=MyCorrId``` we expect message body 
to contain Hello, World! and correlation id be set. Instead it will result in message:

![image](https://user-images.githubusercontent.com/8479582/132107807-0e4e1f3d-fe53-45e4-866b-884aff854b52.png)

### Why
I work with applications using in-memory brokers for development. It´s not uncommon for me to have to manually send
a text message to trigger a listener. The messages I send often include comma in the body, for example a json or a csv.

### Proposed solution
This PR enables possibility to provide own delimiter to the operation.
Given input of ```body=Hello, World!;JMSCorrelationID=MyCorrId``` and delimiter ```;``` results in 
expected message:

![image](https://user-images.githubusercontent.com/8479582/132107965-e559b83b-4831-4cbd-b2a0-b34d87500466.png)

