### PR TITLE
No Jira: forkedProcessTimeoutInSeconds

### DIFF
--- a/activemq-unit-tests/pom.xml
+++ b/activemq-unit-tests/pom.xml
@@ -422,7 +422,7 @@
         <configuration>
           <forkCount>1</forkCount>
           <reuseForks>false</reuseForks>
-          <forkedProcessTimeoutInSeconds>1200</forkedProcessTimeoutInSeconds>
+          <forkedProcessTimeoutInSeconds>3600</forkedProcessTimeoutInSeconds>
           <runOrder>alphabetical</runOrder>
           <excludes>
             <!-- temporarily exclude failing tests so that CI works; fix asap and reenable -->


### PR DESCRIPTION
Since enabling more tests in AMQ-9152 all the runs keep timing out with the same error of "There was a timeout in the fork". Attempting to increase the timeout to see if that works otherwise we will have to try and figure out the specific test causing the issue.

This isn't meant to be merged yet, it's just being pushed so tests can run.