### PR TITLE
AMQ-9074: javadoc output simplifications

### DIFF
--- a/activemq-broker/pom.xml
+++ b/activemq-broker/pom.xml
@@ -106,9 +106,9 @@
             <link>http://junit.sourceforge.net/javadoc/</link>
           </links>
           <stylesheetfile>${basedir}/../etc/css/stylesheet.css</stylesheetfile>
-          <linksource>true</linksource>
           <maxmemory>256m</maxmemory>
           <source>${source-version}</source>
+          <noindex>true</noindex>
           <groups>
             <group>
               <title>JMS Client</title>

--- a/activemq-client/pom.xml
+++ b/activemq-client/pom.xml
@@ -103,9 +103,9 @@
             <link>http://junit.sourceforge.net/javadoc/</link>
           </links>
           <stylesheetfile>${basedir}/../etc/css/stylesheet.css</stylesheetfile>
-          <linksource>true</linksource>
           <maxmemory>256m</maxmemory>
           <source>${source-version}</source>
+          <noindex>true</noindex>
           <groups>
             <group>
               <title>JMS Client</title>

--- a/activemq-unit-tests/pom.xml
+++ b/activemq-unit-tests/pom.xml
@@ -323,9 +323,9 @@
             <link>http://junit.sourceforge.net/javadoc/</link>
           </links>
           <stylesheetfile>${basedir}/../etc/css/stylesheet.css</stylesheetfile>
-          <linksource>true</linksource>
           <maxmemory>256m</maxmemory>
           <source>${source-version}</source>
+          <noindex>true</noindex>
           <groups>
             <group>
               <title>JMS Client</title>

--- a/pom.xml
+++ b/pom.xml
@@ -1462,9 +1462,9 @@
             <link>http://logging.apache.org/log4j/docs/api/</link>
           </links>
           <stylesheetfile>${basedir}/../etc/css/stylesheet.css</stylesheetfile>
-          <linksource>true</linksource>
           <maxmemory>2048m</maxmemory>
           <source>${source-version}</source>
+          <noindex>true</noindex>
           <additionalJOption>-J-Xmx2048m</additionalJOption>
           <!-- necessary for now under the javadocs can be fixed because jdk8 is much stricter -->
           <additionalJOption>${javadoc.options}</additionalJOption>
@@ -1593,6 +1593,9 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
+            <configuration>
+              <noindex>true</noindex>
+            </configuration>
             <executions>
               <execution>
                 <id>attach-javadocs</id>


### PR DESCRIPTION
use -noindex to remove various .js files, disable html source listings for javadoc

https://issues.apache.org/jira/browse/AMQ-9074