### PR TITLE
AMQ-8550 - Check for null keystore/truststore passwords

### DIFF
--- a/activemq-client/src/main/java/org/apache/activemq/ActiveMQSslConnectionFactory.java
+++ b/activemq-client/src/main/java/org/apache/activemq/ActiveMQSslConnectionFactory.java
@@ -132,7 +132,7 @@ public class ActiveMQSslConnectionFactory extends ActiveMQConnectionFactory {
         if (trustStore != null) {
             try(InputStream tsStream = getInputStream(trustStore)) {
 
-                trustedCertStore.load(tsStream, trustStorePassword.toCharArray());
+                trustedCertStore.load(tsStream, trustStorePassword != null ? trustStorePassword.toCharArray() : null);
                 TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
 
                 tmf.init(trustedCertStore);
@@ -151,8 +151,11 @@ public class ActiveMQSslConnectionFactory extends ActiveMQConnectionFactory {
 
             if (sslCert != null && sslCert.length > 0) {
                 try(ByteArrayInputStream bin = new ByteArrayInputStream(sslCert)) {
-                    ks.load(bin, keyStorePassword.toCharArray());
-                    kmf.init(ks, keyStoreKeyPassword !=null ? keyStoreKeyPassword.toCharArray() : keyStorePassword.toCharArray());
+                    //A null password may not be allowed depending on implementation
+                    //Check for null so an UnrecoverableKeyException is thrown if not supported or wrong instead of NullPointerException here
+                    final char[] keyStorePass = keyStorePassword != null ? keyStorePassword.toCharArray() : null;
+                    ks.load(bin, keyStorePass);
+                    kmf.init(ks, keyStoreKeyPassword != null ? keyStoreKeyPassword.toCharArray() : keyStorePass);
                     keystoreManagers = kmf.getKeyManagers();
                 }
             }


### PR DESCRIPTION
Inside ActiveMQSslConnectionFactory the passwords should be checked for
null so a NPE isn't thrown. Null will be passed to the factories instead
and the keystore/truststore factories will try and load the keystores
using null for the password which may or may not work depending on the
implementation and if password is set.