### PR TITLE
[AMQ-8317] Use inclusive terminology in logs and errors

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/advisory/AdvisoryBroker.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/advisory/AdvisoryBroker.java
@@ -756,7 +756,7 @@ public class AdvisoryBroker extends BrokerFilter {
             context.setBroker(getBrokerService().getBroker());
             fireAdvisory(context, topic, null, null, advisoryMessage);
         } catch (Exception e) {
-            handleFireFailure("now master broker", e);
+            handleFireFailure("now Active broker", e);
         }
     }
 

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/BrokerService.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/BrokerService.java
@@ -483,14 +483,14 @@ public class BrokerService implements Service {
 
     public void masterFailed() {
         if (shutdownOnActiveFailure) {
-            LOG.error("The Master has failed ... shutting down");
+            LOG.error("The Active has failed ... shutting down");
             try {
                 stop();
             } catch (Exception e) {
-                LOG.error("Failed to stop for master failure", e);
+                LOG.error("Failed to stop for Active failure", e);
             }
         } else {
-            LOG.warn("Master Failed - starting all connectors");
+            LOG.warn("Active Failed - starting all connectors");
             try {
                 startAllConnectors();
                 broker.nowMasterBroker();

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/BrokerService.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/BrokerService.java
@@ -153,9 +153,6 @@ public class BrokerService implements Service {
     private boolean useLoggingForShutdownErrors;
     private boolean shutdownOnMasterFailure;
     private boolean shutdownOnSlaveFailure;
-    private boolean waitForSlave;
-    private long waitForSlaveTimeout = DEFAULT_START_TIMEOUT;
-    private boolean passiveSlave;
     private String brokerName = DEFAULT_BROKER_NAME;
     private File dataDirectoryFile;
     private File tmpDataDirectory;
@@ -517,7 +514,6 @@ public class BrokerService implements Service {
         if (startDate == null) {
             return 0;
         }
-
         return new Date().getTime() - startDate.getTime();
     }
 
@@ -771,7 +767,7 @@ public class BrokerService implements Service {
      * delegates to stop, done to prevent backwards incompatible signature change
      */
     @PreDestroy
-    private void preDestroy () {
+    private void preDestroy() {
         try {
             stop();
         } catch (Exception ex) {
@@ -2905,42 +2901,6 @@ public class BrokerService implements Service {
      */
     public void setShutdownOnSlaveFailure(boolean shutdownOnSlaveFailure) {
         this.shutdownOnSlaveFailure = shutdownOnSlaveFailure;
-    }
-
-    public boolean isWaitForSlave() {
-        return waitForSlave;
-    }
-
-    /**
-     * @org.apache.xbean.Property propertyEditor="org.apache.activemq.util.BooleanEditor"
-     */
-    public void setWaitForSlave(boolean waitForSlave) {
-        this.waitForSlave = waitForSlave;
-    }
-
-    public long getWaitForSlaveTimeout() {
-        return this.waitForSlaveTimeout;
-    }
-
-    public void setWaitForSlaveTimeout(long waitForSlaveTimeout) {
-        this.waitForSlaveTimeout = waitForSlaveTimeout;
-    }
-
-    /**
-     * Get the passiveSlave
-     * @return the passiveSlave
-     */
-    public boolean isPassiveSlave() {
-        return this.passiveSlave;
-    }
-
-    /**
-     * Set the passiveSlave
-     * @param passiveSlave the passiveSlave to set
-     * @org.apache.xbean.Property propertyEditor="org.apache.activemq.util.BooleanEditor"
-     */
-    public void setPassiveSlave(boolean passiveSlave) {
-        this.passiveSlave = passiveSlave;
     }
 
     /**

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/BrokerService.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/BrokerService.java
@@ -151,8 +151,8 @@ public class BrokerService implements Service {
 
     private boolean useShutdownHook = true;
     private boolean useLoggingForShutdownErrors;
-    private boolean shutdownOnMasterFailure;
-    private boolean shutdownOnSlaveFailure;
+    private boolean shutdownOnActiveFailure;
+    private boolean shutdownOnStandbyFailure;
     private String brokerName = DEFAULT_BROKER_NAME;
     private File dataDirectoryFile;
     private File tmpDataDirectory;
@@ -482,7 +482,7 @@ public class BrokerService implements Service {
     }
 
     public void masterFailed() {
-        if (shutdownOnMasterFailure) {
+        if (shutdownOnActiveFailure) {
             LOG.error("The Master has failed ... shutting down");
             try {
                 stop();
@@ -609,7 +609,7 @@ public class BrokerService implements Service {
                 }
             }
 
-            // in jvm master slave, lets not publish over existing broker till we get the lock
+            // in jvm active standby, lets not publish over existing broker till we get the lock
             final BrokerRegistry brokerRegistry = BrokerRegistry.getInstance();
             if (brokerRegistry.lookup(getBrokerName()) == null) {
                 brokerRegistry.bind(getBrokerName(), BrokerService.this);
@@ -731,7 +731,7 @@ public class BrokerService implements Service {
         if (isUseJmx()) {
             if (getManagementContext().isCreateConnector() && !getManagementContext().isConnectorStarted()) {
                 // try to restart management context
-                // typical for slaves that use the same ports as master
+                // typical for stanbdy instances that use the same ports as the active instance
                 managementContext.stop();
                 startManagementContext();
             }
@@ -1661,18 +1661,37 @@ public class BrokerService implements Service {
     }
 
     /**
+     * @deprecated AMQ-7514 in the move to inclusive nomenclature
      * @return Returns the shutdownOnMasterFailure.
      */
+    @Deprecated
     public boolean isShutdownOnMasterFailure() {
-        return shutdownOnMasterFailure;
+        return shutdownOnActiveFailure;
     }
 
     /**
+     * Configuration `shutdownOnMasterFailure` is deprecated and will be removed in a future release. Use `shutdownOnActiveFailure` instead.
+     * @deprecated AMQ-7514 in the move to inclusive nomenclature
      * @param shutdownOnMasterFailure
-     *            The shutdownOnMasterFailure to set.
      */
+    @Deprecated
     public void setShutdownOnMasterFailure(boolean shutdownOnMasterFailure) {
-        this.shutdownOnMasterFailure = shutdownOnMasterFailure;
+        this.shutdownOnActiveFailure = shutdownOnMasterFailure;
+        LOG.warn("Configuration `shutdownOnMasterFailure` is deprecated and will be removed in a future release. Use `shutdownOnActiveFailure` instead.");
+    }
+
+    /**
+     * @return Returns the shutdownOnActiveFailure.
+     */
+    public boolean isShutdownOnActiveFailure() {
+        return shutdownOnActiveFailure;
+    }
+
+    /**
+     * @param shutdownOnActiveFailure
+     */
+    public void setShutdownOnActiveFailure(boolean shutdownOnActiveFailure) {
+        this.shutdownOnActiveFailure = shutdownOnActiveFailure;
     }
 
     public boolean isKeepDurableSubsActive() {
@@ -1682,11 +1701,11 @@ public class BrokerService implements Service {
     public void setKeepDurableSubsActive(boolean keepDurableSubsActive) {
         this.keepDurableSubsActive = keepDurableSubsActive;
     }
-    
+
     public boolean isEnableMessageExpirationOnActiveDurableSubs() {
     	return enableMessageExpirationOnActiveDurableSubs;
     }
-    
+
     public void setEnableMessageExpirationOnActiveDurableSubs(boolean enableMessageExpirationOnActiveDurableSubs) {
     	this.enableMessageExpirationOnActiveDurableSubs = enableMessageExpirationOnActiveDurableSubs;
     }
@@ -2892,15 +2911,35 @@ public class BrokerService implements Service {
         this.sslContext = sslContext;
     }
 
+    /**
+     * @deprecated AMQ-7514 in the move to inclusive nomenclature
+     */
+    @Deprecated
     public boolean isShutdownOnSlaveFailure() {
-        return shutdownOnSlaveFailure;
+        return shutdownOnStandbyFailure;
+    }
+
+    /**
+     * Configuration `shutdownOnSlaveFailure` is deprecated and will be removed in a future release. Use `shutdownOnStandbyFailure` instead.
+     * @deprecated AMQ-7514 in the move to inclusive nomenclature
+     * @param shutdownOnSlaveFailure
+     * @org.apache.xbean.Property propertyEditor="org.apache.activemq.util.BooleanEditor"
+     */
+    @Deprecated
+    public void setShutdownOnSlaveFailure(boolean shutdownOnSlaveFailure) {
+        this.shutdownOnStandbyFailure = shutdownOnSlaveFailure;
+        LOG.warn("Configuration `shutdownOnSlaveFailure` is deprecated and will be removed in a future release. Use `shutdownOnStandbyFailure` instead.");
+    }
+
+    public boolean isShutdownOnStandbyFailure() {
+        return shutdownOnStandbyFailure;
     }
 
     /**
      * @org.apache.xbean.Property propertyEditor="org.apache.activemq.util.BooleanEditor"
      */
-    public void setShutdownOnSlaveFailure(boolean shutdownOnSlaveFailure) {
-        this.shutdownOnSlaveFailure = shutdownOnSlaveFailure;
+    public void setShutdownOnStandbyFailure(boolean shutdownOnStandbyFailure) {
+        this.shutdownOnStandbyFailure = shutdownOnStandbyFailure;
     }
 
     /**

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/LockableServiceSupport.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/LockableServiceSupport.java
@@ -156,7 +156,7 @@ public abstract class LockableServiceSupport extends ServiceSupport implements L
 
     protected void stopBroker() {
         // we can no longer keep the lock so lets fail
-        LOG.error("{}, no longer able to keep the exclusive lock so giving up being a master", brokerService.getBrokerName());
+        LOG.error("{}, no longer able to keep the exclusive lock so giving up being Active", brokerService.getBrokerName());
         try {
             if( brokerService.isRestartAllowed() ) {
                 brokerService.requestRestart();

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/region/AbstractRegion.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/region/AbstractRegion.java
@@ -574,7 +574,7 @@ public abstract class AbstractRegion implements Region {
         if (sub != null) {
             sub.processMessageDispatchNotification(messageDispatchNotification);
         } else {
-            throw new JMSException("Slave broker out of sync with master - Subscription: "
+            throw new JMSException("Standby broker out of sync with Active - Subscription: "
                     + messageDispatchNotification.getConsumerId() + " on "
                     + messageDispatchNotification.getDestination() + " does not exist for dispatch of message: "
                     + messageDispatchNotification.getMessageId());
@@ -599,7 +599,7 @@ public abstract class AbstractRegion implements Region {
         if (dest != null) {
             dest.processDispatchNotification(messageDispatchNotification);
         } else {
-            throw new JMSException("Slave broker out of sync with master - Destination: "
+            throw new JMSException("Standby broker out of sync with Active - Destination: "
                     + messageDispatchNotification.getDestination() + " does not exist for consumer "
                     + messageDispatchNotification.getConsumerId() + " with message: "
                     + messageDispatchNotification.getMessageId());

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/region/PrefetchSubscription.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/region/PrefetchSubscription.java
@@ -184,7 +184,7 @@ public abstract class PrefetchSubscription extends AbstractSubscription {
             }
         }
         throw new JMSException(
-                "Slave broker out of sync with master: Dispatched message ("
+                "Standby broker out of sync with Active: Dispatched message ("
                         + mdn.getMessageId() + ") was not in the pending list for "
                         + mdn.getConsumerId() + " on " + mdn.getDestination().getPhysicalName());
     }

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/region/Queue.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/region/Queue.java
@@ -2396,7 +2396,7 @@ public class Queue extends BaseDestination implements Task, UsageListener, Index
         }
 
         if (message == null) {
-            throw new JMSException("Slave broker out of sync with master - Message: "
+            throw new JMSException("Standby broker out of sync with Active - Message: "
                     + messageDispatchNotification.getMessageId() + " on "
                     + messageDispatchNotification.getDestination() + " does not exist among pending("
                     + dispatchPendingList.size() + ") for subscription: "

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/util/LoggingBrokerPlugin.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/util/LoggingBrokerPlugin.java
@@ -576,7 +576,7 @@ public class LoggingBrokerPlugin extends BrokerPluginSupport {
     @Override
     public void nowMasterBroker() {
         if (isLogAll() || isLogInternalEvents()) {
-            LOG.info("Is now the master broker: {}", getBrokerName());
+            LOG.info("Is now the Active broker: {}", getBrokerName());
         }
         super.nowMasterBroker();
     }

--- a/activemq-broker/src/main/java/org/apache/activemq/store/SharedFileLocker.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/store/SharedFileLocker.java
@@ -65,11 +65,11 @@ public class SharedFileLocker extends AbstractLocker {
                         locked = keepAlive();
                         break;
                     } catch (IOException e) {
-                        if (!warned)
-                        {
+                        if (!warned) {
                             LOG.info("Database "
-                                         + lockFileName
-                                         + " is locked by another server. This broker is now in slave mode waiting a lock to be acquired");
+                                + lockFileName
+                                + " is locked by another server."
+                                + " This broker is now in Active mode waiting a lock to be acquired");
                             warned = true;
                         }
 

--- a/activemq-client/src/main/java/org/apache/activemq/transport/discovery/masterslave/MasterSlaveDiscoveryAgent.java
+++ b/activemq-client/src/main/java/org/apache/activemq/transport/discovery/masterslave/MasterSlaveDiscoveryAgent.java
@@ -59,7 +59,7 @@ public class MasterSlaveDiscoveryAgent extends SimpleDiscoveryAgent {
 
     protected void configureServices() {
         if ((msServices == null) || (msServices.length < 2)) {
-            LOG.error("masterSlave requires at least 2 URIs");
+            LOG.error("Active/Standby (masterSlave) requires at least 2 URIs");
             msServices = new String[]{};
             throw new IllegalArgumentException("Expecting at least 2 arguments");
         }

--- a/activemq-jdbc-store/src/main/java/org/apache/activemq/store/jdbc/DefaultDatabaseLocker.java
+++ b/activemq-jdbc-store/src/main/java/org/apache/activemq/store/jdbc/DefaultDatabaseLocker.java
@@ -42,8 +42,7 @@ public class DefaultDatabaseLocker extends AbstractJDBCLocker {
     protected Handler<Exception> exceptionHandler;
 
     public void doStart() throws Exception {
-
-        LOG.info("Attempting to acquire the exclusive lock to become the Master broker");
+        LOG.info("Attempting to acquire the exclusive lock to become the Active broker");
         String sql = getStatements().getLockCreateStatement();
         LOG.debug("Locking Query is "+sql);
         
@@ -111,11 +110,11 @@ public class DefaultDatabaseLocker extends AbstractJDBCLocker {
             try {
                 Thread.sleep(lockAcquireSleepInterval);
             } catch (InterruptedException ie) {
-                LOG.warn("Master lock retry sleep interrupted", ie);
+                LOG.warn("Active lock retry sleep interrupted", ie);
             }
         }
 
-        LOG.info("Becoming the master on dataSource: " + dataSource);
+        LOG.info("Becoming the Active on dataSource: " + dataSource);
     }
 
     public void doStop(ServiceStopper stopper) throws Exception {

--- a/activemq-jdbc-store/src/main/java/org/apache/activemq/store/jdbc/JDBCPersistenceAdapter.java
+++ b/activemq-jdbc-store/src/main/java/org/apache/activemq/store/jdbc/JDBCPersistenceAdapter.java
@@ -632,7 +632,7 @@ public class JDBCPersistenceAdapter extends DataSourceServiceSupport implements 
      * @deprecated use {@link #setUseLock(boolean)} instead
      *
      * Sets whether or not an exclusive database lock should be used to enable
-     * JDBC Master/Slave. Enabled by default.
+     * JDBC Active/Standby. Enabled by default.
      */
     @Deprecated
     public void setUseDatabaseLock(boolean useDatabaseLock) {

--- a/activemq-jdbc-store/src/main/java/org/apache/activemq/store/jdbc/LeaseDatabaseLocker.java
+++ b/activemq-jdbc-store/src/main/java/org/apache/activemq/store/jdbc/LeaseDatabaseLocker.java
@@ -52,7 +52,7 @@ public class LeaseDatabaseLocker extends AbstractJDBCLocker {
                     + ", the lease duration. These values will allow the lease to expire.");
         }
 
-        LOG.info(getLeaseHolderId() + " attempting to acquire exclusive lease to become the master");
+        LOG.info(getLeaseHolderId() + " attempting to acquire exclusive lease to become the Active");
         String sql = getStatements().getLeaseObtainStatement();
         LOG.debug(getLeaseHolderId() + " locking Query is "+sql);
 
@@ -105,7 +105,10 @@ public class LeaseDatabaseLocker extends AbstractJDBCLocker {
             throw new RuntimeException(getLeaseHolderId() + " failing lease acquire due to stop");
         }
 
-        LOG.info(getLeaseHolderId() + ", becoming master with lease expiry " + new Date(now + lockAcquireSleepInterval) + " on dataSource: " + dataSource);
+        LOG.info("{}, becoming Active with lease expiry {} on dataSource: {}",
+            getLeaseHolderId(),
+            new Date(now + lockAcquireSleepInterval),
+            dataSource);
     }
 
     private void reportLeasOwnerShipAndDuration(Connection connection) throws SQLException {

--- a/activemq-jdbc-store/src/main/java/org/apache/activemq/store/jdbc/adapter/TransactDatabaseLocker.java
+++ b/activemq-jdbc-store/src/main/java/org/apache/activemq/store/jdbc/adapter/TransactDatabaseLocker.java
@@ -16,15 +16,12 @@
  */
 package org.apache.activemq.store.jdbc.adapter;
 
-import java.io.IOException;
+import org.apache.activemq.store.jdbc.DefaultDatabaseLocker;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-
-import org.apache.activemq.store.jdbc.DefaultDatabaseLocker;
-import org.apache.activemq.store.jdbc.JDBCPersistenceAdapter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Represents an exclusive lock on a database to avoid multiple brokers running
@@ -38,8 +35,7 @@ public class TransactDatabaseLocker extends DefaultDatabaseLocker {
     
     @Override
     public void doStart() throws Exception {
-
-        LOG.info("Attempting to acquire the exclusive lock to become the Master broker");
+        LOG.info("Attempting to acquire the exclusive lock to become the Active broker");
         PreparedStatement statement = null;
         while (true) {
             try {
@@ -87,11 +83,11 @@ public class TransactDatabaseLocker extends DefaultDatabaseLocker {
             try {
             	Thread.sleep(lockAcquireSleepInterval);
             } catch (InterruptedException ie) {
-            	LOG.warn("Master lock retry sleep interrupted", ie);
+                LOG.warn("Active lock retry sleep interrupted", ie);
             }
         }
 
-        LOG.info("Becoming the master on dataSource: " + dataSource);
+        LOG.info("Becoming the Active on dataSource: {}", dataSource);
     }
 
 }

--- a/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/JournalPersistenceAdapterFactory.java
+++ b/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/JournalPersistenceAdapterFactory.java
@@ -199,7 +199,7 @@ public class JournalPersistenceAdapterFactory extends DataSourceServiceSupport i
 
     /**
      * Sets whether or not an exclusive database lock should be used to enable
-     * JDBC Master/Slave. Enabled by default.
+     * JDBC Active/Standby. Enabled by default.
      */
     public void setUseDatabaseLock(boolean useDatabaseLock) {
         jdbcPersistenceAdapter.setUseLock(useDatabaseLock);


### PR DESCRIPTION
This PR supercedes that of #679, #700, #714 to remove the toggling of inclusive terminology. In effect this PR does:

- Removal of unused methods in `BrokerService` (non-inclusive terminology)
- Add deprecation warning for config that uses non-inclusive language
- Adjust messaging in logging/erros to use inclusive terminology