### PR TITLE
AMQ-8528: Fix test failures in integration module

### DIFF
--- a/activemq-unit-tests/pom.xml
+++ b/activemq-unit-tests/pom.xml
@@ -1074,6 +1074,11 @@
                 <exclude>org/apache/activemq/store/kahadb/disk/util/DataByteArrayInputStreamTest.*</exclude>
                 <exclude>org/apache/activemq/bugs/AMQ5266StarvedConsumerTest.*</exclude>
                 <exclude>org/apache/activemq/bugs/AMQ5266Test.*</exclude>
+
+                <!--Broken tests -->
+                <exclude>**/NetworkFailoverTest.*/**</exclude>
+                <!-- This test only works on machines which have ssh properly configured -->
+                <exclude>**/SSHTunnelNetworkReconnectTest.*</exclude>
               </excludes>
             </configuration>
           </plugin>

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/broker/BrokerRedeliveryTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/broker/BrokerRedeliveryTest.java
@@ -146,6 +146,7 @@ public class BrokerRedeliveryTest extends org.apache.activemq.TestSupport {
 
         PolicyEntry policyEntry = new PolicyEntry();
         policyEntry.setUseCache(false); // disable the cache such that duplicates are not suppressed on send
+        policyEntry.setSendDuplicateFromStoreToDLQ(true);
 
         PolicyMap policyMap = new PolicyMap();
         policyMap.setDefaultEntry(policyEntry);

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/bugs/AMQ3537Test.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/bugs/AMQ3537Test.java
@@ -51,7 +51,7 @@ import org.junit.Test;
 public class AMQ3537Test implements InvocationHandler, Serializable {
 
     static {
-        System.setProperty("org.apache.activemq.SERIALIZABLE_PACKAGES", "java.util,org.apache.activemq.bugs");
+        System.setProperty("org.apache.activemq.SERIALIZABLE_PACKAGES", "com.sun.proxy,java.util,org.apache.activemq.bugs");
     }
 
     private static final long serialVersionUID = 1L;

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/bugs/AMQ4952Test.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/bugs/AMQ4952Test.java
@@ -418,6 +418,7 @@ public class AMQ4952Test {
         policy.setQueue(">");
         policy.setEnableAudit(enableCursorAudit);
         policy.setExpireMessagesPeriod(0);
+        policy.setSendDuplicateFromStoreToDLQ(true);
 
         // set replay with no consumers
         ConditionalNetworkBridgeFilterFactory conditionalNetworkBridgeFilterFactory = new ConditionalNetworkBridgeFilterFactory();

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/network/DurableFiveBrokerNetworkBridgeTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/network/DurableFiveBrokerNetworkBridgeTest.java
@@ -52,6 +52,7 @@ public class DurableFiveBrokerNetworkBridgeTest extends JmsMultipleBrokersTestSu
         NetworkConnector connector = super.bridgeBrokers(localBrokerName, remoteBrokerName);
         ArrayList<ActiveMQDestination> includedDestinations = new ArrayList<>();
         includedDestinations.add(new ActiveMQTopic("TEST.FOO?forceDurable=true"));
+        connector.setDynamicallyIncludedDestinations(includedDestinations);
         connector.setDuplex(duplex);
         connector.setDecreaseNetworkConsumerPriority(false);
         connector.setConduitSubscriptions(true);

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/store/jdbc/JDBCConcurrentDLQTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/store/jdbc/JDBCConcurrentDLQTest.java
@@ -72,7 +72,8 @@ public class JDBCConcurrentDLQTest {
         appender = new AbstractAppender("testAppender", new AbstractFilter() {}, new MessageLayout(), false, new Property[0]) {
             @Override
             public void append(LogEvent event) {
-                if (event.getLevel().isMoreSpecificThan(Level.INFO)) {
+                //isMoreSpecificThan is actually greather or equal so poorly named
+                if (event.getLevel().isMoreSpecificThan(Level.WARN)) {
                     LOG.error("Got error from log:" + event.getMessage().getFormattedMessage());
                     gotError.set(true);
                 }

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/usecases/OfflineDurableSubscriberTimeoutTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/usecases/OfflineDurableSubscriberTimeoutTest.java
@@ -128,7 +128,8 @@ public class OfflineDurableSubscriberTimeoutTest extends org.apache.activemq.Tes
         final var appender = new AbstractAppender("testAppender", new AbstractFilter() {}, new MessageLayout(), false, new Property[0]) {
             @Override
             public void append(LogEvent event) {
-                if (event.getLevel().isLessSpecificThan(Level.WARN)) {
+                if (event.getLevel().isMoreSpecificThan(Level.WARN) &&
+                    !event.getMessage().getFormattedMessage().contains("Store limit")) {
                     LOG.info("received unexpected log message: " + event.getMessage());
                     foundLogMessage.set(true);
                 }

--- a/activemq-unit-tests/src/test/resources/spring-embedded-xbean-local.xml
+++ b/activemq-unit-tests/src/test/resources/spring-embedded-xbean-local.xml
@@ -44,7 +44,7 @@
       <!-- lets wrap in a pool to avoid creating a connection per send -->
       <bean class="org.springframework.jms.connection.SingleConnectionFactory">
         <property name="targetConnectionFactory">
-          <ref local="jmsFactory" />
+          <ref bean="jmsFactory" />
         </property>
       </bean>
     </property>

--- a/activemq-unit-tests/src/test/resources/spring-embedded-xbean.xml
+++ b/activemq-unit-tests/src/test/resources/spring-embedded-xbean.xml
@@ -44,7 +44,7 @@
       <!-- lets wrap in a pool to avoid creating a connection per send -->
       <bean class="org.springframework.jms.connection.SingleConnectionFactory">
         <property name="targetConnectionFactory">
-          <ref local="jmsFactory" />
+          <ref bean="jmsFactory" />
         </property>
       </bean>
     </property>

--- a/activemq-unit-tests/src/test/resources/spring-embedded.xml
+++ b/activemq-unit-tests/src/test/resources/spring-embedded.xml
@@ -36,7 +36,7 @@
             <!-- lets wrap in a pool to avoid creating a connection per send -->
             <bean class="org.springframework.jms.connection.SingleConnectionFactory">
                 <property name="targetConnectionFactory">
-                    <ref local="jmsFactory"/>
+                    <ref bean="jmsFactory"/>
                 </property>
             </bean>
         </property>

--- a/activemq-unit-tests/src/test/resources/spring-queue.xml
+++ b/activemq-unit-tests/src/test/resources/spring-queue.xml
@@ -31,7 +31,7 @@
       <!-- lets wrap in a pool to avoid creating a connection per send -->
       <bean class="org.springframework.jms.connection.SingleConnectionFactory">
         <property name="targetConnectionFactory">
-          <ref local="jmsFactory"/>
+          <ref bean="jmsFactory"/>
         </property>
       </bean>
     </property>

--- a/activemq-unit-tests/src/test/resources/spring.xml
+++ b/activemq-unit-tests/src/test/resources/spring.xml
@@ -31,7 +31,7 @@
       <!-- lets wrap in a pool to avoid creating a connection per send -->
       <bean class="org.springframework.jms.connection.SingleConnectionFactory">
         <property name="targetConnectionFactory">
-          <ref local="jmsFactory"/>
+          <ref bean="jmsFactory"/>
         </property>
       </bean>
     </property>


### PR DESCRIPTION
**Broken Tests Fixed by this PR:**
- [x] org.apache.activemq.network.DurableFiveBrokerNetworkBridgeTest
- [x] org.apache.activemq.spring.SpringTest
- [x] org.apache.activemq.broker.BrokerRedeliveryTest
- [x] org.apache.activemq.bugs.AMQ3537Test
- [x] org.apache.activemq.bugs.AMQ4952Test
- [x] org.apache.activemq.usecases.OfflineDurableSubscriberTimeoutTest
- [x] org.apache.activemq.store.jdbc.JDBCConcurrentDLQTest

**Broken Tests already fixed in main: (JMS 2.0, only applies to 5.18.x so don't need to backport)**
- [x] org.apache.activemq.bugs.AMQ6122Test (this works fine in 5.17.x)
- [x] org.apache.activemq.bugs.AMQ5212Test

**Broken Tests already fixed in another PR:**
- [x] org.apache.activemq.broker.virtual.MessageDestinationVirtualTopicTest - Fixed here: https://github.com/apache/activemq/pull/796 - This can be backported to 5.17.1

The issue is Spring 5.3 seems to require an updated annotation spec. geronimo-annotation_1.0_spec is too old. However, it's broken due to @Resource annotation usage which we only used in a couple unit tests. The jar is marked as optional and it's never used anywhere in the real codebase so the broker will run out of the box just fine. I think we can just fix/update this in 5.17.1 and 5.18.0 because if someone is using that annotation in their own code and Spring 5.3 they can just make sure to include the right annotation jar (spring already pulls it in) so they really just need to add an exclusion on the gernomio one so not a huge deal as it's marked as optional anyways. 

**Flaky or non broken Tests: (These tests intermittently fail, or binding errors, etc. Can fix later.)**
- org.apache.activemq.usecases.StartAndConcurrentStopBrokerTest - fails intermittently for me
- org.apache.activemq.proxy.ProxyConnectorTest - due to Address already in use bind error
- org.apache.activemq.store.jdbc.JDBCIOExceptionHandlerTest - passed for me

These last 2 are already part of the exclude broken test profile so should also be excluded from quick tests and other profiles
- org.apache.activemq.network.SSHTunnelNetworkReconnectTest - works for me as long as ssh is properly configured, so probably just an environment thing in CI so should exclude
- org.apache.activemq.network.NetworkFailoverTest.testRequestReply - Has been broken for a long time
