### PR TITLE
[AMQ-9058] Upgrade javacc-maven-plugin to 3.0.1

### DIFF
--- a/activemq-client/src/main/grammar/SelectorParser.jj
+++ b/activemq-client/src/main/grammar/SelectorParser.jj
@@ -121,7 +121,7 @@ public class SelectorParser {
         }
     }
 
-    private BooleanExpression asBooleanExpression(Expression value) throws ParseException  {
+    private static BooleanExpression asBooleanExpression(Expression value) throws ParseException  {
         if (value instanceof BooleanExpression) {
             return (BooleanExpression) value;
         }

--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
     <maven-install-plugin-version>2.5.2</maven-install-plugin-version>
     <maven-shade-plugin-version>3.3.0</maven-shade-plugin-version>
     <findbugs-maven-plugin-version>3.0.5</findbugs-maven-plugin-version>
-    <javacc-maven-plugin-version>2.6</javacc-maven-plugin-version>
+    <javacc-maven-plugin-version>3.0.1</javacc-maven-plugin-version>
     <cobertura-maven-plugin-version>2.7</cobertura-maven-plugin-version>
     <taglist-maven-plugin-version>3.0.0</taglist-maven-plugin-version>
     <build-helper-maven-plugin-version>3.3.0</build-helper-maven-plugin-version>


### PR DESCRIPTION
Build warnings that need review

```
Reading from file activemq/activemq-client/src/main/grammar/SelectorParser.jj . . .
Warning: Line 22, Column 3: Command line setting of "STATIC" modifies option value in file.
Warning: Line 23, Column 3: Command line setting of "UNICODE_INPUT" modifies option value in file.
Warning: Line 26, Column 3: Command line setting of "ERROR_REPORTING" modifies option value in file.
File "TokenMgrError.java" does not exist.  Will create one.
File "ParseException.java" does not exist.  Will create one.
File "Token.java" does not exist.  Will create one.
File "SimpleCharStream.java" does not exist.  Will create one.
Parser generated with 0 errors and 3 warnings.
```
