### PR TITLE
Removing dead code after making `concurrentStoreAndDispatchTransactions` was made final

### DIFF
--- a/activemq-kahadb-store/src/main/java/org/apache/activemq/store/kahadb/KahaDBStore.java
+++ b/activemq-kahadb-store/src/main/java/org/apache/activemq/store/kahadb/KahaDBStore.java
@@ -118,7 +118,6 @@ public class KahaDBStore extends MessageDatabase implements PersistenceAdapter, 
     // when true, message order may be compromised when cache is exhausted if store is out
     // or order w.r.t cache
     private boolean concurrentStoreAndDispatchTopics = false;
-    private final boolean concurrentStoreAndDispatchTransactions = false;
     private int maxAsyncJobs = MAX_ASYNC_JOBS;
     private final KahaDBTransactionStore transactionStore;
     private TransactionIdTransformer transactionIdTransformer;
@@ -179,10 +178,6 @@ public class KahaDBStore extends MessageDatabase implements PersistenceAdapter, 
      */
     public void setConcurrentStoreAndDispatchTopics(boolean concurrentStoreAndDispatch) {
         this.concurrentStoreAndDispatchTopics = concurrentStoreAndDispatch;
-    }
-
-    public boolean isConcurrentStoreAndDispatchTransactions() {
-        return this.concurrentStoreAndDispatchTransactions;
     }
 
     /**


### PR DESCRIPTION
### Descriptions
`concurrentStoreAndDispatchTransactions` variable in `KahaDBStore` has been made final long time ago. 
Removing the variable, cleaning up the dead code and conditions that are always true.