### PR TITLE
[Security] Fix user permissions in web console

### DIFF
--- a/assembly/src/release/conf/jetty.xml
+++ b/assembly/src/release/conf/jetty.xml
@@ -43,7 +43,7 @@
     </bean>
     <bean id="securityConstraintMapping" class="org.eclipse.jetty.security.ConstraintMapping">
         <property name="constraint" ref="securityConstraint" />
-        <property name="pathSpec" value="/*,/api/*,/admin/*,*.jsp" />
+        <property name="pathSpec" value="/,*.jsp,*.html,*.js,*.css,*.png,*.gif,*.ico" />
     </bean>
     <bean id="adminSecurityConstraintMapping" class="org.eclipse.jetty.security.ConstraintMapping">
         <property name="constraint" ref="adminSecurityConstraint" />


### PR DESCRIPTION
It unbelievable, but standard users had administrative permissions for the last 8 years since [this commit](https://github.com/apache/activemq/commit/75c659f122bc60a4e21da1f3bf3eadd227c49cbe#diff-71f952bc2da8f034245e7a495529308f986cce1d07143b5b961f93b03a860630R40) left a glaring security hole in a web console's configuration.

This patch plugs that hole.

Please apply it ASAP since default ActiveMQ configuration is used by hundreds of Docker images including [official GCP image](https://github.com/GoogleCloudPlatform/click-to-deploy/blob/d380caae20fa460182b7764c0e0d463a7f5917cb/docker/activemq/5/debian9/5.16/Dockerfile#L8) and ActiveMQ Kubernetes application on Google Marketplace which has [a simple configuration switch](https://github.com/GoogleCloudPlatform/click-to-deploy/blob/d380caae20fa460182b7764c0e0d463a7f5917cb/docker/activemq/5/debian9/5.16/docker-entrypoint.sh#L30) to allow exposure of ActiveMQ instance to the internet. Most of the system administrators are completely unaware that _user_/_user_ credentials exist, and even if they are, they have no idea that this user has administrative access. 

P.S. I have tested only /admin part, since I don't have /api configured. Somebody needs to test /api side. Probably it is better to move /api/* into adminSecurityConstraint altogether?