### PR TITLE
Fix for removed java.xml.bind dependency in Java 11

### DIFF
--- a/activemq-web/pom.xml
+++ b/activemq-web/pom.xml
@@ -122,6 +122,11 @@
       <groupId>com.thoughtworks.xstream</groupId>
       <artifactId>xstream</artifactId>
     </dependency>
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+      <version>2.3.1</version>
+    </dependency>
 
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
Without this change, in my local clone of the project (and Intellij) fails to build because there's no shipped version of `DataTypeConverter` that's referenced.