### PR TITLE
StatisticsBrokerPlugin: Add feature: request destination firstMessageTimestamp

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/broker/region/Topic.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/region/Topic.java
@@ -654,7 +654,7 @@ public class Topic extends BaseDestination implements Task {
         return result.toArray(new Message[result.size()]);
     }
 
-    private void doBrowse(final List<Message> browseList, final int max) {
+    public void doBrowse(final List<Message> browseList, final int max) {
         try {
             if (topicStore != null) {
                 final List<Message> toExpire = new ArrayList<Message>();

--- a/activemq-partition/src/test/java/org/apache/activemq/partition/PartitionBrokerTest.java
+++ b/activemq-partition/src/test/java/org/apache/activemq/partition/PartitionBrokerTest.java
@@ -17,7 +17,6 @@
 package org.apache.activemq.partition;
 
 import org.apache.activemq.ActiveMQConnectionFactory;
-import org.apache.activemq.AutoFailTestSupport;
 import org.apache.activemq.broker.BrokerPlugin;
 import org.apache.activemq.broker.BrokerService;
 import org.apache.activemq.broker.TransportConnector;


### PR DESCRIPTION
_(To main branch)_
Adding a feature (STATS_FIRST_MESSAGE_TIMESTAMP) to the StatisticsBrokerPlugin's destination-statistics for getting the
timestamp of the first message in the destination(s) being requested: If you on the query-message set the property StatisticsBroker.STATS_FIRST_MESSAGE_TIMESTAMP to anything (e.g. boolean true), a long value "firstMessageTimestamp" will be added to the statistics reply message(s). Since the reply message has JMSTimestamp set, which is the broker's now-timestamp, you may also on the query side calculate the age of the first message in milliseconds. The key name was chosen since that is the name of the corresponding feature in Artemis.

This extension of the existing feature is implemented to be as non-intrusive as possible, adding very little runtime cost if not requested. It also seems like the runtime cost for enabling this feature, thus finding and adding the firstMessageTimestamp, is small.

While at it, also slightly improving an existing feature (STATS_DENOTE_END_LIST) where a reply to a destination query can be
"null terminated": After sending the relevant replies, the StatisticsBroker also sends an empty message. This feature is relevant
if the query is a wildcard query, thus returning multiple messages: The empty message denotes the end of the replies. However, to activate this feature, a somewhat complicated query destination had to be constructed. Adopting the solution for the other StatisticsBroker feature where you may reset the broker statistics by adding a property to the query message, this null-termination feature now /also/ checks for the presence of this query modifier STATS_DENOTE_END_LIST as a property. (This property based solution was thus also adopted for the present 'firstMessageTimestamp' solution, as it was found much more intuitive).

Added tests for both the STATS_FIRST_MESSAGE_TIMESTAMP query modifier, and the improved STATS_DENOTE_END_LIST property-based query modifier.