### PR TITLE
AMQ-8520: Re-enable all modules to compile and build by default

### DIFF
--- a/activemq-itests-spring31/pom.xml
+++ b/activemq-itests-spring31/pom.xml
@@ -83,4 +83,25 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <profiles>
+    <profile>
+      <!-- Default - no tests -->
+      <id>default</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <skipTests>true</skipTests>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/activemq-karaf-itest/pom.xml
+++ b/activemq-karaf-itest/pom.xml
@@ -139,8 +139,18 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -221,6 +231,24 @@
   </build>
 
   <profiles>
+    <profile>
+      <!-- Default - no tests -->
+      <id>default</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <skipTests>true</skipTests>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
     <profile>
       <id>ci-build-profile</id>
       <activation>

--- a/activemq-osgi/pom.xml
+++ b/activemq-osgi/pom.xml
@@ -499,15 +499,15 @@
           <optional>true</optional>
         </dependency>
         <dependency>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-log4j12</artifactId>
-          <version>${slf4j-version}</version>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-slf4j-impl</artifactId>
+          <version>${log4j-version}</version>
           <classifier>sources</classifier>
           <optional>true</optional>
         </dependency>
         <dependency>
-          <groupId>log4j</groupId>
-          <artifactId>log4j</artifactId>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-core</artifactId>
           <version>${log4j-version}</version>
           <classifier>sources</classifier>
           <optional>true</optional>

--- a/activemq-tooling/activemq-perf-maven-plugin/pom.xml
+++ b/activemq-tooling/activemq-perf-maven-plugin/pom.xml
@@ -76,10 +76,5 @@
       <artifactId>slf4j-simple</artifactId>
       <version>${slf4j-version}</version>
     </dependency>
-    <!-- dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-    </dependency -->
-
   </dependencies>
 </project>

--- a/activemq-unit-tests/pom.xml
+++ b/activemq-unit-tests/pom.xml
@@ -184,13 +184,18 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -260,9 +265,8 @@
     </dependency>
     <dependency>
       <!-- using it for Jetty's JNDI context to work /w Joram tests. -->
-      <groupId>org.eclipse.jetty.aggregate</groupId>
-      <artifactId>jetty-all</artifactId>
-      <classifier>uber</classifier>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-jndi</artifactId>
       <scope>test</scope>
     </dependency>
 
@@ -507,6 +511,24 @@
   </build>
   <profiles>
     <profile>
+      <!-- Default - no tests -->
+      <id>default</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <skipTests>true</skipTests>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
       <id>activemq.tests-all</id>
       <activation>
         <property>
@@ -595,9 +617,9 @@
     <profile>
       <id>activemq.exclude-broken-tests</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
         <property>
           <name>activemq.tests</name>
+          <value>excludeBroken</value>
         </property>
       </activation>
       <build>
@@ -653,7 +675,10 @@
     <profile>
       <id>activemq.tests-quick</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>activemq.tests</name>
+          <value>quick</value>
+        </property>
       </activation>
       <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -212,6 +212,7 @@
     <module>activemq-amqp</module>
     <module>activemq-kahadb-store</module>
     <module>activemq-jdbc-store</module>
+    <module>activemq-unit-tests</module>
     <module>activemq-all</module>
     <module>activemq-console</module>
     <module>activemq-jaas</module>
@@ -232,6 +233,8 @@
     <module>activemq-blueprint</module>
     <module>activemq-web-demo</module>
     <module>activemq-web-console</module>
+    <module>activemq-karaf-itest</module>
+    <module>activemq-itests-spring31</module>
     <module>assembly</module>
     <module>activemq-log4j-appender</module>
     <module>activemq-http</module>
@@ -1515,15 +1518,6 @@
   </reporting>
 
   <profiles>
-
-    <profile>
-      <id>full.test</id>
-      <modules>
-        <module>activemq-unit-tests</module>
-        <module>activemq-karaf-itest</module>
-        <module>activemq-itests-spring31</module>
-      </modules>
-    </profile>
 
     <!-- If you enable this profile, the console message will have a timestamp -->
     <profile>


### PR DESCRIPTION
Updates the modules part of the previous full.test profile to always
build but skip running tests by default.

Also fixed miss dependency updates including log4j and jetty
