### PR TITLE
[AMQ-9005] remove xalan dependency due to it being end of life

### DIFF
--- a/activemq-broker/pom.xml
+++ b/activemq-broker/pom.xml
@@ -67,13 +67,6 @@
       <optional>true</optional>
     </dependency>
 
-    <!-- to support XPath based Selectors -->
-    <dependency>
-      <groupId>xalan</groupId>
-      <artifactId>xalan</artifactId>
-      <optional>true</optional>
-    </dependency>
-
     <!-- =============================== -->
     <!-- Testing Dependencies -->
     <!-- =============================== -->

--- a/activemq-kahadb-store/pom.xml
+++ b/activemq-kahadb-store/pom.xml
@@ -106,11 +106,6 @@
       <artifactId>spring-context</artifactId>
       <optional>true</optional>
     </dependency>
-    <dependency>
-      <groupId>xalan</groupId>
-      <artifactId>xalan</artifactId>
-      <optional>true</optional>
-    </dependency>
 
     <!-- =============================== -->
     <!-- Testing Dependencies            -->

--- a/activemq-mqtt/pom.xml
+++ b/activemq-mqtt/pom.xml
@@ -116,11 +116,6 @@
       <artifactId>spring-context</artifactId>
       <optional>true</optional>
     </dependency>
-    <dependency>
-      <groupId>xalan</groupId>
-      <artifactId>xalan</artifactId>
-      <optional>true</optional>
-    </dependency>
 
     <!-- =============================== -->
     <!-- Testing Dependencies            -->

--- a/activemq-rar/pom.xml
+++ b/activemq-rar/pom.xml
@@ -118,10 +118,6 @@
           <artifactId>jmdns</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>xalan</groupId>
-          <artifactId>xalan</artifactId>
-        </exclusion>
-        <exclusion>
           <groupId>xmlbeans</groupId>
           <artifactId>xbean</artifactId>
         </exclusion>
@@ -250,10 +246,6 @@
         <exclusion>
           <groupId>javax.jmdns</groupId>
           <artifactId>jmdns</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>xalan</groupId>
-          <artifactId>xalan</artifactId>
         </exclusion>
         <exclusion>
           <groupId>xmlbeans</groupId>

--- a/activemq-unit-tests/pom.xml
+++ b/activemq-unit-tests/pom.xml
@@ -147,11 +147,6 @@
       <artifactId>derbytools</artifactId>
       <optional>true</optional>
     </dependency>
-    <dependency>
-      <groupId>xalan</groupId>
-      <artifactId>xalan</artifactId>
-      <optional>true</optional>
-    </dependency>
 
     <!-- =============================== -->
     <!-- Testing Dependencies            -->

--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,6 @@
     <spring-version>5.3.22</spring-version>
     <taglibs-version>1.2.5</taglibs-version>
     <velocity-version>2.3</velocity-version>
-    <xalan-version>2.7.2</xalan-version>
     <xpp3-version>1.1.4c</xpp3-version>
     <xstream-version>1.4.19</xstream-version>
     <xbean-version>4.21</xbean-version>
@@ -932,12 +931,6 @@
         <groupId>activesoap</groupId>
         <artifactId>jaxp-api</artifactId>
         <version>${activesoap-version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>xalan</groupId>
-        <artifactId>xalan</artifactId>
-        <version>${xalan-version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/AMQ-9005

There's no use of Xalan in code and all tests are passing without the dependency. Seems safe to remove but I assume we'll need a note about it in the release notes. 