### PR TITLE
AMQ-8488: fail 5.16.x build quickly+obviously if not run on Java 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,6 +146,7 @@
     <maven-javadoc-plugin-version>3.3.1</maven-javadoc-plugin-version>
     <maven-install-plugin-version>2.5.2</maven-install-plugin-version>
     <maven-shade-plugin-version>3.2.4</maven-shade-plugin-version>
+    <maven-enforcer-plugin-version>3.0.0</maven-enforcer-plugin-version>
     <findbugs-maven-plugin-version>3.0.1</findbugs-maven-plugin-version>
     <javacc-maven-plugin-version>2.6</javacc-maven-plugin-version>
     <cobertura-maven-plugin-version>2.5.2</cobertura-maven-plugin-version>
@@ -1175,6 +1176,11 @@
           </configuration>
         </plugin>
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <version>${maven-enforcer-plugin-version}</version>
+        </plugin>
+        <plugin>
           <groupId>org.apache.felix</groupId>
           <artifactId>maven-bundle-plugin</artifactId>
           <version>${maven-bundle-plugin-version}</version>
@@ -1324,6 +1330,7 @@
         </plugin>
       </plugins>
     </pluginManagement>
+
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -1477,6 +1484,26 @@
                     <goal>aggregate</goal>
                 </goals>
             </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>enforce-java-version</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireJavaVersion>
+                  <version>[1.8, 9)</version>
+                  <message>You must use Java 8 to build.</message>
+                </requireJavaVersion>
+              </rules>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
     </plugins>


### PR DESCRIPTION
5.16.x must be built with Java 8. Main requires Java 11+. Many people just have Java 11 defaults now regardless.

This enforces the restriction to make it fail quickly+obviously to aid during mismatches or slips when switching back and forth.