### PR TITLE
DO_NOT_MERGE: setting test run to debug to troubleshoot timeouts

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -75,7 +75,7 @@ pipeline {
                 echo 'Running tests'
                 // all tests is very very long (10 hours on Apache Jenkins)
                 // sh 'mvn -B -e test -pl activemq-unit-tests -Dactivemq.tests=all'
-                sh 'mvn -B -e -fae test'
+                sh 'mvn -B -e -X -fae test'
             }
             post {
                 always {


### PR DESCRIPTION
This isn't meant to be merged, just submitted to run CI.

This commit is just adding -X to the mvn build so we can figure out why we keep getting the CI error:

org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:2.22.2:test (default-test) on project activemq-unit-tests: There was a timeout or other error in the fork