### PR TITLE
add the capability to override memory options

### DIFF
--- a/assembly/src/release/bin/env
+++ b/assembly/src/release/bin/env
@@ -30,8 +30,9 @@
 # ACTIVEMQ_TMP="$ACTIVEMQ_BASE/tmp"
 
 # Set jvm memory configuration (minimal/maximum amount of memory)
-ACTIVEMQ_OPTS_MEMORY="-Xms64M -Xmx1G"
-
+if [ -z "$ACTIVEMQ_OPTS_MEMORY" ] ; then
+    ACTIVEMQ_OPTS_MEMORY="-Xms64M -Xmx1G"
+fi
 if [ -z "$ACTIVEMQ_OPTS" ] ; then
     ACTIVEMQ_OPTS="$ACTIVEMQ_OPTS_MEMORY -Djava.util.logging.config.file=logging.properties -Djava.security.auth.login.config=$ACTIVEMQ_CONF/login.config"
 fi


### PR DESCRIPTION
since the last release , the xmx and xms are hardcoded on `env` , the goal is to use ACTIVEMQ_OPTS_MEMORY environement variable if needed to override memory options