### PR TITLE
Update Spring to 5.3.18.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
     <shiro-version>1.8.0</shiro-version>
     <slf4j-version>1.7.36</slf4j-version>
     <snappy-version>1.1.2</snappy-version>
-    <spring-version>5.3.16</spring-version>
+    <spring-version>5.3.18</spring-version>
     <taglibs-version>1.2.5</taglibs-version>
     <velocity-version>2.3</velocity-version>
     <xalan-version>2.7.2</xalan-version>


### PR DESCRIPTION
This PR updates the Spring Framework version used in ActiveMQ to 5.3.18.