### PR TITLE
[AMQ-9161] Relocate activeio classes used by JDBC Journal impl  and deprecate JDBC Journal

### DIFF
--- a/activemq-console/pom.xml
+++ b/activemq-console/pom.xml
@@ -49,11 +49,6 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>activemq-kahadb-store</artifactId>
     </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>activeio-core</artifactId>
-    </dependency>
-
     <!-- geronimo -->
     <dependency>
       <groupId>jakarta.jms</groupId>

--- a/activemq-jdbc-store/pom.xml
+++ b/activemq-jdbc-store/pom.xml
@@ -53,12 +53,6 @@
       <artifactId>derbytools</artifactId>
       <optional>true</optional>
     </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>activeio-core</artifactId>
-      <optional>true</optional>
-    </dependency>
-
     <!-- =============================== -->
     <!-- Testing Dependencies -->
     <!-- =============================== -->

--- a/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/InvalidRecordLocationException.java
+++ b/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/InvalidRecordLocationException.java
@@ -1,0 +1,60 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.store.journal;
+
+/**
+ * Exception thrown by a Journal to indicate that an invalid RecordLocation was detected.
+ * 
+ * @version $Revision: 1.1 $
+ */
+public class InvalidRecordLocationException extends Exception {
+
+	/**
+     * Comment for <code>serialVersionUID</code>
+     */
+    private static final long serialVersionUID = 3618414947307239475L;
+
+    /**
+	 * 
+	 */
+	public InvalidRecordLocationException() {
+		super();
+	}
+
+	/**
+	 * @param msg
+	 */
+	public InvalidRecordLocationException(String msg) {
+		super(msg);
+	}
+
+	/**
+	 * @param msg
+	 * @param rootCause
+	 */
+	public InvalidRecordLocationException(String msg, Throwable rootCause) {
+		super(msg, rootCause);
+	}
+	
+	/**
+	 * @param rootCause
+	 */
+	public InvalidRecordLocationException(Throwable rootCause) {
+		super(rootCause);
+	}
+}

--- a/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/Journal.java
+++ b/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/Journal.java
@@ -1,0 +1,128 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.store.journal;
+
+import java.io.IOException;
+
+import org.apache.activemq.store.journal.packet.Packet;
+
+/**
+ * A Journal is a record logging Interface that can be used to implement 
+ * a transaction log.  
+ * 
+ * 
+ * This interface was largely extracted out of the HOWL project to allow 
+ * ActiveMQ to switch between different Journal implementations verry easily. 
+ * 
+ * @version $Revision: 1.1 $
+ */
+public interface Journal {
+
+	/**
+	 * Writes a {@see Packet} of  data to the journal.  If <code>sync</code>
+	 * is true, then this call blocks until the data has landed on the physical 
+	 * disk.  Otherwise, this enqueues the write request and returns.
+	 * 
+	 * @param record - the data to be written to disk.
+	 * @param sync - If this call should block until the data lands on disk.
+	 * 
+	 * @return RecordLocation the location where the data will be written to on disk.
+	 * 
+	 * @throws IOException if the write failed.
+	 * @throws IllegalStateException if the journal is closed.
+	 */
+	public RecordLocation write(Packet packet, boolean sync) throws IOException, IllegalStateException;
+
+	/**
+	 * Reads a previously written record from the journal. 
+	 *  
+	 * @param location is where to read the record from.
+	 * 
+	 * @return the data previously written at the <code>location</code>.
+	 * 
+	 * @throws InvalidRecordLocationException if <code>location</code> parameter is out of range.  
+	 *         It cannot be a location that is before the current mark. 
+	 * @throws IOException if the record could not be read.
+	 * @throws IllegalStateException if the journal is closed.
+	 */
+	public Packet read(RecordLocation location) throws InvalidRecordLocationException, IOException, IllegalStateException;
+
+	/**
+	 * Informs the journal that all the journal space up to the <code>location</code> is no longer
+	 * needed and can be reclaimed for reuse.
+	 * 
+	 * @param location the location of the record to mark.  All record locations before the marked 
+	 * location will no longger be vaild. 
+	 * 
+	 * @param sync if this call should block until the mark is set on the journal.
+	 * 
+	 * @throws InvalidRecordLocationException if <code>location</code> parameter is out of range.  
+	 *         It cannot be a location that is before the current mark. 
+	 * @throws IOException if the record could not be read.
+	 * @throws IllegalStateException if the journal is closed.
+	 */
+	public abstract void setMark(RecordLocation location, boolean sync)
+			throws InvalidRecordLocationException, IOException, IllegalStateException;
+	
+	/**
+	 * Obtains the mark that was set in the Journal.
+	 * 
+	 * @see read(RecordLocation location);
+	 * @return the mark that was set in the Journal.
+	 * @throws IllegalStateException if the journal is closed.
+	 */
+	public RecordLocation getMark() throws IllegalStateException;
+
+
+	/**
+	 * Close the Journal.  
+	 * This is blocking operation that waits for any pending put opperations to be forced to disk.
+	 * Once the Journal is closed, all other methods of the journal should throw IllegalStateException.
+	 * 
+	 * @throws IOException if an error occurs while the journal is being closed.
+	 */
+	public abstract void close() throws IOException;
+
+	/**
+	 * Allows you to get the next RecordLocation after the <code>location</code> that 
+	 * is in the journal.
+	 * 
+	 * @param location the reference location the is used to find the next location.
+	 * To get the oldest location available in the journal, <code>location</code> 
+	 * should be set to null.
+	 * 
+	 * 
+	 * @return the next record location
+	 * 
+	 * @throws InvalidRecordLocationException if <code>location</code> parameter is out of range.  
+	 *         It cannot be a location that is before the current mark. 
+	 * @throws IllegalStateException if the journal is closed.
+	 */
+	public abstract RecordLocation getNextRecordLocation(RecordLocation location)
+		throws InvalidRecordLocationException, IOException, IllegalStateException;
+
+
+	/**
+	 * Registers a <code>JournalEventListener</code> that will receive notifications from the Journal.
+	 * 
+	 * @param listener object that will receive journal events.
+	 * @throws IllegalStateException if the journal is closed.
+	 */
+	public abstract void setJournalEventListener(JournalEventListener listener) throws IllegalStateException;
+	
+}

--- a/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/JournalEventListener.java
+++ b/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/JournalEventListener.java
@@ -1,0 +1,38 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.store.journal;
+
+/**
+ * Defines an object which listens for Journal Events.
+ * 
+ * @version $Revision: 1.1 $
+ */
+public interface JournalEventListener {
+
+	/**
+	 * This event is issues when a Journal implementations wants to recover 
+	 * disk space used by old records.  If journal space is not reliquised 
+	 * by setting the Journal's mark at or past the <code>safeLocation</code>
+	 * further write opperations against the Journal may casuse IOExceptions 
+	 * to occur due to a log overflow condition.
+	 * 
+	 * @param safeLocation the oldest location that the journal recomends the mark to be set.
+	 */
+	void overflowNotification(RecordLocation safeLocation);
+
+}

--- a/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/JournalMessageStore.java
+++ b/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/JournalMessageStore.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.activeio.journal.RecordLocation;
 import org.apache.activemq.broker.ConnectionContext;
 import org.apache.activemq.command.ActiveMQDestination;
 import org.apache.activemq.command.JournalQueueAck;

--- a/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/JournalPersistenceAdapter.java
+++ b/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/JournalPersistenceAdapter.java
@@ -33,12 +33,8 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.apache.activeio.journal.InvalidRecordLocationException;
-import org.apache.activeio.journal.Journal;
-import org.apache.activeio.journal.JournalEventListener;
-import org.apache.activeio.journal.RecordLocation;
-import org.apache.activeio.packet.ByteArrayPacket;
-import org.apache.activeio.packet.Packet;
+import org.apache.activemq.store.journal.packet.ByteArrayPacket;
+import org.apache.activemq.store.journal.packet.Packet;
 import org.apache.activemq.broker.BrokerService;
 import org.apache.activemq.broker.BrokerServiceAware;
 import org.apache.activemq.broker.ConnectionContext;
@@ -85,6 +81,7 @@ import org.slf4j.LoggerFactory;
  * @org.apache.xbean.XBean
  *
  */
+@Deprecated(forRemoval = true)
 public class JournalPersistenceAdapter implements PersistenceAdapter, JournalEventListener, UsageListener, BrokerServiceAware {
 
     private BrokerService brokerService;
@@ -752,11 +749,11 @@ public class JournalPersistenceAdapter implements PersistenceAdapter, JournalEve
     }
 
     public Packet toPacket(ByteSequence sequence) {
-        return new ByteArrayPacket(new org.apache.activeio.packet.ByteSequence(sequence.data, sequence.offset, sequence.length));
+        return new ByteArrayPacket(new org.apache.activemq.store.journal.packet.ByteSequence(sequence.data, sequence.offset, sequence.length));
     }
 
     public ByteSequence toByteSequence(Packet packet) {
-        org.apache.activeio.packet.ByteSequence sequence = packet.asByteSequence();
+        org.apache.activemq.store.journal.packet.ByteSequence sequence = packet.asByteSequence();
         return new ByteSequence(sequence.getData(), sequence.getOffset(), sequence.getLength());
     }
 

--- a/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/JournalPersistenceAdapterFactory.java
+++ b/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/JournalPersistenceAdapterFactory.java
@@ -19,9 +19,8 @@ package org.apache.activemq.store.journal;
 import java.io.File;
 import java.io.IOException;
 
-import org.apache.activeio.journal.Journal;
-import org.apache.activeio.journal.active.JournalImpl;
-import org.apache.activeio.journal.active.JournalLockedException;
+import org.apache.activemq.store.journal.active.JournalImpl;
+import org.apache.activemq.store.journal.active.JournalLockedException;
 import org.apache.activemq.broker.Locker;
 import org.apache.activemq.store.PersistenceAdapter;
 import org.apache.activemq.store.PersistenceAdapterFactory;
@@ -40,6 +39,7 @@ import org.slf4j.LoggerFactory;
  * @org.apache.xbean.XBean
  * 
  */
+@Deprecated(forRemoval = true)
 public class JournalPersistenceAdapterFactory extends DataSourceServiceSupport implements PersistenceAdapterFactory {
 
     private static final int JOURNAL_LOCKED_WAIT_DELAY = 10 * 1000;

--- a/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/JournalTopicMessageStore.java
+++ b/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/JournalTopicMessageStore.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Iterator;
 
-import org.apache.activeio.journal.RecordLocation;
 import org.apache.activemq.broker.ConnectionContext;
 import org.apache.activemq.command.ActiveMQTopic;
 import org.apache.activemq.command.JournalTopicAck;

--- a/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/JournalTransactionStore.java
+++ b/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/JournalTransactionStore.java
@@ -23,7 +23,6 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import javax.transaction.xa.XAException;
-import org.apache.activeio.journal.RecordLocation;
 import org.apache.activemq.command.JournalTopicAck;
 import org.apache.activemq.command.JournalTransaction;
 import org.apache.activemq.command.Message;

--- a/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/RecordLocation.java
+++ b/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/RecordLocation.java
@@ -1,0 +1,31 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.store.journal;
+
+/**
+ * A RecordLocation is used to locate data records that have been 
+ * logged to a Journal via the <code>Journal.put()</code> method call.
+ * 
+ * RecordLocation are comparable on the position in the Journal 
+ * where they reside.
+ * 
+ * @version $Revision: 1.1 $
+ */
+public interface RecordLocation extends Comparable {
+
+}

--- a/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/active/BatchedWrite.java
+++ b/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/active/BatchedWrite.java
@@ -1,0 +1,143 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.store.journal.active;
+
+import org.apache.activemq.store.journal.packet.Packet;
+
+import java.util.concurrent.CountDownLatch;
+
+/**
+ * This contains all the data needed to write and force a list of records to a
+ * LogFile. The more records that can be cramed into a single BatchedWrite, the
+ * higher throughput that can be achived by a write and force operation.
+ * 
+ * @version $Revision: 1.1 $
+ */
+final public class BatchedWrite {
+
+    private final Packet packet;
+    public Throwable error;
+    private Location mark;
+    private boolean appendDisabled = false;
+    private boolean appendInProgress = false;
+    private CountDownLatch writeDoneCountDownLatch;
+
+    /**
+     * @param packet
+     */
+    public BatchedWrite(Packet packet) {
+        this.packet = packet;
+    }
+
+    /**
+     * @throws InterruptedException
+     * 
+     */
+    synchronized private void disableAppend() throws InterruptedException {
+        appendDisabled = true;
+        while (appendInProgress) {
+            wait();
+        }
+    }
+
+    /**
+     * @param packet2
+     * @param mark2
+     * @return
+     */
+    public boolean append(Record record, Location recordMark, boolean force) {
+
+        synchronized (this) {
+            if (appendDisabled)
+                return false;
+            appendInProgress = true;
+        }
+        
+        
+        if( force && writeDoneCountDownLatch==null)
+            writeDoneCountDownLatch = new CountDownLatch(1);
+        
+        record.read(packet);
+
+        // if we fit the record in this batch
+        if ( !record.hasRemaining() ) {
+            if (recordMark != null)
+                mark = recordMark;
+        }
+
+        synchronized (this) {
+            appendInProgress = false;
+            this.notify();
+
+            if (appendDisabled)
+                return false;
+            else
+                return packet.remaining() > 0;
+        }
+    }
+
+    public void waitForForce() throws Throwable {
+        if( writeDoneCountDownLatch!=null ) {
+            writeDoneCountDownLatch.await();
+            synchronized (this) {
+                if (error != null)
+                    throw error;
+            }
+        }
+    }
+
+    public void forced() {
+        if( writeDoneCountDownLatch!=null ) {
+            writeDoneCountDownLatch.countDown();
+        }
+    }
+
+    public void writeFailed(Throwable error) {
+        if( writeDoneCountDownLatch!=null ) {
+            synchronized (this) {
+                this.error = error;
+            }
+            writeDoneCountDownLatch.countDown();
+        }
+    }
+
+    public Packet getPacket() {
+        return packet;
+    }
+
+    /**
+     * @return
+     */
+    public Location getMark() {
+        return mark;
+    }
+
+    /**
+     * @throws InterruptedException
+     * 
+     */
+    public void flip() throws InterruptedException {
+        disableAppend();
+        packet.flip();
+    }
+
+    public boolean getForce() {
+        return writeDoneCountDownLatch!=null;
+    }
+
+}

--- a/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/active/ControlFile.java
+++ b/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/active/ControlFile.java
@@ -1,0 +1,182 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.store.journal.active;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.util.HashSet;
+import java.util.Properties;
+import java.util.Set;
+
+import org.apache.activemq.store.journal.packet.ByteBufferPacket;
+import org.apache.activemq.store.journal.packet.Packet;
+
+/**
+ * Control file holds the last known good state of the journal.  It stores the state in 
+ * record that is versioned and repeated twice in the file so that a failure in the
+ * middle of the write of the first or second record do not not result in an unknown
+ * state. 
+ * 
+ * @version $Revision: 1.1 $
+ */
+final public class ControlFile {
+
+    /** The File that holds the control data. */
+    private final RandomAccessFile file;
+    private final FileChannel channel;
+    private final ByteBufferPacket controlData;
+    
+    private final static boolean brokenFileLock = "true".equals(System.getProperty("java.nio.channels.FileLock.broken", "false"));
+
+    private long controlDataVersion=0;
+    private FileLock lock;
+	private boolean disposed;
+    private static Set lockSet;
+    private String canonicalPath;
+
+    public ControlFile(File fileName, int controlDataSize) throws IOException {
+        canonicalPath = fileName.getCanonicalPath();
+        boolean existed = fileName.exists();        
+        file = new RandomAccessFile(fileName, "rw");
+        channel = file.getChannel();
+        controlData = new ByteBufferPacket(ByteBuffer.allocateDirect(controlDataSize));
+
+    }
+
+    /**
+     * Locks the control file.
+     * @throws IOException 
+     */
+    public void lock() throws IOException {
+
+        Properties properties = System.getProperties();
+        synchronized(properties) {
+            String lockKey = "org.apache.activemq.store.journal.active.lockMap:"+canonicalPath;
+            if( properties.setProperty(lockKey, "true")!=null ) {
+                throw new JournalLockedException("Journal is already opened by this application.");
+            }
+
+            if( !brokenFileLock ) {
+                lock = channel.tryLock();
+                if (lock == null) {
+                   properties.remove(lockKey);
+                   throw new JournalLockedException("Journal is already opened by another application");
+                }
+            }
+        }
+    }
+
+    /**
+     * Un locks the control file.
+     * 
+     * @throws IOException
+     */
+    public void unlock() throws IOException {
+
+        Properties properties = System.getProperties();
+        synchronized(properties) {
+            if (lock != null) {
+                String lockKey = "org.apache.activemq.store.journal.active.lockMap:"+canonicalPath;
+                properties.remove(lockKey);
+                lock.release();
+                lock = null;
+            }
+        }
+    }
+    
+    public boolean load() throws IOException {
+        long l = file.length();
+        if( l < controlData.capacity() ) {
+            controlDataVersion=0;
+            controlData.position(0);
+            controlData.limit(0);
+            return false;
+        } else {            
+            file.seek(0);
+            long v1 = file.readLong();
+            file.seek(controlData.capacity()+8);
+            long v1check = file.readLong();
+            
+            file.seek(controlData.capacity()+16);
+            long v2 = file.readLong();
+            file.seek((controlData.capacity()*2)+24);
+            long v2check = file.readLong();
+            
+            if( v2 == v2check ) {
+                controlDataVersion = v2;
+                file.seek(controlData.capacity()+24);
+                controlData.clear();
+                channel.read(controlData.getByteBuffer());
+            } else if ( v1 == v1check ){
+                controlDataVersion = v1;
+                file.seek(controlData.capacity()+8);
+                controlData.clear();
+                channel.read(controlData.getByteBuffer());
+            } else {
+                // Bummer.. Both checks are screwed. we don't know
+                // if any of the two buffer are ok.  This should
+                // only happen is data got corrupted.
+                throw new IOException("Control data corrupted.");
+            }         
+            return true;
+        }
+    }
+    
+    public void store() throws IOException {
+        controlDataVersion++;
+        file.setLength((controlData.capacity()*2)+32);
+        file.seek(0);
+        
+        // Write the first copy of the control data.
+        file.writeLong(controlDataVersion);
+        controlData.clear();
+        channel.write(controlData.getByteBuffer());
+        file.writeLong(controlDataVersion);
+
+        // Write the second copy of the control data.
+        file.writeLong(controlDataVersion);
+        controlData.clear();
+        channel.write(controlData.getByteBuffer());
+        file.writeLong(controlDataVersion);
+        
+        channel.force(false);        
+    }
+
+    public Packet getControlData() {
+        controlData.clear();
+        return controlData;
+    }
+
+    public void dispose() {
+    	if( disposed )
+    		return;
+    	disposed=true;
+        try {
+            unlock();
+        } catch (IOException e) {
+        }
+        try {
+            file.close();
+        } catch (IOException e) {
+        }
+    }
+}

--- a/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/active/JournalImpl.java
+++ b/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/active/JournalImpl.java
@@ -1,0 +1,467 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.store.journal.active;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InterruptedIOException;
+
+import org.apache.activemq.store.journal.InvalidRecordLocationException;
+import org.apache.activemq.store.journal.Journal;
+import org.apache.activemq.store.journal.JournalEventListener;
+import org.apache.activemq.store.journal.RecordLocation;
+import org.apache.activemq.store.journal.packet.ByteArrayPacket;
+import org.apache.activemq.store.journal.packet.ByteBufferPacketPool;
+import org.apache.activemq.store.journal.packet.Packet;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A high speed Journal implementation. Inspired by the ideas of the <a
+ * href="http://howl.objectweb.org/">Howl </a> project but tailored to the needs
+ * of ActiveMQ. <p/>This Journal provides the following features:
+ * <ul>
+ * <li>Concurrent writes are batched into a single write/force done by a
+ * background thread.</li>
+ * <li>Uses preallocated logs to avoid disk fragmentation and performance
+ * degregation.</li>
+ * <li>The number and size of the preallocated logs are configurable.</li>
+ * <li>Uses direct ByteBuffers to write data to log files.</li>
+ * <li>Allows logs to grow in case of an overflow condition so that overflow
+ * exceptions are not not thrown. Grown logs that are inactivate (due to a new
+ * mark) are resized to their original size.</li>
+ * <li>No limit on the size of the record written to the journal</li>
+ * <li>Should be possible to extend so that multiple physical disk are used
+ * concurrently to increase throughput and decrease latency.</li>
+ * </ul>
+ * <p/>
+ * 
+ * @version $Revision: 1.1 $
+ */
+final public class JournalImpl implements Journal {
+
+    public static final int DEFAULT_POOL_SIZE = Integer.parseInt(System.getProperty("org.apache.activemq.store.journal.active.DefaultPoolSize", ""+(5)));
+    public static final int DEFAULT_PACKET_SIZE = Integer.parseInt(System.getProperty("org.apache.activemq.store.journal.active.DefaultPacketSize", ""+(1024*1024*4)));
+
+    static final private int OVERFLOW_RENOTIFICATION_DELAY = 500;
+    
+    static private ByteBufferPacketPool lastPool;
+    
+    private boolean disposed = false;
+
+    // The id of the current log file that is being filled.
+    private int appendLogFileId = 0;
+
+    // The offset in the current log file that is being filled.
+    private int appendLogFileOffset = 0;
+
+    // Used to batch writes together.
+    private BatchedWrite pendingBatchWrite;
+    
+    private Location lastMarkedLocation;
+    private LogFileManager file;
+    private ThreadPoolExecutor executor;
+    private int rolloverFence;
+    private JournalEventListener eventListener;
+    private ByteBufferPacketPool packetPool;
+    private long overflowNotificationTime = System.currentTimeMillis();
+    private Packet markPacket = new ByteArrayPacket(new byte[Location.SERIALIZED_SIZE]);
+    private boolean doingNotification=false;
+    
+    public JournalImpl(File logDirectory) throws IOException {
+        this(new LogFileManager(logDirectory));
+    }
+
+    public JournalImpl(File logDirectory, int logFileCount, int logFileSize) throws IOException {
+        this(new LogFileManager(logDirectory, logFileCount, logFileSize, null));
+    }
+    
+    public JournalImpl(File logDirectory, int logFileCount, int logFileSize, File archiveDirectory) throws IOException {
+        this(new LogFileManager(logDirectory, logFileCount, logFileSize, archiveDirectory));
+    }
+
+    public JournalImpl(LogFileManager logFile) {
+        this.file = logFile;
+        this.packetPool = createBufferPool();
+        this.executor = new ThreadPoolExecutor(1, 1, 30, TimeUnit.SECONDS, new LinkedBlockingQueue(), new ThreadFactory() {
+            public Thread newThread(Runnable runnable) {
+                Thread answer = new Thread(runnable, "Journal Writer");
+                answer.setPriority(Thread.MAX_PRIORITY);
+                answer.setDaemon(true);
+                return answer;
+            }
+        });
+        //executor.allowCoreThreadTimeOut(true);
+        
+        lastMarkedLocation = file.getLastMarkedRecordLocation();
+        Location nextAppendLocation = file.getNextAppendLocation();
+        appendLogFileId = nextAppendLocation.getLogFileId();
+        appendLogFileOffset = nextAppendLocation.getLogFileOffset();
+        
+        rolloverFence = (file.getInitialLogFileSize() / 10) * 9;
+    }
+
+    
+    /**
+     * When running unit tests we may not be able to create new pools fast enough
+     * since the old pools are not being gc'ed fast enough.  So we pool the pool.
+     * @return
+     */
+    synchronized static private ByteBufferPacketPool createBufferPool() {
+        if( lastPool !=null ) {
+            ByteBufferPacketPool rc = lastPool;
+            lastPool = null;
+            return rc;
+        } else { 
+            return new ByteBufferPacketPool(DEFAULT_POOL_SIZE, DEFAULT_PACKET_SIZE);
+        }
+    }
+    
+    /**
+     * When running unit tests we may not be able to create new pools fast enough
+     * since the old pools are not being gc'ed fast enough.  So we pool the pool.
+     * @return
+     */
+    synchronized static private void disposeBufferPool(ByteBufferPacketPool pool) {
+        if( lastPool!=null ) {
+            pool.dispose();
+        } else {
+            pool.waitForPacketsToReturn();
+            lastPool = pool;
+        }
+    }
+
+
+
+    public RecordLocation write(Packet data, boolean sync) throws IOException {
+        return write(LogFileManager.DATA_RECORD_TYPE, data, sync, null);
+    }
+
+    private Location write(byte recordType, Packet data, boolean sync, Location mark) throws IOException {
+        try {
+            Location location;
+            BatchedWrite writeCommand;
+            
+            Record record = new Record(recordType, data, mark);
+            
+            // The following synchronized block is the bottle neck of the journal.  Make this
+            // code faster and the journal should speed up.
+            synchronized (this) {
+                if (disposed) {
+                    throw new IOException("Journal has been closed.");
+                }
+
+                // Create our record
+                location = new Location(appendLogFileId, appendLogFileOffset);
+                record.setLocation(location);
+                
+                // Piggy back the packet on the pending write batch.
+                writeCommand = addToPendingWriteBatch(record, mark, sync);
+
+                // Update where the next record will land.
+                appendLogFileOffset += data.limit() + Record.RECORD_BASE_SIZE;
+                rolloverCheck();
+            }
+
+            if (sync) {
+                writeCommand.waitForForce();
+            }
+
+            return location;
+        } catch (IOException e) {
+            throw e;
+        } catch (InterruptedException e) {
+            throw (IOException) new InterruptedIOException().initCause(e);
+        } catch (Throwable e) {
+            throw (IOException) new IOException("Write failed: " + e).initCause(e);
+        }
+    }
+
+    /**
+     * @param record
+     * @return
+     * @throws InterruptedException
+     */
+    private BatchedWrite addToPendingWriteBatch(Record record, Location mark, boolean force) throws InterruptedException {
+
+        // Load the write batch up with data from our record.
+        // it may take more than one write batch if the record is large.
+        BatchedWrite answer = null;
+        while (record.hasRemaining()) {
+            
+            // Do we need another BatchWrite?
+            boolean queueTheWrite=false;
+            if (pendingBatchWrite == null) {
+                pendingBatchWrite =  new BatchedWrite(packetPool.getPacket());
+                queueTheWrite = true;
+            }
+            answer = pendingBatchWrite;
+
+            // Can we continue to use the pendingBatchWrite?
+            boolean full = !pendingBatchWrite.append(record, mark, force);
+            
+            if( queueTheWrite ) {
+                final BatchedWrite queuedWrite = pendingBatchWrite;
+                executor.execute(new Runnable() {
+                    public void run() {
+                        try {
+                            queuedWrite(queuedWrite);
+                        } catch (InterruptedException e) {
+                        }
+                    }
+                });
+            }
+            
+            if( full )
+                pendingBatchWrite = null;            
+        }
+        return answer;
+
+    }
+
+    /**
+     * This is a blocking call
+     * 
+     * @param write
+     * @throws InterruptedException
+     */
+    private void queuedWrite(BatchedWrite write) throws InterruptedException {
+
+        // Stop other threads from appending more pendingBatchWrite.
+        write.flip();
+
+        // Do the write.
+        try {
+            file.append(write);
+            write.forced();
+        } catch (Throwable e) {
+            write.writeFailed(e);
+        } finally {
+            write.getPacket().dispose();
+        }
+    }
+
+    /**
+     * 
+     */
+    private void rolloverCheck() throws IOException {
+
+        // See if we need to issue an overflow notification.
+        if (eventListener != null && file.isPastHalfActive()
+                && overflowNotificationTime + OVERFLOW_RENOTIFICATION_DELAY < System.currentTimeMillis() && !doingNotification ) {
+            doingNotification = true;
+            try {
+                // We need to send an overflow notification to free up
+                // some logFiles.
+                Location safeSpot = file.getFirstRecordLocationOfSecondActiveLogFile();
+                eventListener.overflowNotification(safeSpot);
+                overflowNotificationTime = System.currentTimeMillis();
+            } finally {
+                doingNotification = false;
+            }
+        }
+
+        // Is it time to roll over?
+        if (appendLogFileOffset > rolloverFence ) {
+
+            // Can we roll over?
+            if ( !file.canActivateNextLogFile() ) {
+                // don't delay the next overflow notification.
+                overflowNotificationTime -= OVERFLOW_RENOTIFICATION_DELAY;
+                
+            } else {
+                
+                try {
+                    final FutureTask result = new FutureTask(new Callable() {
+                        public Object call() throws Exception {
+                            return queuedActivateNextLogFile();
+                        }});
+                    executor.execute(result);
+                    Location location = (Location) result.get();
+                    appendLogFileId = location.getLogFileId();
+                    appendLogFileOffset = location.getLogFileOffset();
+    
+                } catch (InterruptedException e) {
+                    throw (IOException) new IOException("Interrupted.").initCause(e);
+                }
+                catch (ExecutionException e) {
+                    throw handleExecutionException(e);
+                }
+            }
+        }
+    }
+
+    /**
+     * This is a blocking call
+     */
+    private Location queuedActivateNextLogFile() throws IOException {
+        file.activateNextLogFile();
+        return file.getNextAppendLocation();
+    }
+
+    
+    
+    /**
+     * @param recordLocator
+     * @param force
+     * @return
+     * @throws InvalidRecordLocationException
+     * @throws IOException
+     * @throws InterruptedException
+     */
+    synchronized public void setMark(RecordLocation l, boolean force) throws InvalidRecordLocationException,
+            IOException {
+        
+        Location location = (Location) l;
+        if (location == null)
+            throw new InvalidRecordLocationException("The location cannot be null.");
+        if (lastMarkedLocation != null && location.compareTo(lastMarkedLocation) < 0)
+            throw new InvalidRecordLocationException("The location is less than the last mark.");
+        
+        markPacket.clear();
+        location.writeToPacket(markPacket);    
+        markPacket.flip();
+        write(LogFileManager.MARK_RECORD_TYPE, markPacket, force, location);
+        
+        lastMarkedLocation = location;
+    }
+
+    /**
+     * @return
+     */
+    public RecordLocation getMark() {
+        return lastMarkedLocation;
+    }
+
+    /**
+     * @param lastLocation
+     * @return
+     * @throws IOException
+     * @throws InvalidRecordLocationException
+     */
+    public RecordLocation getNextRecordLocation(final RecordLocation lastLocation) throws IOException,
+            InvalidRecordLocationException {
+        
+        if (lastLocation == null) {
+            if (lastMarkedLocation != null) {
+                return lastMarkedLocation;
+            } else {
+                return file.getFirstActiveLogLocation();
+            }
+        }
+
+        // Run this in the queued executor thread.
+        try {
+            final FutureTask result = new FutureTask(new Callable() {
+                public Object call() throws Exception {
+                    return queuedGetNextRecordLocation((Location) lastLocation);
+                }});
+            executor.execute(result);
+            return (Location) result.get();
+        } catch (InterruptedException e) {
+            throw (IOException) new IOException("Interrupted.").initCause(e);
+        }
+        catch (ExecutionException e) {
+            throw handleExecutionException(e);
+        }
+    }
+
+    protected IOException handleExecutionException(ExecutionException e) throws IOException {
+        Throwable cause = e.getCause();
+        if (cause instanceof IOException) {
+            return (IOException) cause;
+        }
+        else {
+            return (IOException) new IOException(cause.getMessage()).initCause(cause);
+        }
+    }
+
+    private Location queuedGetNextRecordLocation(Location location) throws IOException, InvalidRecordLocationException {
+        return file.getNextDataRecordLocation(location);
+    }
+
+    /**
+     * @param location
+     * @return
+     * @throws InvalidRecordLocationException
+     * @throws IOException
+     */
+    public Packet read(final RecordLocation l) throws IOException, InvalidRecordLocationException {
+        final Location location = (Location) l;
+        // Run this in the queued executor thread.
+        try {
+            final FutureTask result = new FutureTask(new Callable() {
+                public Object call() throws Exception {
+                    return file.readPacket(location);
+                }});
+            executor.execute(result);
+            return (Packet) result.get();
+        } catch (InterruptedException e) {
+            throw (IOException) new IOException("Interrupted.").initCause(e);
+        }
+        catch (ExecutionException e) {
+            throw handleExecutionException(e);
+        }
+    }
+
+    public void setJournalEventListener(JournalEventListener eventListener) {
+        this.eventListener = eventListener;
+    }
+
+    /**
+     * @deprecated @see #dispose()
+     */
+    public void close() throws IOException {
+    	dispose();
+    }
+    
+    /**
+     */
+    public void dispose() {
+        if (disposed)
+            return;
+        disposed=true;
+        executor.shutdown();
+        file.dispose();
+        ByteBufferPacketPool pool = packetPool;
+        packetPool=null;
+        disposeBufferPool(pool);
+    }
+
+    /**
+     * @return
+     */
+    public File getLogDirectory() {
+        return file.getLogDirectory();
+    }
+
+    public int getInitialLogFileSize() {
+        return file.getInitialLogFileSize();
+    }
+    
+    public String toString() {
+        return "Active Journal: using "+file.getOnlineLogFileCount()+" x " + (file.getInitialLogFileSize()/(1024*1024f)) + " Megs at: " + getLogDirectory();
+    }
+
+}

--- a/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/active/JournalLockedException.java
+++ b/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/active/JournalLockedException.java
@@ -1,0 +1,40 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.store.journal.active;
+
+import java.io.IOException;
+
+/**
+ * @version $Revision$
+ */
+public class JournalLockedException extends IOException {
+
+    private static final long serialVersionUID = -3696987774575855799L;
+
+    public JournalLockedException() {
+        super();
+    }
+
+    /**
+     * @param arg0
+     */
+    public JournalLockedException(String arg0) {
+        super(arg0);
+    }
+
+}

--- a/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/active/Location.java
+++ b/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/active/Location.java
@@ -1,0 +1,97 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.store.journal.active;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+
+import org.apache.activemq.store.journal.RecordLocation;
+import org.apache.activemq.store.journal.packet.Packet;
+import org.apache.activemq.store.journal.packet.PacketData;
+
+/**
+ * Defines a where a record can be located in the Journal.
+ * 
+ * @version $Revision: 1.1 $
+ */
+final public class Location implements RecordLocation {
+    
+    static final public int SERIALIZED_SIZE=8;
+
+    final private int logFileId;
+    final private int logFileOffset;
+
+    public Location(int logFileId, int fileOffset) {
+        this.logFileId = logFileId;
+        this.logFileOffset = fileOffset;
+    }
+
+    public int compareTo(Object o) {
+        int rc = logFileId - ((Location) o).logFileId;
+        if (rc != 0)
+            return rc;
+
+        return logFileOffset - ((Location) o).logFileOffset;
+    }
+
+    public int hashCode() {
+        return logFileOffset ^ logFileId;
+    }
+
+    public boolean equals(Object o) {
+        if (o == null || o.getClass() != Location.class)
+            return false;
+        Location rl = (Location) o;
+        return rl.logFileId == this.logFileId && rl.logFileOffset == this.logFileOffset;
+    }
+
+    public String toString() {
+        return "" + logFileId + ":" + logFileOffset;
+    }
+
+    public int getLogFileId() {
+        return logFileId;
+    }
+
+    public int getLogFileOffset() {
+        return logFileOffset;
+    }
+    
+    public void writeToPacket(Packet packet) throws IOException {
+        PacketData data = new PacketData(packet);
+        data.writeInt(logFileId);
+        data.writeInt(logFileOffset);
+    }
+
+    public void writeToDataOutput(DataOutput data) throws IOException {
+        data.writeInt(logFileId);
+        data.writeInt(logFileOffset);
+    }    
+
+    static public Location readFromPacket(Packet packet) throws IOException {
+        PacketData data = new PacketData(packet);
+        return new Location(data.readInt(), data.readInt());
+    }
+
+    public static Location readFromDataInput(DataInput data) throws IOException {
+        return new Location(data.readInt(), data.readInt());
+    }
+
+    
+}

--- a/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/active/LogFile.java
+++ b/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/active/LogFile.java
@@ -1,0 +1,154 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.store.journal.active;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+
+/**
+ * Allows read/append access to a LogFile.
+ * 
+ * @version $Revision: 1.1 $
+ */
+final public class LogFile {
+
+    private final RandomAccessFile file;
+    private final FileChannel channel;
+
+    /** Prefered size. The size that the log file is set to when initilaized. */
+    private final int initialSize;
+
+    /** Where the we are in the file right now */
+    private int currentOffset;
+	private boolean disposed;
+    
+    public LogFile(File file, int initialSize) throws IOException {
+        this.initialSize = initialSize;
+        boolean initializationNeeeded = !file.exists();
+        this.file = new RandomAccessFile(file, "rw");
+        channel = this.file.getChannel();
+        if( initializationNeeeded )
+            resize();
+        channel.position(0);
+        reloadCurrentOffset();
+    }
+
+    /**
+     * To avoid doing un-needed seeks.
+     */
+    private void seek(int offset) throws IOException {
+        if( offset == currentOffset ) {
+            if( currentOffset != channel.position() )
+                throw new RuntimeException(" "+currentOffset+", "+channel.position() );                
+            return;
+        }
+        channel.position(offset);
+        currentOffset = offset;
+    }
+    private void reloadCurrentOffset() throws IOException {
+        currentOffset= (int) channel.position();
+    }
+    private void addToCurrentOffset(int rc) {
+        currentOffset+=rc;
+    }
+    
+    public boolean loadAndCheckRecord(int offset, Record record) throws IOException {
+        
+        try { 
+            // Read the next header
+            seek(offset);        
+            record.readHeader(file);
+                    
+            if (Record.isChecksumingEnabled()) {
+                record.checksum(file);
+            }            
+            // Load the footer.
+            seek(offset+record.getPayloadLength()+Record.RECORD_HEADER_SIZE);
+            record.readFooter(file);
+            
+            addToCurrentOffset(record.getRecordLength());
+            return true;
+                
+        } catch (IOException e) {
+            reloadCurrentOffset();
+            return false;
+        }
+    }
+    
+    public void resize() throws IOException {
+        file.setLength(initialSize);
+    }
+
+    public void force() throws IOException {
+        channel.force(false);
+    }
+
+    public void dispose() {
+    	if( disposed )
+    		return;
+    	disposed=true;
+        try {
+			this.file.close();
+		} catch (IOException e) {
+		}
+    }
+
+    public void write(int offset, ByteBuffer buffer) throws IOException {
+        
+        try {
+
+            int size = buffer.remaining();
+            seek(offset);
+            while (buffer.hasRemaining()) {
+                channel.write(buffer);                
+            }
+            addToCurrentOffset(size);
+            
+        } catch (IOException e) {
+            reloadCurrentOffset();
+        }
+    }
+
+    public void readRecordHeader(int offset, Record record) throws IOException {
+        seek(offset);  
+        try {
+            record.readHeader(file);
+        } catch ( IOException e ) {
+            reloadCurrentOffset();
+            throw e;
+        }
+        addToCurrentOffset(Record.RECORD_HEADER_SIZE);
+    }
+
+    public void read(int offset, byte[] answer) throws IOException {
+        seek(offset);
+        file.readFully(answer);
+        addToCurrentOffset(answer.length);
+    }
+
+    public void copyTo(File location) throws IOException {
+        FileOutputStream fos = new FileOutputStream(location);
+        channel.transferTo(0, channel.size(), fos.getChannel());
+        fos.getChannel().force(false);
+        fos.close();
+    }
+}

--- a/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/active/LogFileManager.java
+++ b/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/active/LogFileManager.java
@@ -1,0 +1,544 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.store.journal.active;
+
+import java.io.DataInput;
+import java.io.DataInputStream;
+import java.io.DataOutput;
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.text.NumberFormat;
+import java.util.HashMap;
+import java.util.Iterator;
+
+import org.apache.activemq.store.journal.adapter.PacketOutputStream;
+import org.apache.activemq.store.journal.adapter.PacketToInputStream;
+import org.apache.activemq.store.journal.InvalidRecordLocationException;
+import org.apache.activemq.store.journal.packet.ByteArrayPacket;
+import org.apache.activemq.store.journal.packet.ByteBufferPacket;
+import org.apache.activemq.store.journal.packet.Packet;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Provides a logical view of many separate files as one single long log file.
+ * The separate files that compose the LogFile are Segments of the LogFile.
+ * <p/>This class is not thread safe.
+ * 
+ * @version $Revision: 1.1 $
+ */
+final public class LogFileManager {
+
+    public static final int DEFAULT_LOGFILE_COUNT = Integer.parseInt(System.getProperty("org.apache.activemq.store.journal.active.DefaultLogFileCount", ""+(2)));
+    public static final int DEFAULT_LOGFILE_SIZE = Integer.parseInt(System.getProperty("org.apache.activemq.store.journal.active.DefaultLogFileSize", ""+(1024*1024*20)));
+
+    static final public int SERIALIZED_SIZE = 6+Location.SERIALIZED_SIZE;
+
+    static final public byte DATA_RECORD_TYPE = 1;
+    static final public byte MARK_RECORD_TYPE = 2;
+    static final private NumberFormat onlineLogNameFormat = NumberFormat.getNumberInstance();
+    static {
+        onlineLogNameFormat.setMinimumIntegerDigits(3);
+        onlineLogNameFormat.setMaximumIntegerDigits(3);
+        onlineLogNameFormat.setGroupingUsed(false);
+        onlineLogNameFormat.setParseIntegerOnly(true);
+        onlineLogNameFormat.setMaximumFractionDigits(0);
+    }
+    
+    static final private NumberFormat archiveLogNameFormat = NumberFormat.getNumberInstance();
+    static {
+        archiveLogNameFormat.setMinimumIntegerDigits(8);
+        archiveLogNameFormat.setMaximumIntegerDigits(8);
+        archiveLogNameFormat.setGroupingUsed(false);
+        archiveLogNameFormat.setParseIntegerOnly(true);
+        archiveLogNameFormat.setMaximumFractionDigits(0);
+    }
+
+    // Config
+    private final File logDirectory;
+    private final int initialLogFileSize;
+    private final int onlineLogFileCount;
+    private final AtomicInteger activeLogFileCount = new AtomicInteger(0);
+    
+    // Keeps track of the online log file.
+    private LogFileNode firstNode;
+    private LogFileNode firstActiveNode;
+    private LogFileNode firstInactiveNode;
+    private LogFileNode appendNode;
+
+    private ControlFile controlFile;
+    private int lastLogFileId = -1;
+    private Location lastMark;
+    private boolean disposed;
+    private boolean loadedFromCleanShutDown;
+    
+    private File archiveDirectory;
+    HashMap openArchivedLogs = new HashMap();
+
+    public LogFileManager(File logDirectory) throws IOException {
+        this(logDirectory, DEFAULT_LOGFILE_COUNT, DEFAULT_LOGFILE_SIZE, null);
+    }
+
+    public LogFileManager(File logDirectory, int onlineLogFileCount, int initialLogFileSize, File archiveDirectory) throws IOException {
+        this.logDirectory = logDirectory;
+        this.onlineLogFileCount = onlineLogFileCount;
+        this.initialLogFileSize = initialLogFileSize;
+        initialize(onlineLogFileCount);
+        this.archiveDirectory=archiveDirectory;
+    }
+
+    void initialize(int onlineLogFileCount) throws IOException {
+      try
+      {
+        LogFileNode logFiles[] = new LogFileNode[onlineLogFileCount];
+
+        // Create the log directory if it does not exist.
+        if (!logDirectory.exists()) {
+            if (!logDirectory.mkdirs()) {
+                throw new IOException("Could not create directory: " + logDirectory);
+            }
+        }
+
+        // Open the control file.        
+        int controlDataSize = SERIALIZED_SIZE + (LogFileNode.SERIALIZED_SIZE*onlineLogFileCount);
+        controlFile = new ControlFile(new File(logDirectory, "control.dat"),  controlDataSize);
+        // Make sure we are the only process using the control file.
+        controlFile.lock();
+        
+        // Initialize the nodes.
+        for (int i = 0; i < onlineLogFileCount; i++) {
+            LogFile file = new LogFile(new File(logDirectory, "log-" + onlineLogNameFormat.format(i) + ".dat"),
+                    initialLogFileSize);
+            logFiles[i] = new LogFileNode(file);
+        }
+
+        // Link the nodes together.
+        for (int i = 0; i < onlineLogFileCount; i++) {
+            if (i == (onlineLogFileCount - 1)) {
+                logFiles[i].setNext(logFiles[0]);
+            } else {
+                logFiles[i].setNext(logFiles[i + 1]);
+            }
+        }
+        
+        firstNode = logFiles[0];
+        loadState();
+
+        // Find the first active node
+        for (int i = 0; i < onlineLogFileCount; i++) {
+            if( logFiles[i].isActive() ) {
+                activeLogFileCount.incrementAndGet();
+                if( firstActiveNode == null || logFiles[i].getId() < firstActiveNode.getId() ) {
+                    firstActiveNode = logFiles[i];
+                }
+            }
+        }
+        
+        // None was active? activate one.
+        if ( firstActiveNode == null ) {
+            firstInactiveNode = logFiles[0];
+            activateNextLogFile();
+        } else {            
+            // Find the append log and the first inactive node
+            firstInactiveNode = null;
+            LogFileNode log = firstActiveNode;
+            do {
+                if( !log.isActive() ) {
+                    firstInactiveNode = log;
+                    break;
+                } else {
+                    appendNode = log;
+                }
+                log = log.getNext();
+            } while (log != firstActiveNode);
+        }
+        
+        // If we did not have a clean shut down then we have to check the state 
+        // of the append log.
+        if( !this.loadedFromCleanShutDown ) {
+            checkAppendLog();
+        }
+                    
+        loadedFromCleanShutDown = false;
+        storeState();
+      }
+      catch (JournalLockedException e)
+      {
+        controlFile.dispose();
+        throw e;
+      }
+    }
+
+    private void checkAppendLog() throws IOException {
+        
+        // We are trying to get the true append offset and the last Mark that was written in 
+        // the append log.
+        
+        int offset = 0;
+        Record record = new Record();
+        LogFile logFile = appendNode.getLogFile();
+        Location markLocation=null;
+        
+        while( logFile.loadAndCheckRecord(offset, record) ) {
+            
+            if( record.getLocation().getLogFileId()!= appendNode.getId() || record.getLocation().getLogFileOffset()!=offset ) {
+                // We must have run past the end of the append location.
+                break;
+            }
+
+            if ( record.getRecordType()==LogFileManager.MARK_RECORD_TYPE) {
+                markLocation = record.getLocation();
+            }
+            
+            offset += record.getRecordLength();            
+        }
+        
+        appendNode.setAppendOffset(offset);
+        
+        if( markLocation!=null ) {
+            try {
+                Packet packet = readPacket(markLocation);
+                markLocation = Location.readFromPacket(packet);
+            } catch (InvalidRecordLocationException e) {
+                throw (IOException)new IOException(e.getMessage()).initCause(e);
+            }
+            updateMark(markLocation);
+        }
+        
+    }
+
+    private void storeState() throws IOException {
+        Packet controlData = controlFile.getControlData();
+        if( controlData.remaining() == 0 )
+            return;
+        
+        DataOutput data = new DataOutputStream(new PacketOutputStream(controlData));
+
+        data.writeInt(lastLogFileId);
+        data.writeBoolean(lastMark!=null);
+        if( lastMark!=null )
+            lastMark.writeToDataOutput(data);
+        data.writeBoolean(loadedFromCleanShutDown);
+        
+        // Load each node's state
+        LogFileNode log = firstNode;
+        do {            
+            log.writeExternal( data );
+            log = log.getNext();
+        } while (log != firstNode);
+        
+        controlFile.store();
+    }
+
+    private void loadState() throws IOException {
+        if( controlFile.load() ) {
+            Packet controlData = controlFile.getControlData();
+            if( controlData.remaining() == 0 )
+                return;
+            
+            DataInput data = new DataInputStream(new PacketToInputStream(controlData));
+    
+            lastLogFileId =data.readInt();
+            if( data.readBoolean() )
+                lastMark = Location.readFromDataInput(data);
+            else
+                lastMark = null;
+            loadedFromCleanShutDown = data.readBoolean();
+    
+            // Load each node's state
+            LogFileNode log = firstNode;
+            do {            
+                log.readExternal( data );
+                log = log.getNext();
+            } while (log != firstNode);
+        }
+    }
+
+    public void dispose() {
+
+        if (disposed)
+            return;
+        this.disposed = true;
+        try {
+	        // Close all the opened log files.
+	        LogFileNode log = firstNode;
+	        do {
+	            log.getLogFile().dispose();
+	            log = log.getNext();
+	        } while (log != firstNode);
+
+			Iterator iter = openArchivedLogs.values().iterator();
+			while (iter.hasNext()) {
+			    ((LogFile)iter.next()).dispose();
+            }
+
+            loadedFromCleanShutDown=true;
+	        storeState();
+	        controlFile.dispose();
+        } catch ( IOException e ) {        	
+        }
+        
+    }
+
+    private int getNextLogFileId() {
+        return ++lastLogFileId;
+    }
+
+    /**
+     * @param write
+     * @throws IOException
+     */
+    public void append(BatchedWrite write) throws IOException {
+
+        if (!appendNode.isActive())
+            throw new IllegalStateException("Log file is not active.  Writes are not allowed");
+        if (appendNode.isReadOnly())
+            throw new IllegalStateException("Log file has been marked Read Only.  Writes are not allowed");
+
+        // Write and force the data to disk.
+        LogFile logFile = appendNode.getLogFile();
+        ByteBuffer buffer = ((ByteBufferPacket)write.getPacket().getAdapter(ByteBufferPacket.class)).getByteBuffer();
+        int size = buffer.remaining();
+        logFile.write(appendNode.getAppendOffset(), buffer);
+        if( write.getForce() )
+            logFile.force();
+
+        // Update state
+        appendNode.appended(size);
+        if (write.getMark() != null) {
+            updateMark(write.getMark());
+        }
+    }
+
+    /**
+     * @param write
+     * @throws IOException
+     */
+    synchronized private void updateMark(Location mark) throws IOException {
+        // If we wrote a mark we may need to deactivate some log files.
+        this.lastMark = mark;
+        while (firstActiveNode != appendNode) {
+            if (firstActiveNode.getId() < lastMark.getLogFileId()) {
+                
+                if( archiveDirectory!=null ) {
+                    File file = getArchiveFile(firstActiveNode.getId());
+                    firstActiveNode.getLogFile().copyTo(file);
+                }
+                
+                firstActiveNode.deactivate();
+                activeLogFileCount.decrementAndGet();
+                if( firstInactiveNode == null )
+                    firstInactiveNode = firstActiveNode;
+                firstActiveNode = firstActiveNode.getNextActive();
+                
+            } else {
+                break;
+            }
+        }
+    }
+    
+    private File getArchiveFile(int logId) {
+        return new File(archiveDirectory, "" + archiveLogNameFormat.format(logId) + ".log");
+    }
+    
+    RecordInfo readRecordInfo(Location location) throws IOException, InvalidRecordLocationException {
+
+        LogFile logFile;
+        LogFileNode logFileState = getLogFileWithId(location.getLogFileId());
+        if( logFileState !=null ) {
+            // There can be no record at the append offset.
+            if (logFileState.getAppendOffset() == location.getLogFileOffset()) {
+                throw new InvalidRecordLocationException("No record at (" + location
+                        + ") found.  Location past end of logged data.");
+            }
+            logFile = logFileState.getLogFile();
+        } else {
+            if( archiveDirectory==null ) {
+                throw new InvalidRecordLocationException("Log file: " + location.getLogFileId() + " is not active.");
+            } else {
+                logFile = getArchivedLogFile(location.getLogFileId());
+            }
+        }
+
+        // Is there a record header at the seeked location?
+        try {
+            Record header = new Record();
+            logFile.readRecordHeader(location.getLogFileOffset(), header);
+            return new RecordInfo(location, header, logFileState, logFile);
+        } catch (IOException e) {
+            throw new InvalidRecordLocationException("No record at (" + location + ") found.");
+        }
+    }
+
+    private LogFile getArchivedLogFile(int logFileId) throws InvalidRecordLocationException, IOException {
+        Integer key = new Integer(logFileId);
+        LogFile rc = (LogFile) openArchivedLogs.get(key);
+        if( rc == null ) {
+            File archiveFile = getArchiveFile(logFileId);
+            if( !archiveFile.canRead() )
+                throw new InvalidRecordLocationException("Log file: " + logFileId + " does not exist.");
+            rc = new LogFile(archiveFile, getInitialLogFileSize());
+            openArchivedLogs.put(key, rc);
+            
+            // TODO: turn openArchivedLogs into LRU cache and close old log files.
+        }
+        return rc;
+    }
+
+    LogFileNode getLogFileWithId(int logFileId) throws InvalidRecordLocationException {
+        for (LogFileNode lf = firstActiveNode; lf != null; lf = lf.getNextActive()) {
+            if (lf.getId() == logFileId) {
+                return lf;
+            }
+
+            // Short cut since id's will only increment
+            if (logFileId < lf.getId())
+                break;
+        }
+        return null;
+    }
+
+    /**
+     * @param lastLocation
+     * @return
+     */
+    public Location getNextDataRecordLocation(Location lastLocation) throws IOException, InvalidRecordLocationException {
+        RecordInfo ri = readRecordInfo(lastLocation);
+        while (true) {
+
+            int logFileId = ri.getLocation().getLogFileId();
+            int offset = ri.getNextLocation();
+
+            // Are we overflowing into next logFile?
+            if (offset >= ri.getLogFileState().getAppendOffset()) {
+                LogFileNode nextActive = ri.getLogFileState().getNextActive();
+                if (nextActive == null || nextActive.getId() <= ri.getLogFileState().getId() ) {
+                    return null;
+                }
+                logFileId = nextActive.getId();
+                offset = 0;
+            }
+
+            try {
+                ri = readRecordInfo(new Location(logFileId, offset));
+            } catch (InvalidRecordLocationException e) {
+                return null;
+            }
+
+            // Is the next record the right record type?
+            if (ri.getHeader().getRecordType() == DATA_RECORD_TYPE) {
+                return ri.getLocation();
+            }
+            // No? go onto the next record.
+        }
+    }
+
+    /**
+     * @param logFileIndex
+     * @param logFileOffset
+     * @return
+     * @throws IOException
+     * @throws InvalidRecordLocationException
+     */
+    public Packet readPacket(Location location) throws IOException, InvalidRecordLocationException {
+
+        // Is there a record header at the seeked location?
+        RecordInfo recordInfo = readRecordInfo(location);
+
+        byte data[] = new byte[recordInfo.getHeader().getPayloadLength()];
+
+        LogFile logFile = recordInfo.getLogFile();
+        logFile.read(recordInfo.getDataOffset(), data);
+
+        return new ByteArrayPacket(data);
+
+    }
+
+    public int getInitialLogFileSize() {
+        return initialLogFileSize;
+    }
+
+    public Location getFirstActiveLogLocation() {
+        if (firstActiveNode == null)
+            return null;
+        if (firstActiveNode.getAppendOffset() == 0)
+            return null;
+        return new Location(firstActiveNode.getId(), 0);
+    }
+
+    void activateNextLogFile() throws IOException {
+
+        // The current append logFile becomes readonly
+        if (appendNode != null) {
+            appendNode.setReadOnly(true);
+        }
+
+        LogFileNode next = firstInactiveNode;
+        synchronized (this) {
+            firstInactiveNode = firstInactiveNode.getNextInactive();
+            next.activate(getNextLogFileId());
+            if (firstActiveNode == null) {
+                firstActiveNode = next;
+            }
+        }        
+        activeLogFileCount.incrementAndGet();        
+        appendNode = next;
+        
+        storeState();
+    }
+
+    /**
+     * @return Returns the logDirectory.
+     */
+    public File getLogDirectory() {
+        return logDirectory;
+    }
+
+    /**
+     * @return Returns the lastMark.
+     */
+    public Location getLastMarkedRecordLocation() {
+        return lastMark;
+    }
+
+    public Location getNextAppendLocation() {
+        return new Location(appendNode.getId(), appendNode.getAppendOffset());
+    }
+
+    /**
+     * @return Returns the onlineLogFileCount.
+     */
+    public int getOnlineLogFileCount() {
+        return onlineLogFileCount;
+    }
+
+    public boolean isPastHalfActive() {
+        return (onlineLogFileCount/2.f) < activeLogFileCount.get();
+    }
+
+    synchronized  public Location getFirstRecordLocationOfSecondActiveLogFile() {
+        return firstActiveNode.getNextActive().getFirstRecordLocation();
+    }
+
+    synchronized public boolean canActivateNextLogFile() {
+        return firstInactiveNode!=null;
+    }
+
+}

--- a/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/active/LogFileNode.java
+++ b/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/active/LogFileNode.java
@@ -1,0 +1,161 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.store.journal.active;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+
+/**
+ * @version $Revision: 1.1 $
+ */
+final class LogFileNode {
+    
+    static final public int SERIALIZED_SIZE = 10;
+
+    private final LogFile logFile;    
+    private LogFileNode next;
+
+    /** The id of the log file. */
+    private int id;
+    /** Does it have live records in it? */
+    private boolean active = false;
+    /** Is the log file in readonly mode */
+    private boolean readOnly;
+    /** The location of the next append offset */
+    private int appendOffset = 0;
+
+    public LogFileNode(LogFile logFile) {
+        this.logFile = logFile;
+    }
+
+    public LogFile getLogFile() {
+        return logFile;
+    }
+
+    /////////////////////////////////////////////////////////////
+    //
+    // Method used to mange the state of the log file.
+    //
+    /////////////////////////////////////////////////////////////
+
+    public void activate(int id) {
+        if (active)
+            throw new IllegalStateException("Log already active.");
+        this.id = id;
+        this.readOnly = false;
+        this.active = true;
+        this.appendOffset = 0;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setReadOnly(boolean enable) {
+        if (!active)
+            throw new IllegalStateException("Log not active.");
+        this.readOnly = enable;
+    }
+
+    public void deactivate() throws IOException {
+        if (!active)
+            throw new IllegalStateException("Log already inactive.");      
+        this.active=false; 
+        this.id = -1;
+        this.readOnly = true;
+        this.appendOffset = 0;
+        getLogFile().resize();
+    }
+
+    public boolean isActive() {
+        return active;
+    }
+
+    public int getAppendOffset() {
+        return appendOffset;
+    }
+
+    public Location getFirstRecordLocation() {
+        if (isActive() && appendOffset > 0)
+            return new Location(getId(), 0);
+        return null;
+    }
+
+    public boolean isReadOnly() {
+        return readOnly;
+    }
+
+    public void appended(int i) {
+        appendOffset += i;
+    }
+    
+    /////////////////////////////////////////////////////////////
+    //
+    // Method used to maintain the list of LogFileNodes used by 
+    // the LogFileManager
+    //
+    /////////////////////////////////////////////////////////////
+    
+    public LogFileNode getNext() {
+        return next;
+    }
+
+    public void setNext(LogFileNode state) {
+        next = state;
+    }
+
+    public LogFileNode getNextActive() {
+        if (getNext().isActive())
+            return getNext();
+        return null;
+    }
+
+    public LogFileNode getNextInactive() {
+        if (!getNext().isActive())
+            return getNext();
+        return null;
+    }
+    
+    /**
+     * @param data
+     * @throws IOException 
+     */
+    public void writeExternal(DataOutput data) throws IOException {
+        data.writeInt(id);
+        data.writeBoolean(active);
+        data.writeBoolean(readOnly);
+        data.writeInt(appendOffset);
+    }
+
+    /**
+     * @param data
+     * @throws IOException 
+     */
+    public void readExternal(DataInput data) throws IOException {
+        id = data.readInt();
+        active = data.readBoolean();
+        readOnly = data.readBoolean();
+        appendOffset = data.readInt();
+    }
+
+    public void setAppendOffset(int offset) {
+        appendOffset = offset;
+    }
+
+}

--- a/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/active/Record.java
+++ b/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/active/Record.java
@@ -1,0 +1,308 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.store.journal.active;
+
+import java.io.DataInput;
+import java.io.DataInputStream;
+import java.io.DataOutput;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.zip.CRC32;
+
+import org.apache.activemq.store.journal.adapter.PacketOutputStream;
+import org.apache.activemq.store.journal.adapter.PacketToInputStream;
+import org.apache.activemq.store.journal.packet.ByteArrayPacket;
+import org.apache.activemq.store.journal.packet.Packet;
+
+
+/**
+ * Serializes/Deserializes data records. 
+ * 
+ * @version $Revision: 1.1 $
+ */
+final public class Record {
+    
+    static final public int RECORD_HEADER_SIZE=8+Location.SERIALIZED_SIZE;
+    static final public int RECORD_FOOTER_SIZE=12+Location.SERIALIZED_SIZE;
+	static final public int RECORD_BASE_SIZE=RECORD_HEADER_SIZE+RECORD_FOOTER_SIZE;
+	
+    static final public byte[] START_OF_RECORD 	= new byte[] { 'S', 'o', 'R' }; 
+    static final public byte[] END_OF_RECORD 	= new byte[] { 'E', 'o', 'R', '.' }; 
+        
+	static final public int SELECTED_CHECKSUM_ALGORITHIM;
+	static final public int NO_CHECKSUM_ALGORITHIM=0;
+	static final public int HASH_CHECKSUM_ALGORITHIM=1;
+	static final public int CRC32_CHECKSUM_ALGORITHIM=2;
+	
+	static {
+		String type = System.getProperty("org.apache.activemq.store.journal.active.SELECTED_CHECKSUM_ALGORITHIM", "none");
+		if( "none".equals(type) ) {
+			SELECTED_CHECKSUM_ALGORITHIM = NO_CHECKSUM_ALGORITHIM;			
+		} else if( "crc32".equals(type) ) {
+			SELECTED_CHECKSUM_ALGORITHIM = CRC32_CHECKSUM_ALGORITHIM;			
+		} else if( "hash".equals(type) ) {
+			SELECTED_CHECKSUM_ALGORITHIM = HASH_CHECKSUM_ALGORITHIM;			
+		} else {
+			System.err.println("System property 'org.apache.activemq.store.journal.active.SELECTED_CHECKSUM_ALGORITHIM' not set properly.  Valid values are: 'none', 'hash', or 'crc32'");
+			SELECTED_CHECKSUM_ALGORITHIM = NO_CHECKSUM_ALGORITHIM;			
+		}
+	}
+	
+	static public boolean isChecksumingEnabled() {
+		return SELECTED_CHECKSUM_ALGORITHIM!=NO_CHECKSUM_ALGORITHIM;
+	}
+		    
+    private final ByteArrayPacket headerFooterPacket = new ByteArrayPacket(new byte[RECORD_BASE_SIZE]);
+    private final DataOutputStream headerFooterData = new DataOutputStream(new PacketOutputStream(headerFooterPacket));
+
+    private int payloadLength;
+    private Location location;
+    private byte recordType;        
+    private long checksum;	
+    private Location mark;
+    private Packet payload;
+ 		
+    public Record() {        
+    }
+
+    public Record(byte recordType, Packet payload, Location mark) throws IOException {
+        this(null, recordType, payload, mark);
+    }
+    
+    public Record(Location location, byte recordType, Packet payload, Location mark) throws IOException {
+        this.location = location;
+        this.recordType = recordType;
+        this.mark = mark;
+        this.payload = payload.slice();
+        this.payloadLength = payload.remaining();
+        if( isChecksumingEnabled() ) {
+            checksum(new DataInputStream(new PacketToInputStream(this.payload)));
+        }
+
+        writeHeader(headerFooterData);
+        writeFooter(headerFooterData);
+    }    
+    
+    public void setLocation(Location location) throws IOException {
+        this.location = location;
+        headerFooterPacket.clear();
+        headerFooterPacket.position(8);
+        location.writeToDataOutput(headerFooterData);
+        headerFooterPacket.position(RECORD_HEADER_SIZE+8);
+        location.writeToDataOutput(headerFooterData);
+        payload.clear();
+        headerFooterPacket.position(0);
+        headerFooterPacket.limit(RECORD_HEADER_SIZE);
+    }
+    
+	private void writeHeader( DataOutput out ) throws IOException {
+	    out.write(START_OF_RECORD);
+	    out.writeByte(recordType);
+	    out.writeInt(payloadLength);
+        if( location!=null )
+            location.writeToDataOutput(out);
+        else
+            out.writeLong(0);
+	}	
+	
+	public void readHeader( DataInput in ) throws IOException {
+        readAndCheckConstant(in, START_OF_RECORD, "Invalid record header: start of record constant missing.");
+        recordType = in.readByte();
+        payloadLength = in.readInt();
+        if( payloadLength < 0 )
+            throw new IOException("Invalid record header: record length cannot be less than zero.");
+        location = Location.readFromDataInput(in);
+	}
+	
+	private void writeFooter( DataOutput out ) throws IOException {
+	    out.writeLong(checksum);
+        if( location!=null )
+            location.writeToDataOutput(out);
+        else
+            out.writeLong(0);
+	    out.write(END_OF_RECORD);
+	}
+	
+	public void readFooter( DataInput in ) throws IOException {
+	    long l = in.readLong();	    
+        if( isChecksumingEnabled() ) {
+            if( l!=checksum )            
+                throw new IOException("Invalid record footer: checksum does not match.");
+        } else {
+            checksum = l;            
+        }
+        
+        Location loc = Location.readFromDataInput(in);
+        if( !loc.equals(location) )
+            throw new IOException("Invalid record footer: location id does not match.");
+        
+        readAndCheckConstant(in, END_OF_RECORD, "Invalid record header: end of record constant missing.");
+	}
+	
+    /**
+     * @param randomAccessFile
+     * @throws IOException
+     */
+	public void checksum(DataInput in) throws IOException {
+		if( SELECTED_CHECKSUM_ALGORITHIM==HASH_CHECKSUM_ALGORITHIM ) {
+
+		    byte  buffer[] = new byte[1024];
+			byte rc[] = new byte[8];
+			for (int i = 0; i < payloadLength;) {
+			    int l = Math.min(buffer.length, payloadLength-i);
+				in.readFully(buffer,0,l);
+				for (int j = 0; j < l; j++) {
+					rc[j%8] ^= buffer[j];			
+				}
+				i+=l;
+			}			
+			checksum = (rc[0])|(rc[1]<<1)|(rc[2]<<2)|(rc[3]<<3)|(rc[4]<<4)|(rc[5]<<5)|(rc[6]<<6)|(rc[7]<<7) ;
+			
+		} else if( SELECTED_CHECKSUM_ALGORITHIM==CRC32_CHECKSUM_ALGORITHIM ) {
+			byte  buffer[] = new byte[1024];
+			CRC32 crc32 = new CRC32();
+			for (int i = 0; i < payloadLength;) {
+			    int l = Math.min(buffer.length, payloadLength-i);
+				in.readFully(buffer,0,l);
+				crc32.update(buffer,0,l);
+				i+=l;
+			}			
+			checksum = crc32.getValue();
+		} else {
+		    checksum = 0L;
+		}
+    }
+
+	
+    /**
+     */
+    private void readAndCheckConstant(DataInput in, byte[] byteConstant, String errorMessage ) throws IOException {
+        for (int i = 0; i < byteConstant.length; i++) {
+            byte checkByte = byteConstant[i];
+            if( in.readByte()!= checkByte ) {
+                throw new IOException(errorMessage);
+            }
+        }
+    }    
+    
+    public boolean readFromPacket(Packet packet) throws IOException {
+        Packet dup = packet.duplicate();
+
+        if( dup.remaining() < RECORD_HEADER_SIZE )
+            return false;
+        DataInputStream is = new DataInputStream(new PacketToInputStream(dup));
+        readHeader( is );
+        if( dup.remaining() < payloadLength+RECORD_FOOTER_SIZE ) {
+            return false;
+        }
+        
+        // Set limit to create a slice of the payload.
+        dup.limit(dup.position()+payloadLength);
+        this.payload = dup.slice();        
+	    if( isChecksumingEnabled() ) {
+	        checksum(new DataInputStream(new PacketToInputStream(payload)));
+	    }
+	    
+	    // restore the limit and seek to the footer.
+        dup.limit(packet.limit());
+        dup.position(dup.position()+payloadLength);
+        readFooter(is);
+        
+        // If every thing went well.. advance the position of the orignal packet.
+        packet.position(dup.position());
+        dup.dispose();
+        return true;        
+    }
+    
+    /**
+     * @return Returns the checksum.
+     */
+    public long getChecksum() {
+        return checksum;
+    }
+
+    /**
+     * @return Returns the length.
+     */
+    public int getPayloadLength() {
+        return payloadLength;
+    }
+
+    /**
+     * @return Returns the length of the record .
+     */
+    public int getRecordLength() {
+        return payloadLength+Record.RECORD_BASE_SIZE;
+    }
+
+    /**
+     * @return Returns the location.
+     */
+    public Location getLocation() {
+        return location;
+    }
+    
+    /**
+     * @return Returns the mark.
+     */
+    public Location getMark() {
+        return mark;
+    }
+
+    /**
+     * @return Returns the payload.
+     */
+    public Packet getPayload() {
+        return payload;
+    }
+
+    /**
+     * @return Returns the recordType.
+     */
+    public byte getRecordType() {
+        return recordType;
+    }
+
+	public boolean hasRemaining() {
+		return headerFooterPacket.position()!=RECORD_BASE_SIZE;
+	}
+
+	public void read(Packet packet) {
+		
+		// push the header
+		headerFooterPacket.read(packet);
+		// push the payload.
+		payload.read(packet);
+		
+		// Can we switch to the footer now?
+		if( !payload.hasRemaining() && headerFooterPacket.position()==RECORD_HEADER_SIZE ) {
+			headerFooterPacket.position(RECORD_HEADER_SIZE);
+             headerFooterPacket.limit(RECORD_BASE_SIZE);
+			headerFooterPacket.read(packet);			
+		}
+		
+	}
+
+    public void dispose() {
+        if( payload!=null ) {
+            payload.dispose();
+            payload=null;
+        }
+    }
+
+}

--- a/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/active/RecordInfo.java
+++ b/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/active/RecordInfo.java
@@ -1,0 +1,60 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.store.journal.active;
+
+/**
+ * @version $Revision: 1.1 $
+ */
+final public class RecordInfo {
+
+    private final Location location;
+    private final Record header;
+    private final LogFileNode logFileState;
+    private final LogFile logFile;
+
+    public RecordInfo(Location location, Record header, LogFileNode logFileState, LogFile logFile) {
+        this.location = location;
+        this.header = header;
+        this.logFileState = logFileState;
+        this.logFile = logFile;
+    }
+
+    int getNextLocation() {
+        return location.getLogFileOffset() + header.getPayloadLength() + Record.RECORD_BASE_SIZE;
+    }
+
+    public Record getHeader() {
+        return header;
+    }
+
+    public Location getLocation() {
+        return location;
+    }
+
+    public LogFileNode getLogFileState() {
+        return logFileState;
+    }
+
+    public LogFile getLogFile() {
+        return logFile;
+    }
+
+    public int getDataOffset() {
+        return location.getLogFileOffset() + Record.RECORD_HEADER_SIZE;
+    }
+}

--- a/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/adapter/PacketByteArrayOutputStream.java
+++ b/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/adapter/PacketByteArrayOutputStream.java
@@ -1,0 +1,110 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.store.journal.adapter;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+import org.apache.activemq.store.journal.packet.AppendedPacket;
+import org.apache.activemq.store.journal.packet.ByteArrayPacket;
+import org.apache.activemq.store.journal.packet.Packet;
+
+/**
+ *
+ */
+final public class PacketByteArrayOutputStream extends OutputStream {
+    
+    private Packet result;
+    private Packet current;
+    int nextAllocationSize=0;
+    
+    public PacketByteArrayOutputStream() {
+    	this( 1024 );
+    }
+    
+    public PacketByteArrayOutputStream(int initialSize) {
+    	nextAllocationSize = initialSize;
+        current = allocate();
+    }
+    
+    protected Packet allocate() {
+    	ByteArrayPacket packet = new ByteArrayPacket(new byte[nextAllocationSize]);
+    	nextAllocationSize <<= 3; // x by 8
+        return packet;
+    }
+    
+    public void skip(int size) {
+        while( size > 0 ) {
+            if( !current.hasRemaining() ) {
+                allocatedNext();
+            }
+            
+            int skip = ((size <= current.remaining()) ? size : current.remaining());
+            current.position(current.position()+skip);
+            size -= skip;
+        }
+    }
+    
+    public void write(int b) throws IOException {
+        if( !current.hasRemaining() ) {
+            allocatedNext();
+        }
+        current.write(b);
+    }
+    
+    public void write(byte[] b, int off, int len) throws IOException {
+        while( len > 0 ) {
+	        if( !current.hasRemaining() ) {
+	            allocatedNext();
+	        }
+	        int wrote = current.write(b,off,len);
+	        off+=wrote;
+	        len-=wrote;
+        }
+    }
+    
+    private void allocatedNext() {
+        if( result == null ) {
+            current.flip();
+            result = current;
+        } else {
+            current.flip();
+            result = AppendedPacket.join(result, current);            
+        }
+        current = allocate();
+    }
+    
+    public Packet getPacket() {
+        if( result == null ) {
+            current.flip();
+            return current.slice();
+        } else {
+            current.flip();
+            return AppendedPacket.join(result, current);                
+        }
+    }
+
+    public void reset() {
+        result = null;
+        current.clear();
+    }
+
+    public int position() {
+        return current.position() + (result==null ? 0 : result.remaining());
+    }
+}

--- a/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/adapter/PacketInputStream.java
+++ b/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/adapter/PacketInputStream.java
@@ -1,0 +1,29 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.store.journal.adapter;
+
+import org.apache.activemq.store.journal.packet.Packet;
+
+/**
+ * @deprecated  Use PacketToInputStream instead.  This class will be removed very soon.
+ */
+public class PacketInputStream extends PacketToInputStream {
+    public PacketInputStream(Packet packet) {
+        super(packet);
+    }
+}

--- a/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/adapter/PacketOutputStream.java
+++ b/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/adapter/PacketOutputStream.java
@@ -1,0 +1,47 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.store.journal.adapter;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+import org.apache.activemq.store.journal.packet.Packet;
+
+/**
+ * Provides an OutputStream for a given Packet.
+ *  
+ * @version $Revision$
+ */
+public class PacketOutputStream extends OutputStream {
+    
+    final Packet packet;
+    
+    public PacketOutputStream(Packet packet) {
+        this.packet = packet;
+    }
+
+    public void write(int b) throws IOException {
+        if( !packet.write(b) )
+            throw new IOException("Packet does not have any remaining space to write to.");
+    }
+    
+    public void write(byte[] b, int off, int len) throws IOException {
+        if( packet.write(b, off, len)!=len )
+            throw new IOException("Packet does not have "+len+" byte(s) left to write to.");
+    }
+}

--- a/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/adapter/PacketToInputStream.java
+++ b/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/adapter/PacketToInputStream.java
@@ -1,0 +1,55 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.store.journal.adapter;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.apache.activemq.store.journal.packet.Packet;
+
+/**
+ * Provides an InputStream for a given Packet.
+ *  
+ * @version $Revision$
+ */
+public class PacketToInputStream extends InputStream {
+    
+    final Packet packet;
+    
+    /**
+     * @param packet
+     */
+    public PacketToInputStream(Packet packet) {
+        this.packet = packet;
+    }
+    
+    /**
+     * @see java.io.InputStream#read()
+     */
+    public int read() throws IOException {
+        return packet.read();
+    }
+
+    /**
+     * @see java.io.InputStream#read(byte[], int, int)
+     */
+    public int read(byte[] b, int off, int len) throws IOException {
+        return packet.read(b, off, len);
+    }
+
+}

--- a/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/packet/AppendedPacket.java
+++ b/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/packet/AppendedPacket.java
@@ -1,0 +1,246 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.store.journal.packet;
+
+import java.io.DataOutput;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.reflect.Constructor;
+
+
+/**
+ * Appends two packets together.
+ * 
+ * @version $Revision$
+ */
+final public class AppendedPacket implements Packet {
+
+    private final Packet first;
+    private final Packet last;
+
+    private final int capacity;
+    private final int firstCapacity;
+
+    static public Packet join(Packet first, Packet last) {
+        if( first.hasRemaining() ) {
+            if( last.hasRemaining() ) {
+                
+                //TODO: this might even be a rejoin of the same continous buffer.
+                //It would be good if we detected that and avoided just returned the buffer.
+                
+                return new AppendedPacket(first.slice(), last.slice());               
+            } else {
+                return first.slice();
+            }
+        } else {
+            if( last.hasRemaining() ) {
+                return last.slice();                
+            } else {
+                return EmptyPacket.EMPTY_PACKET;
+            }            
+        }
+    }
+    
+    /**
+     * @deprecated use {@see #join(Packet, Packet)} instead.
+     */
+    public AppendedPacket(Packet first, Packet second) {
+        this.first = first;
+        this.last = second;
+        this.firstCapacity = first.capacity();
+        this.capacity = first.capacity()+last.capacity();
+        clear();        
+    }
+        
+    public void position(int position) {
+        if( position <= firstCapacity ) {
+            last.position(0);
+            first.position(position);
+        } else {
+            last.position(position-firstCapacity);
+            first.position(firstCapacity);
+        }
+    }
+    
+    public void limit(int limit) {
+        if( limit <= firstCapacity ) {
+            last.limit(0);
+            first.limit(limit);
+        } else {
+            last.limit(limit-firstCapacity);
+            first.limit(firstCapacity);
+        }
+    }
+
+    public Packet slice() {
+        return join(first,last);
+    }
+
+    public Packet duplicate() {
+        return new AppendedPacket(first.duplicate(), last.duplicate());               
+    }
+
+    public Object duplicate(ClassLoader cl) throws IOException {
+        try {
+            Class pclazz = cl.loadClass(Packet.class.getName());
+            Class clazz = cl.loadClass(AppendedPacket.class.getName());
+            Constructor constructor = clazz.getConstructor(new Class[]{pclazz, pclazz});
+            return constructor.newInstance(new Object[]{first.duplicate(cl), last.duplicate(cl)});
+        } catch (Throwable e) {
+            throw (IOException)new IOException("Could not duplicate packet in a different classloader: "+e).initCause(e);
+        }
+    }
+    
+    public void flip() {
+        limit(position());
+        position(0);
+    }
+
+    public int position() {
+        return first.position()+last.position();
+    }
+    
+    public int limit() {
+        return first.limit()+last.limit();
+    }    
+
+    public int remaining() {
+        return first.remaining()+last.remaining();
+    }
+
+    public void rewind() {
+        first.rewind();
+        last.rewind();
+    }
+
+    public boolean hasRemaining() {
+        return first.hasRemaining()||last.hasRemaining();
+    }
+
+    public void clear() {
+        first.clear();
+        last.clear();        
+    }
+
+    public int capacity() {
+        return capacity;
+    }
+
+    public void writeTo(OutputStream out) throws IOException {
+        first.writeTo(out);
+        last.writeTo(out);
+    }
+    
+    public void writeTo(DataOutput out) throws IOException {
+        first.writeTo(out);
+        last.writeTo(out);
+    }
+
+
+    /**
+     * @see org.apache.activemq.store.journal.packet.Packet#read()
+     */
+    public int read() {
+        if( first.hasRemaining() ) {
+            return first.read();
+        } else if( last.hasRemaining() ) {
+            return last.read();
+        } else {
+            return -1;
+        }
+    }
+
+    /**
+     * @see org.apache.activemq.store.journal.packet.Packet#read(byte[], int, int)
+     */
+    public int read(byte[] data, int offset, int length) {        
+        
+        int rc1 = first.read(data, offset, length);        
+        if( rc1==-1 ) {
+            int rc2 = last.read(data, offset, length);
+            return ( rc2==-1 ) ? -1 : rc2;
+        } else {
+            int rc2 = last.read(data, offset+rc1, length-rc1);
+            return ( rc2==-1 ) ? rc1 : rc1+rc2;
+        }
+
+    }
+
+    /**
+     * @see org.apache.activemq.store.journal.packet.Packet#write(int)
+     */
+    public boolean write(int data) {
+        if( first.hasRemaining() ) {
+            return first.write(data);
+        } else if( last.hasRemaining() ) {
+            return last.write(data);
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * @see org.apache.activemq.store.journal.packet.Packet#write(byte[], int, int)
+     */
+    public int write(byte[] data, int offset, int length) {
+        int rc1 = first.write(data, offset, length);        
+        if( rc1==-1 ) {
+            int rc2 = last.write(data, offset, length);
+            return ( rc2==-1 ) ? -1 : rc2;
+        } else {
+            int rc2 = last.write(data, offset+rc1, length-rc1);
+            return ( rc2==-1 ) ? rc1 : rc1+rc2;
+        }
+    }
+
+    public int read(Packet dest) {        
+	    int rc = first.read(dest);
+	    rc += last.read(dest);
+	    return rc;
+    }    
+    
+    public String toString() {
+        return "{position="+position()+",limit="+limit()+",capacity="+capacity()+"}";
+    }
+
+    public Object getAdapter(Class target) {
+        if( target.isAssignableFrom(getClass()) ) {
+            return this;
+        }
+        Object object = first.getAdapter(target);
+        if( object == null )
+            object = last.getAdapter(target);
+        return object;
+    }
+
+    public ByteSequence asByteSequence() {      
+        // TODO: implement me
+        return null;
+    }
+
+    public byte[] sliceAsBytes() {
+        // TODO: implement me
+        return null;
+    }
+
+    public void dispose() {
+        first.dispose();
+        last.dispose();
+    }
+
+}

--- a/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/packet/ByteArrayPacket.java
+++ b/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/packet/ByteArrayPacket.java
@@ -1,0 +1,240 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.store.journal.packet;
+
+import java.io.DataOutput;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.reflect.Constructor;
+
+
+/**
+ * Provides a Packet implementation that is directly backed by a <code>byte[]</code>.
+ * 
+ * @version $Revision$
+ */
+final public class ByteArrayPacket implements Packet {
+
+    private final byte buffer[];
+
+    private final int offset;
+    private final int capacity;
+    private int position;
+    private int limit;
+    private int remaining;
+    
+
+    public ByteArrayPacket(byte buffer[]) {
+        this(buffer,0, buffer.length);
+    }
+    
+    public ByteArrayPacket(ByteSequence sequence) {
+        this(sequence.getData(), sequence.getOffset(), sequence.getLength());
+    }
+    
+    public ByteArrayPacket(byte buffer[], int offset, int capacity) {
+        this.buffer = buffer;
+        this.offset=offset;
+        this.capacity=capacity;
+		this.position = 0;
+		this.limit = capacity;
+		this.remaining = limit-position;
+    }
+
+    public int position() {
+        return position;
+    }
+
+    public void position(int position) {
+        this.position = position;
+        remaining = limit-position;
+    }
+
+    public int limit() {
+        return limit;
+    }
+
+    public void limit(int limit) {
+        this.limit = limit;
+        remaining = limit-position;
+    }
+
+    public void flip() {
+        limit = position;
+        position = 0;
+        remaining = limit - position;
+    }
+
+    public int remaining() {
+        return remaining;
+    }
+
+    public void rewind() {
+        position = 0;
+        remaining = limit - position;
+    }
+
+    public boolean hasRemaining() {
+        return remaining > 0;
+    }
+
+    public void clear() {
+        position = 0;
+        limit = capacity;
+        remaining = limit - position;
+    }
+
+    public int capacity() {
+        return capacity;
+    }
+
+    public Packet slice() {
+        return new ByteArrayPacket(buffer, offset+position, remaining);
+    }
+    
+    public Packet duplicate() {
+        return new ByteArrayPacket(buffer, offset, capacity);
+    }
+
+    public Object duplicate(ClassLoader cl) throws IOException {
+        try{
+            Class clazz = cl.loadClass(ByteArrayPacket.class.getName());
+            Constructor constructor = clazz.getConstructor(new Class[]{byte[].class, int.class, int.class});
+            return constructor.newInstance(new Object[]{buffer, new Integer(offset), new Integer(capacity())});
+        } catch (Throwable e) {
+            throw (IOException)new IOException("Could not duplicate packet in a different classloader: "+e).initCause(e);
+        }
+    }
+
+    public void writeTo(OutputStream out) throws IOException {
+        out.write(buffer, offset+position, remaining);
+        position=limit;
+        remaining = limit-position;
+    }
+    
+    public void writeTo(DataOutput out) throws IOException {
+        out.write(buffer, offset+position, remaining);
+        position=limit;
+        remaining = limit-position;
+    }
+
+    /**
+     * @see org.apache.activemq.store.journal.packet.Packet#read()
+     */
+    public int read() {
+        if( !(remaining > 0) )
+            return -1;
+        int rc = buffer[offset+position];
+        position++;
+        remaining = limit-position;
+        return rc & 0xff;
+    }
+
+    /**
+     * @see org.apache.activemq.store.journal.packet.Packet#read(byte[], int, int)
+     */
+    public int read(byte[] data, int offset, int length) {
+        if( !(remaining > 0) )
+            return -1;
+        
+        int copyLength = ((length <= remaining) ? length : remaining);
+        System.arraycopy(buffer, this.offset+position, data, offset, copyLength);
+        position += copyLength;
+        remaining = limit-position;
+        return copyLength;
+    }
+
+    /**
+     * @see org.apache.activemq.store.journal.packet.Packet#write(int)
+     */
+    public boolean write(int data) {
+        if( !(remaining > 0) )
+            return false;
+        buffer[offset+position]=(byte) data;
+        position++;
+        remaining = limit-position;
+        return true;
+    }
+
+    /**
+     * @see org.apache.activemq.store.journal.packet.Packet#write(byte[], int, int)
+     */
+    public int write(byte[] data, int offset, int length) {
+        if( !(remaining > 0) )
+            return -1;
+        
+        int copyLength = ((length <= remaining) ? length : remaining);
+        System.arraycopy(data, offset, buffer, this.offset+position, copyLength);
+        position+=copyLength;
+        remaining = limit-position;
+        return copyLength;
+    }
+
+    public ByteSequence asByteSequence() {
+        return new ByteSequence(buffer, offset+position, remaining);
+    }
+
+    /**
+     * @see org.apache.activemq.store.journal.packet.Packet#sliceAsBytes()
+     */
+    public byte[] sliceAsBytes() {
+        if( buffer.length == remaining ) {
+            return buffer;
+        } else {
+            byte rc[] = new byte[remaining];
+            int op = position;
+            read(rc,0,remaining);
+            position=op;
+            remaining = limit-position;
+            return rc;
+        }
+    }
+    
+    /**
+     * @param dest
+     * @return the number of bytes read into the dest.
+     */
+    public int read(Packet dest) {        
+	    int a = dest.remaining();
+		int rc = ((a <= remaining) ? a : remaining); 
+		if( rc > 0 ) {
+		    dest.write( buffer, offset+position, rc);
+		    position = position+rc;
+	        remaining = limit-position;
+		}
+		return rc;
+    }
+    
+    public String toString() {
+        return "{position="+position+",limit="+limit+",capacity="+capacity+"}";
+    }
+
+    public Object getAdapter(Class target) {
+        if( target.isAssignableFrom(getClass()) ) {
+            return this;
+        }
+        return null;
+    }
+    
+    public byte[] getBuffer() {
+        return buffer;
+    }
+    
+    public void dispose() {        
+    }
+}

--- a/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/packet/ByteBufferPacket.java
+++ b/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/packet/ByteBufferPacket.java
@@ -1,0 +1,285 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.store.journal.packet;
+
+import java.io.DataOutput;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.reflect.Constructor;
+import java.nio.ByteBuffer;
+
+
+/**
+ * Provides a Packet implementation that is backed by a {@see java.nio.ByteBuffer}
+ * 
+ * @version $Revision$
+ */
+final public class ByteBufferPacket implements Packet {
+
+	public static final int DEFAULT_BUFFER_SIZE = Integer.parseInt(System.getProperty("org.apache.activemq.store.DefaultByteBufferSize", ""+(64*1024)));
+	public static final int DEFAULT_DIRECT_BUFFER_SIZE = Integer.parseInt(System.getProperty("org.apache.activemq.store.DefaultDirectByteBufferSize", ""+(8*1024)));
+
+    private final ByteBuffer buffer;
+    private static final int TEMP_BUFFER_SIZE = 64*1024;
+
+    public ByteBufferPacket(ByteBuffer buffer) {
+        this.buffer = buffer;
+        clear();
+    }
+    
+    public ByteBuffer getByteBuffer() {
+        return buffer;
+    }
+    
+    public static ByteBufferPacket createDefaultBuffer(boolean direct) {
+    	if( direct )
+    		return new ByteBufferPacket( ByteBuffer.allocateDirect(DEFAULT_DIRECT_BUFFER_SIZE) );
+    	return new ByteBufferPacket( ByteBuffer.allocate(DEFAULT_BUFFER_SIZE)  );
+    }
+    
+    public void writeTo(OutputStream out) throws IOException {
+        if( buffer.hasArray() ) {
+            
+            // If the buffer is backed by an array.. then use it directly.
+            out.write(buffer.array(), position(), remaining());
+            position(limit());
+            
+        } else {
+            
+            // It's not backed by a buffer.. We can only dump it to a OutputStream via a byte[] so,
+            // create a temp buffer that we can use to chunk it out.            
+            byte temp[] = new byte[TEMP_BUFFER_SIZE];            
+            while( buffer.hasRemaining() ) {
+                int maxWrite = buffer.remaining() > temp.length ? temp.length : buffer.remaining();
+	            buffer.get(temp, 0, maxWrite);
+	            out.write(temp,0, maxWrite);
+            }
+            
+        }        
+    }
+    
+    public void writeTo(DataOutput out) throws IOException {
+        if( buffer.hasArray() ) {
+            
+            // If the buffer is backed by an array.. then use it directly.
+            out.write(buffer.array(), position(), remaining());
+            position(limit());
+            
+        } else {
+            
+            // It's not backed by a buffer.. We can only dump it to a OutputStream via a byte[] so,
+            // create a temp buffer that we can use to chunk it out.            
+            byte temp[] = new byte[TEMP_BUFFER_SIZE];            
+            while( buffer.hasRemaining() ) {
+                int maxWrite = buffer.remaining() > temp.length ? temp.length : buffer.remaining();
+                buffer.get(temp, 0, maxWrite);
+                out.write(temp,0, maxWrite);
+            }
+            
+        }        
+    }
+
+    public int capacity() {
+        return buffer.capacity();
+    }
+
+    public void clear() {
+        buffer.clear();
+    }
+
+    public Packet compact() {
+        buffer.compact();
+        return this;
+    }
+
+    public void flip() {
+        buffer.flip();
+    }
+
+    public boolean hasRemaining() {
+        return buffer.hasRemaining();
+    }
+
+    public boolean isDirect() {
+        return buffer.isDirect();
+    }
+
+    public boolean isReadOnly() {
+        return buffer.isReadOnly();
+    }
+
+    public int limit() {
+        return buffer.limit();
+    }
+
+    public void limit(int arg0) {
+        buffer.limit(arg0);
+    }
+
+    public Packet mark() {
+        buffer.mark();
+        return this;
+    }
+
+    public int position() {
+        return buffer.position();
+    }
+
+    public void position(int arg0) {
+        buffer.position(arg0);
+    }
+
+    public int remaining() {
+        return buffer.remaining();
+    }
+
+    public void rewind() {
+        buffer.rewind();
+    }
+
+    public Packet slice() {
+        return new ByteBufferPacket(buffer.slice());
+    }
+
+    public Packet duplicate() {
+        return new ByteBufferPacket(buffer.duplicate());
+    }
+
+    public Object duplicate(ClassLoader cl) throws IOException {
+        try {
+            Class clazz = cl.loadClass(ByteBufferPacket.class.getName());
+            Constructor constructor = clazz.getConstructor(new Class[]{ByteBuffer.class});
+            return constructor.newInstance(new Object[]{buffer.duplicate()});
+        } catch (Throwable e) {
+            throw (IOException)new IOException("Could not duplicate packet in a different classloader: "+e).initCause(e);
+        }
+
+    }
+    
+
+    /**
+     * @see org.apache.activemq.store.journal.packet.Packet#read()
+     */
+    public int read() {
+        if( !buffer.hasRemaining() )
+            return -1;
+        return buffer.get() & 0xff;
+    }
+
+    /**
+     * @see org.apache.activemq.store.journal.packet.Packet#read(byte[], int, int)
+     */
+    public int read(byte[] data, int offset, int length) {
+        if( !hasRemaining() )
+            return -1;
+        
+        int copyLength = Math.min(length, remaining());
+        buffer.get(data, offset, copyLength);
+        return copyLength;
+    }
+
+    /**
+     * @see org.apache.activemq.store.journal.packet.Packet#write(int)
+     */
+    public boolean write(int data) {
+        if( !buffer.hasRemaining() )
+            return false;
+        buffer.put((byte)data);
+        return true;
+    }
+
+    /**
+     * @see org.apache.activemq.store.journal.packet.Packet#write(byte[], int, int)
+     */
+    public int write(byte[] data, int offset, int length) {
+        if( !hasRemaining() )
+            return -1;
+
+        int copyLength = Math.min(length, remaining());
+        buffer.put(data, offset, copyLength);
+        return copyLength;
+    }
+
+    /**
+     * @see org.apache.activemq.store.journal.packet.Packet#asByteSequence()
+     */
+    public ByteSequence asByteSequence() {
+        if( buffer.hasArray() ) {
+            byte[] bs = buffer.array();
+            return new ByteSequence(bs, buffer.position(), buffer.remaining());
+        } else {
+            byte[] bs = new byte[buffer.remaining()];
+        	int p = buffer.position();
+        	buffer.get(bs);
+        	buffer.position(p);
+        	return new ByteSequence(bs, 0, bs.length);
+        }
+    }
+    
+    /**
+     * @see org.apache.activemq.store.journal.packet.Packet#sliceAsBytes()
+     */
+    public byte[] sliceAsBytes() {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    /**
+     * @param dest
+     * @return the number of bytes read into the dest.
+     */
+    public int read(Packet dest) {
+        
+	    int rc = Math.min(dest.remaining(), remaining()); 
+		if( rc > 0 ) {
+		    
+	        if( dest.getClass() == ByteBufferPacket.class ) {            
+
+			    // Adjust our limit so that we don't overflow the dest buffer. 
+				int limit = limit();
+				limit(position()+rc);
+				
+	            ((ByteBufferPacket)dest).buffer.put(buffer);
+
+	            // restore the limit.
+				limit(limit);
+	            
+	            return 0;
+	        } else {	            
+	            ByteSequence sequence = dest.asByteSequence();
+	            rc = read(sequence.getData(), sequence.getOffset(), sequence.getLength());
+	            dest.position(dest.position()+rc);
+	        }
+		}
+		return rc;
+    }
+	
+    public String toString() {
+        return "{position="+position()+",limit="+limit()+",capacity="+capacity()+"}";
+    }
+
+    public Object getAdapter(Class target) {
+        if( target.isAssignableFrom(getClass()) ) {
+            return this;
+        }
+        return null;
+    }
+    
+    public void dispose() {        
+    }
+}

--- a/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/packet/ByteBufferPacketPool.java
+++ b/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/packet/ByteBufferPacketPool.java
@@ -1,0 +1,47 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.store.journal.packet;
+
+
+import java.nio.ByteBuffer;
+
+/**
+ * Provides a simple pool of ByteBuffer objects.
+ * 
+ * @version $Revision: 1.1 $
+ */
+final public class ByteBufferPacketPool extends PacketPool {
+        
+	private final int packetSize;
+	
+	/**
+	 * Creates a pool of <code>bufferCount</code> ByteBuffers that are 
+	 * directly allocated being <code>bufferSize</code> big.
+	 * 
+	 * @param packetCount the number of buffers that will be in the pool.
+	 * @param packetSize the size of the buffers that are in the pool.
+	 */
+	public ByteBufferPacketPool(int packetCount,int packetSize) {
+		super(packetCount);
+		this.packetSize = packetSize;
+	}
+	
+    protected Packet allocateNewPacket() {
+        return new ByteBufferPacket(ByteBuffer.allocateDirect(packetSize));
+    }	
+}

--- a/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/packet/BytePacket.java
+++ b/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/packet/BytePacket.java
@@ -1,0 +1,210 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.store.journal.packet;
+
+import java.io.DataOutput;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.reflect.Constructor;
+
+
+/**
+ * Provides a Packet implementation that is directly backed by a <code>byte</code>.
+ * 
+ * @version $Revision$
+ */
+final public class BytePacket implements Packet {
+
+    private byte data;
+    private byte position;
+    private byte limit;
+
+    public BytePacket(byte data) {
+        this.data = data;
+        clear();
+    }
+
+    public int position() {
+        return position;
+    }
+
+    public void position(int position) {
+        this.position = (byte) position;
+    }
+
+    public int limit() {
+        return limit;
+    }
+
+    public void limit(int limit) {
+        this.limit = (byte) limit;
+    }
+
+    public void flip() {
+        limit(position());
+        position(0);
+    }
+
+    public int remaining() {
+        return limit() - position();
+    }
+
+    public void rewind() {
+        position(0);
+    }
+
+    public boolean hasRemaining() {
+        return remaining() > 0;
+    }
+
+    public void clear() {
+        position(0);
+        limit(capacity());
+    }
+
+    public int capacity() {
+        return 1;
+    }
+
+    public Packet slice() {
+        if( hasRemaining() )
+            return new BytePacket(data);
+        return EmptyPacket.EMPTY_PACKET;
+    }
+    
+    public Packet duplicate() {
+        BytePacket packet = new BytePacket(data);
+        packet.limit(limit());
+        packet.position(position());
+        return packet;
+    }
+    
+    public Object duplicate(ClassLoader cl) throws IOException {
+        try {
+            Class clazz = cl.loadClass(BytePacket.class.getName());
+            Constructor constructor = clazz.getConstructor(new Class[]{byte.class});
+            return constructor.newInstance(new Object[]{new Byte(data)});
+        } catch (Throwable e) {
+            throw (IOException)new IOException("Could not duplicate packet in a different classloader: "+e).initCause(e);
+        }
+    }
+
+    public void writeTo(OutputStream out) throws IOException {
+        if( hasRemaining() ) {
+            out.write(data);
+            position(1);
+        }
+    }
+
+    public void writeTo(DataOutput out) throws IOException {
+        if( hasRemaining() ) {
+            out.write(data);
+            position(1);
+        }
+    }
+
+    /**
+     * @see org.apache.activemq.store.journal.packet.Packet#read()
+     */
+    public int read() {
+        if( !hasRemaining() )
+            return -1;
+        position(1);
+        return data & 0xff;
+    }
+
+    /**
+     * @see org.apache.activemq.store.journal.packet.Packet#read(byte[], int, int)
+     */
+    public int read(byte[] data, int offset, int length) {
+        if( !hasRemaining() )
+            return -1;
+        
+        if( length > 0 ) {
+            data[offset] = this.data;
+            position(1);
+            return 1;
+        }
+        return 0;
+    }
+
+    /**
+     * @see org.apache.activemq.store.journal.packet.Packet#write(int)
+     */
+    public boolean write(int data) {
+        if( !hasRemaining() )
+            return false;
+        
+        this.data = (byte) data; 
+        position(1);
+        return true;
+    }
+
+    /**
+     * @see org.apache.activemq.store.journal.packet.Packet#write(byte[], int, int)
+     */
+    public int write(byte[] data, int offset, int length) {
+        if( !hasRemaining() )
+            return -1;
+
+        if( length > 0 ) {
+            this.data = data[offset] ;
+            position(1);
+            return 1;
+        }
+        return 0;
+    }
+
+    public ByteSequence asByteSequence() {
+        return null;
+    }
+
+    /**
+     * @see org.apache.activemq.store.journal.packet.Packet#sliceAsBytes()
+     */
+    public byte[] sliceAsBytes() {
+        return null;
+    }
+    
+    /**
+     * @param dest
+     * @return the number of bytes read into the dest.
+     */
+    public int read(Packet dest) {
+        if( hasRemaining() ) {
+            dest.write(data);
+            position(1);
+            return 1;
+        }
+        return 0;
+    }
+    
+    public String toString() {
+        return "{position="+position()+",limit="+limit()+",capacity="+capacity()+"}";
+    }
+
+    public Object getAdapter(Class target) {
+        if( target.isAssignableFrom(getClass()) ) {
+            return this;
+        }
+        return null;
+    }
+    
+    public void dispose() {        
+    }
+}

--- a/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/packet/ByteSequence.java
+++ b/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/packet/ByteSequence.java
@@ -1,0 +1,41 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.store.journal.packet;
+
+public class ByteSequence {
+    final byte[] data;
+    final int offset;
+    final int length;
+
+    public ByteSequence(byte data[], int offset, int length) {
+        this.data = data;
+        this.offset = offset;
+        this.length = length;            
+    }
+    public byte[] getData() {
+        return data;
+    }
+    public int getLength() {
+        return length;
+    }
+    public int getOffset() {
+        return offset;
+    }
+
+}

--- a/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/packet/EOSPacket.java
+++ b/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/packet/EOSPacket.java
@@ -1,0 +1,152 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.store.journal.packet;
+
+import java.io.DataOutput;
+import java.io.IOException;
+import java.io.OutputStream;
+
+
+/**
+ * Provides a Packet implementation that is used to represent the end of a stream.
+ * 
+ * @version $Revision$
+ */
+final public class EOSPacket implements Packet {
+
+    static final public EOSPacket EOS_PACKET = new EOSPacket(); 
+    
+    private EOSPacket() {
+    }
+
+    public void writeTo(OutputStream out) throws IOException {
+    }
+    public void writeTo(DataOutput out) throws IOException {
+    }
+
+    public int position() {
+        return 1;
+    }
+
+    public void position(int position) {
+    }
+
+    public int limit() {
+        return 0;
+    }
+
+    public void limit(int limit) {
+    }
+
+    public void flip() {
+    }
+
+    public int remaining() {
+        return -1;
+    }
+
+    public void rewind() {
+    }
+
+    public boolean hasRemaining() {
+        return false;
+    }
+
+    public void clear() {
+    }
+
+    public int capacity() {
+        return 0;
+    }
+
+    public Packet slice() {
+        return this;
+    }
+    
+    public Packet duplicate() {
+        return this;               
+    }
+
+    public Object duplicate(ClassLoader cl) throws IOException {
+        try {
+            Class clazz = cl.loadClass(EOSPacket.class.getName());
+            return clazz.getField("EOS_PACKET").get(null);
+        } catch (Throwable e) {
+            throw (IOException)new IOException("Could not duplicate packet in a different classloader: "+e).initCause(e);
+        }
+    }
+
+    /**
+     * @see org.apache.activemq.store.journal.packet.Packet#read()
+     */
+    public int read() {
+        return -1;
+    }
+
+    /**
+     * @see org.apache.activemq.store.journal.packet.Packet#read(byte[], int, int)
+     */
+    public int read(byte[] data, int offset, int length) {
+        return -1;
+    }
+
+    /**
+     * @see org.apache.activemq.store.journal.packet.Packet#write(int)
+     */
+    public boolean write(int data) {
+        return false;
+    }
+
+    /**
+     * @see org.apache.activemq.store.journal.packet.Packet#write(byte[], int, int)
+     */
+    public int write(byte[] data, int offset, int length) {
+        return -1;
+    }
+    
+    public ByteSequence asByteSequence() {
+        return EmptyPacket.EMPTY_BYTE_SEQUENCE;
+    }
+
+    public byte[] sliceAsBytes() {
+        return EmptyPacket.EMPTY_BYTE_ARRAY;
+    }
+    
+    /**
+     * @param dest
+     * @return the number of bytes read into the dest.
+     */
+    public int read(Packet dest) {        
+	    return 0;
+    }    
+    
+    public String toString() {
+        return "{position="+position()+",limit="+limit()+",capacity="+capacity()+"}";
+    }
+
+    public Object getAdapter(Class target) {
+        if( target.isAssignableFrom(getClass()) ) {
+            return this;
+        }
+        return null;
+    }
+    
+    public void dispose() {        
+    }
+
+}

--- a/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/packet/EmptyPacket.java
+++ b/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/packet/EmptyPacket.java
@@ -1,0 +1,154 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.store.journal.packet;
+
+import java.io.DataOutput;
+import java.io.IOException;
+import java.io.OutputStream;
+
+
+/**
+ * Provides a Packet implementation that is directly backed by a <code>byte[0]</code>.
+ * 
+ * @version $Revision$
+ */
+final public class EmptyPacket implements Packet {
+
+    static final public EmptyPacket EMPTY_PACKET = new EmptyPacket(); 
+    static final byte EMPTY_BYTE_ARRAY[] = new byte[]{};
+    static final ByteSequence EMPTY_BYTE_SEQUENCE = new ByteSequence(EMPTY_BYTE_ARRAY,0,0);
+    
+    private EmptyPacket() {
+    }
+
+    public void writeTo(OutputStream out) throws IOException {
+    }
+    public void writeTo(DataOutput out) throws IOException {
+    }
+
+    public int position() {
+        return 0;
+    }
+
+    public void position(int position) {
+    }
+
+    public int limit() {
+        return 0;
+    }
+
+    public void limit(int limit) {
+    }
+
+    public void flip() {
+    }
+
+    public int remaining() {
+        return 0;
+    }
+
+    public void rewind() {
+    }
+
+    public boolean hasRemaining() {
+        return false;
+    }
+
+    public void clear() {
+    }
+
+    public int capacity() {
+        return 0;
+    }
+
+    public Packet slice() {
+        return this;
+    }
+    
+    public Packet duplicate() {
+        return this;               
+    }
+    
+    public Object duplicate(ClassLoader cl) throws IOException {
+        try {
+            Class clazz = cl.loadClass(EmptyPacket.class.getName());
+            return clazz.getField("EMPTY_PACKET").get(null);
+        } catch (Throwable e) {
+            throw (IOException)new IOException("Could not duplicate packet in a different classloader: "+e).initCause(e);
+        }
+    }
+
+    /**
+     * @see org.apache.activemq.store.journal.packet.Packet#read()
+     */
+    public int read() {
+        return -1;
+    }
+
+    /**
+     * @see org.apache.activemq.store.journal.packet.Packet#read(byte[], int, int)
+     */
+    public int read(byte[] data, int offset, int length) {
+        return -1;
+    }
+
+    /**
+     * @see org.apache.activemq.store.journal.packet.Packet#write(int)
+     */
+    public boolean write(int data) {
+        return false;
+    }
+
+    /**
+     * @see org.apache.activemq.store.journal.packet.Packet#write(byte[], int, int)
+     */
+    public int write(byte[] data, int offset, int length) {
+        return -1;
+    }
+    
+    public ByteSequence asByteSequence() {
+        return EMPTY_BYTE_SEQUENCE;
+    }
+
+    public byte[] sliceAsBytes() {
+        return EMPTY_BYTE_ARRAY;
+    }
+    
+    /**
+     * @param dest
+     * @return the number of bytes read into the dest.
+     */
+    public int read(Packet dest) {        
+	    return -1;
+    }    
+    
+    public String toString() {
+        return "{position="+position()+",limit="+limit()+",capacity="+capacity()+"}";
+    }
+
+    public Object getAdapter(Class target) {
+        if( target.isAssignableFrom(getClass()) ) {
+            return this;
+        }
+        return null;
+    }
+    
+    public void dispose() {        
+    }
+
+}

--- a/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/packet/FilterPacket.java
+++ b/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/packet/FilterPacket.java
@@ -1,0 +1,138 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.store.journal.packet;
+
+import java.io.DataOutput;
+import java.io.IOException;
+import java.io.OutputStream;
+
+
+/**
+ * Provides a Packet implementation that filters operations to another packet.
+ * 
+ * Used to make it easier to augment the {@see #narrow(Class)}method.
+ * 
+ * @version $Revision$
+ */
+public abstract class FilterPacket implements Packet {
+    final protected Packet next;
+
+    public FilterPacket(Packet next) {
+        this.next = next;
+    }
+
+    public ByteSequence asByteSequence() {
+        return next.asByteSequence();
+    }
+
+    public int capacity() {
+        return next.capacity();
+    }
+
+    public void clear() {
+        next.clear();
+    }
+
+    public void flip() {
+        next.flip();
+    }
+
+    public boolean hasRemaining() {
+        return next.hasRemaining();
+    }
+
+    public int limit() {
+        return next.limit();
+    }
+
+    public void limit(int limit) {
+        next.limit(limit);
+    }
+
+    public Object getAdapter(Class target) {
+        if( target.isAssignableFrom(getClass()) ) {
+            return this;
+        }
+        return next.getAdapter(target);
+    }
+
+    public int position() {
+        return next.position();
+    }
+
+    public void position(int position) {
+        next.position(position);
+    }
+
+    public int read() {
+        return next.read();
+    }
+
+    public int read(byte[] data, int offset, int length) {
+        return next.read(data, offset, length);
+    }
+
+    public int read(Packet dest) {
+        return next.read(dest);
+    }
+
+    public int remaining() {
+        return next.remaining();
+    }
+
+    public void rewind() {
+        next.rewind();
+    }
+
+    public byte[] sliceAsBytes() {
+        return next.sliceAsBytes();
+    }
+
+    public int write(byte[] data, int offset, int length) {
+        return next.write(data, offset, length);
+    }
+
+    public boolean write(int data) {
+        return next.write(data);
+    }
+
+    public void writeTo(OutputStream out) throws IOException {
+        next.writeTo(out);
+    }
+    public void writeTo(DataOutput out) throws IOException {
+        next.writeTo(out);
+    }
+
+    public Object duplicate(ClassLoader cl) throws IOException {
+        return next.duplicate(cl);
+    }
+
+    public Packet duplicate() {
+        return filter(next.duplicate());
+    }
+
+    public Packet slice() {
+        return filter(next.slice());
+    }
+    
+    public void dispose() {
+        next.dispose();
+    }
+
+    abstract public Packet filter(Packet packet);
+}

--- a/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/packet/Packet.java
+++ b/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/packet/Packet.java
@@ -1,0 +1,74 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.store.journal.packet;
+
+import java.io.DataOutput;
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * Provides a ByteBuffer like interface to work with IO channel packets of data.
+ * 
+ * @version $Revision$
+ */
+public interface Packet {
+    
+    public int position();
+    public void position(int position);
+    public int limit();
+    public void limit(int limit);
+    public void flip();
+    public int remaining();
+    public void rewind();
+    public boolean hasRemaining();
+    public void clear();
+    public Packet slice();
+    public Packet duplicate();
+    public Object duplicate(ClassLoader cl) throws IOException;
+    public int capacity();
+    public void dispose();
+    
+    public ByteSequence asByteSequence();
+    public byte[] sliceAsBytes();
+    
+    /**
+     *  @Return object that is an instance of requested type and is associated this this object.  May return null if no 
+     *  object of that type is associated.
+     */
+    Object getAdapter(Class target);
+    
+    
+    /**
+     * Writes the remaing bytes in the packet to the output stream.
+     * 
+     * @param out
+     * @return
+     */
+    void writeTo(OutputStream out) throws IOException;   
+    void writeTo(DataOutput out) throws IOException;
+    
+    // To read data out of the packet.
+    public int read();
+    public int read(byte data[], int offset, int length);
+
+    // To write data into the packet.
+    public boolean write( int data );
+    public int write( byte data[], int offset, int length );
+    public int read(Packet dest);
+    
+}

--- a/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/packet/PacketData.java
+++ b/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/packet/PacketData.java
@@ -1,0 +1,382 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.store.journal.packet;
+
+import java.io.EOFException;
+import java.io.IOException;
+
+
+/**
+ * Used to write and read primitives to and from a Packet.
+ */
+final public class PacketData {
+
+    final private Packet packet;
+    private final boolean bigEndian;
+
+    public PacketData(Packet packet) {
+        this(packet, true);
+    }
+
+    public PacketData(Packet packet, boolean bigEndian) {
+        this.packet = packet;
+        this.bigEndian = bigEndian;
+    }
+
+    private static void spaceNeeded(Packet packet, int space) throws IOException {
+        if (packet.remaining() < space)
+            throw new EOFException("Not enough space left in the packet.");
+    }
+
+    public void readFully(byte[] b) throws IOException {
+        readFully(packet, b, 0, b.length);
+    }
+    
+    public static void readFully(Packet packet, byte[] b) throws IOException {
+        readFully(packet, b, 0, b.length);
+    }
+
+    public void readFully(byte[] b, int off, int len) throws IOException {
+        readFully(packet, b, off, len);
+    }
+    public static void readFully(Packet packet, byte[] b, int off, int len) throws IOException {
+        spaceNeeded(packet, len);
+        packet.read(b, off, len);
+    }
+
+    public int skipBytes(int n) throws IOException {
+        return skipBytes(packet, n);
+    }
+    public static int skipBytes(Packet packet, int n) throws IOException {
+        int rc = Math.min(n, packet.remaining());
+        packet.position(packet.position() + rc);
+        return rc;
+    }
+
+    public boolean readBoolean() throws IOException {
+        return readBoolean(packet);
+    }
+    public static boolean readBoolean(Packet packet) throws IOException {
+        spaceNeeded(packet, 1);
+        return packet.read() != 0;
+    }
+
+    public byte readByte() throws IOException {
+        return readByte(packet);
+    }
+    public static byte readByte(Packet packet) throws IOException {
+        spaceNeeded(packet, 1);
+        return (byte) packet.read();
+    }
+
+    public int readUnsignedByte() throws IOException {
+        return readUnsignedByte(packet);
+    }
+    public static int readUnsignedByte(Packet packet) throws IOException {
+        spaceNeeded(packet, 1);
+        return packet.read();
+    }
+
+    public short readShort() throws IOException {
+        if( bigEndian ) {
+            return readShortBig(packet);
+        } else {
+	        return readShortLittle(packet);
+        }        
+    }
+    public static short readShortBig(Packet packet) throws IOException {
+        spaceNeeded(packet, 2);
+        return (short) ((packet.read() << 8) + (packet.read() << 0));
+    }
+    public static short readShortLittle(Packet packet) throws IOException {
+        spaceNeeded(packet, 2);
+        return (short) ((packet.read() << 0) + (packet.read() << 8) );
+    }
+
+    public int readUnsignedShort() throws IOException {
+        if( bigEndian ) {
+            return readUnsignedShortBig(packet);
+        } else {
+	        return readUnsignedShortLittle(packet);
+        }        
+    }
+    public static int readUnsignedShortBig(Packet packet) throws IOException {
+        spaceNeeded(packet, 2);
+        return ((packet.read() << 8) + (packet.read() << 0));
+    }
+    public static int readUnsignedShortLittle(Packet packet) throws IOException {
+        spaceNeeded(packet, 2);
+        return ((packet.read() << 0) + (packet.read() << 8) );
+    }
+
+    public char readChar() throws IOException {
+        if( bigEndian ) {
+            return readCharBig(packet);
+        } else {
+	        return readCharLittle(packet);
+        }        
+    }
+    public static char readCharBig(Packet packet) throws IOException {
+        spaceNeeded(packet, 2);
+        return (char) ((packet.read() << 8) + (packet.read() << 0));
+    }
+    public static char readCharLittle(Packet packet) throws IOException {
+        spaceNeeded(packet, 2);
+        return (char) ((packet.read() << 0) + (packet.read() << 8) );
+    }
+
+    public int readInt() throws IOException {
+        if( bigEndian ) {
+	        return readIntBig(packet);
+        } else {
+	        return readIntLittle(packet);
+        }        
+    }    
+    public static int readIntBig(Packet packet) throws IOException {
+        spaceNeeded(packet, 4);
+        return ((packet.read() << 24) + 
+                (packet.read() << 16) + 
+                (packet.read() << 8) + 
+                (packet.read() << 0));
+    }    
+    public static int readIntLittle(Packet packet) throws IOException {
+        spaceNeeded(packet, 4);
+        return ((packet.read() << 0) +
+                (packet.read() << 8) + 
+                (packet.read() << 16) + 
+                (packet.read() << 24));
+    }    
+    
+    public long readLong() throws IOException {
+        if( bigEndian ) {
+	        return readLongBig(packet);
+        } else {
+	        return readLongLittle(packet);	                
+        }        
+    }
+    public static long readLongBig(Packet packet) throws IOException {
+        spaceNeeded(packet, 8);
+        return (((long) packet.read() << 56) + 
+                ((long) packet.read() << 48) + 
+                ((long) packet.read() << 40) + 
+                ((long) packet.read() << 32) + 
+                ((long) packet.read() << 24) + 
+                ((packet.read()) << 16) + 
+                ((packet.read()) << 8) + 
+                ((packet.read()) << 0));
+    }
+    public static long readLongLittle(Packet packet) throws IOException {
+        spaceNeeded(packet, 8);
+        return ((packet.read() << 0) +
+                (packet.read() << 8) + 
+                (packet.read() << 16) + 
+                ((long) packet.read() << 24) +
+                ((long) packet.read() << 32) + 
+                ((long) packet.read() << 40) + 
+                ((long) packet.read() << 48) + 
+                ((long) packet.read() << 56));                  
+    }
+    
+    public double readDouble() throws IOException {
+        return Double.longBitsToDouble(readLong());
+    }
+    public static double readDoubleBig(Packet packet) throws IOException {
+        return Double.longBitsToDouble(readLongBig(packet));
+    }
+    public static double readDoubleLittle(Packet packet) throws IOException {
+        return Double.longBitsToDouble(readLongLittle(packet));
+    }
+
+    public float readFloat() throws IOException {
+        return Float.intBitsToFloat(readInt());
+    }
+    public static float readFloatBig(Packet packet) throws IOException {
+        return Float.intBitsToFloat(readIntBig(packet));
+    }
+    public static float readFloatLittle(Packet packet) throws IOException {
+        return Float.intBitsToFloat(readIntLittle(packet));
+    }
+
+    public void write(int b) throws IOException {
+        write(packet, b);
+    }
+    public static void write(Packet packet, int b) throws IOException {
+        spaceNeeded(packet, 1);
+        packet.write(b);
+    }
+
+    public void write(byte[] b) throws IOException {
+        write(packet, b, 0, b.length);
+    }
+    public static void write(Packet packet, byte[] b) throws IOException {
+        write(packet, b, 0, b.length);
+    }
+
+    public void write(byte[] b, int off, int len) throws IOException {
+        write(packet, b, off, len);
+    }
+    public static void write(Packet packet, byte[] b, int off, int len) throws IOException {
+        spaceNeeded(packet, len);
+        packet.write(b, off, len);
+    }
+
+    public void writeBoolean(boolean v) throws IOException {
+        writeBoolean(packet, v);
+    }
+    public static void writeBoolean(Packet packet, boolean v) throws IOException {
+        spaceNeeded(packet, 1);
+        packet.write(v ? 1 : 0);
+    }
+
+    public void writeByte(int v) throws IOException {
+        writeByte(packet, v);
+    }
+    public static void writeByte(Packet packet, int v) throws IOException {
+        spaceNeeded(packet, 1);
+        packet.write(v);
+    }
+
+    public void writeShort(int v) throws IOException {
+        if (bigEndian) {
+	        writeShortBig(packet,v);
+	    } else {
+            writeShortLittle(packet,v);
+	    }
+    }
+    public static void writeShortBig(Packet packet, int v) throws IOException {
+        spaceNeeded(packet, 2);
+        packet.write((v >>> 8) & 0xFF);
+        packet.write((v >>> 0) & 0xFF);
+    }
+    public static void writeShortLittle(Packet packet, int v) throws IOException {
+        spaceNeeded(packet, 2);
+        packet.write((v >>> 0) & 0xFF);
+        packet.write((v >>> 8) & 0xFF);
+    }
+
+    public void writeChar(int v) throws IOException {
+        if (bigEndian) {
+            writeCharBig(packet, v);
+        } else {
+            writeCharLittle(packet, v);
+        }
+    }
+    public static void writeCharBig(Packet packet, int v) throws IOException {
+        spaceNeeded(packet, 2);
+        packet.write((v >>> 8) & 0xFF);
+        packet.write((v >>> 0) & 0xFF);
+    }
+    public static void writeCharLittle(Packet packet, int v) throws IOException {
+        spaceNeeded(packet, 2);
+        packet.write((v >>> 0) & 0xFF);
+        packet.write((v >>> 8) & 0xFF);
+    }
+
+    public void writeInt(int v) throws IOException {
+        if (bigEndian) {
+            writeIntBig(packet, v);
+        } else {
+            writeIntLittle(packet, v);
+        }
+    }
+    public static void writeIntBig(Packet packet, int v) throws IOException {
+        spaceNeeded(packet, 4);
+        packet.write((v >>> 24) & 0xFF);
+        packet.write((v >>> 16) & 0xFF);
+        packet.write((v >>> 8) & 0xFF);
+        packet.write((v >>> 0) & 0xFF);
+    }
+    public static void writeIntLittle(Packet packet, int v) throws IOException {
+        spaceNeeded(packet, 4);
+        packet.write((v >>> 0) & 0xFF);
+        packet.write((v >>> 8) & 0xFF);
+        packet.write((v >>> 16) & 0xFF);
+        packet.write((v >>> 24) & 0xFF);
+    }
+
+    public void writeLong(long v) throws IOException {
+        if (bigEndian) {
+            writeLongBig(packet, v);
+        } else {
+            writeLongLittle(packet, v);
+        }
+    }
+    public static void writeLongBig(Packet packet, long v) throws IOException {
+        spaceNeeded(packet, 8);
+        packet.write((int) (v >>> 56) & 0xFF);
+        packet.write((int) (v >>> 48) & 0xFF);
+        packet.write((int) (v >>> 40) & 0xFF);
+        packet.write((int) (v >>> 32) & 0xFF);
+        packet.write((int) (v >>> 24) & 0xFF);
+        packet.write((int) (v >>> 16) & 0xFF);
+        packet.write((int) (v >>> 8) & 0xFF);
+        packet.write((int) (v >>> 0) & 0xFF);
+    }
+    public static void writeLongLittle(Packet packet, long v) throws IOException {
+        spaceNeeded(packet, 8);
+        packet.write((int) (v >>> 0) & 0xFF);
+        packet.write((int) (v >>> 8) & 0xFF);
+        packet.write((int) (v >>> 16) & 0xFF);
+        packet.write((int) (v >>> 24) & 0xFF);
+        packet.write((int) (v >>> 32) & 0xFF);
+        packet.write((int) (v >>> 40) & 0xFF);
+        packet.write((int) (v >>> 48) & 0xFF);
+        packet.write((int) (v >>> 56) & 0xFF);
+    }
+    
+    public void writeDouble(double v) throws IOException {
+        writeLong(Double.doubleToLongBits(v));
+    }
+    public static void writeDoubleBig(Packet packet, double v) throws IOException {
+        writeLongBig(packet, Double.doubleToLongBits(v));
+    }
+    public static void writeDoubleLittle(Packet packet, double v) throws IOException {
+        writeLongLittle(packet, Double.doubleToLongBits(v));
+    }
+
+    public void writeFloat(float v) throws IOException {
+        writeInt(Float.floatToIntBits(v));
+    }
+    public static void writeFloatBig(Packet packet, float v) throws IOException {
+        writeIntBig(packet, Float.floatToIntBits(v));
+    }
+    public static void writeFloatLittle(Packet packet, float v) throws IOException {
+        writeIntLittle(packet, Float.floatToIntBits(v));
+    }
+    
+    public void writeRawDouble(double v) throws IOException {
+        writeLong(Double.doubleToRawLongBits(v));
+    }
+    public static void writeRawDoubleBig(Packet packet, double v) throws IOException {
+        writeLongBig(packet, Double.doubleToRawLongBits(v));
+    }
+    public static void writeRawDoubleLittle(Packet packet, double v) throws IOException {
+        writeLongLittle(packet, Double.doubleToRawLongBits(v));
+    }
+
+    public void writeRawFloat(float v) throws IOException {
+        writeInt(Float.floatToRawIntBits(v));
+    }
+    public static void writeRawFloatBig(Packet packet, float v) throws IOException {
+        writeIntBig(packet, Float.floatToRawIntBits(v));
+    }
+    public static void writeRawFloatLittle(Packet packet, float v) throws IOException {
+        writeIntLittle(packet, Float.floatToRawIntBits(v));
+    }
+
+}

--- a/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/packet/PacketPool.java
+++ b/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/packet/PacketPool.java
@@ -1,0 +1,145 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.store.journal.packet;
+
+import java.util.ArrayList;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Provides a simple pool of Packet objects.  When the packets that this pool produces are disposed,
+ * they are returned to the pool.
+ * 
+ * @version $Revision: 1.1 $
+ */
+abstract public class PacketPool {
+    
+    public static final int DEFAULT_POOL_SIZE = Integer.parseInt(System.getProperty("org.apache.activemq.store.journal.active.DefaultPoolSize", ""+(5)));
+    public static final int DEFAULT_PACKET_SIZE = Integer.parseInt(System.getProperty("org.apache.activemq.store.journal.active.DefaultPacketSize", ""+(1024*1024*4)));
+    
+	private final ArrayList pool = new ArrayList();
+	private final int maxPackets;
+    private int currentPoolSize;
+    private boolean disposed;
+    
+    public class PooledPacket extends FilterPacket {
+        private final AtomicInteger referenceCounter;
+        
+        public PooledPacket(Packet next) {
+            this(next, new AtomicInteger(0));
+        }
+        
+        private PooledPacket(Packet next, AtomicInteger referenceCounter) {
+            super(next);
+            this.referenceCounter=referenceCounter;
+            this.referenceCounter.incrementAndGet();
+        }
+        
+        public Packet filter(Packet packet) {
+            return new PooledPacket(next, referenceCounter);
+        }
+
+        int getReferenceCounter() {
+            return referenceCounter.get();
+        }
+        
+        public void dispose() {
+            if( referenceCounter.decrementAndGet()==0 ) {
+                returnPacket(next);
+            }
+        }
+    }
+	
+	/**
+	 * @param maxPackets the number of buffers that will be in the pool.
+	 */
+	public PacketPool(int maxPackets) {
+		this.maxPackets = maxPackets;
+	}
+	
+	/**
+	 * Blocks until a ByteBuffer can be retreived from the pool.
+	 * 
+	 * @return
+	 * @throws InterruptedException
+	 */
+	public Packet getPacket() throws InterruptedException {
+	    Packet answer=null;
+		synchronized(this) {
+			while(answer==null) {
+                 if( disposed )
+                     return null;                 
+				if( pool.size()>0) {
+					answer = (Packet) pool.remove(pool.size()-1);
+				} else if( currentPoolSize < maxPackets ) {
+                     answer = allocateNewPacket();
+                     currentPoolSize++;
+                 }
+				if( answer==null ) {
+					this.wait();
+				}
+			}
+		}
+		return new PooledPacket(answer);
+	}
+
+	/**
+	 * Returns a ByteBuffer to the pool.
+	 * 
+	 * @param packet
+	 */
+	private void returnPacket(Packet packet) {
+		packet.clear();
+		synchronized(this) {
+			pool.add(packet);
+			this.notify();
+		}
+	}
+    
+    synchronized public void dispose() {
+        disposed = true;
+        while( currentPoolSize>0 ) {
+            if( pool.size()>0) {
+                currentPoolSize -= pool.size();
+                pool.clear();
+            } else {
+                try {
+                    this.wait();
+                } catch (InterruptedException e) {
+                    return;
+                }
+            }
+        }
+    }
+    
+    synchronized public void waitForPacketsToReturn() {
+        while( currentPoolSize!=pool.size() ) {
+            try {
+                this.wait();
+            } catch (InterruptedException e) {
+                return;
+            }
+        }
+    }
+
+    /**
+     * @return
+     */
+    abstract protected Packet allocateNewPacket();
+        
+}

--- a/activemq-kahadb-store/pom.xml
+++ b/activemq-kahadb-store/pom.xml
@@ -40,11 +40,6 @@
       <artifactId>activemq-broker</artifactId>
     </dependency>
     <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>activeio-core</artifactId>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
       <groupId>org.apache.activemq.protobuf</groupId>
       <artifactId>activemq-protobuf</artifactId>
       <optional>false</optional>

--- a/activemq-karaf/src/main/resources/features-core.xml
+++ b/activemq-karaf/src/main/resources/features-core.xml
@@ -56,7 +56,6 @@
       <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xpp3/${xpp3-bundle-version}</bundle>
       <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xstream/${xstream-bundle-version}</bundle>
       <bundle dependency="true">mvn:org.apache.aries/org.apache.aries.util/${aries-version}</bundle>
-      <bundle dependency="true">mvn:org.apache.activemq/activeio-core/${activeio-version}</bundle>
       <bundle dependency="true">mvn:org.codehaus.jettison/jettison/${jettison-version}</bundle>
       <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-core/${jackson-version}</bundle>
       <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-databind/${jackson-databind-version}</bundle>

--- a/activemq-mqtt/pom.xml
+++ b/activemq-mqtt/pom.xml
@@ -41,11 +41,6 @@
     </dependency>
 
     <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>activeio-core</artifactId>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
       <groupId>org.apache.activemq.protobuf</groupId>
       <artifactId>activemq-protobuf</artifactId>
       <optional>false</optional>

--- a/activemq-openwire-generator/src/main/java/org/apache/activemq/openwire/tool/CHeadersGenerator.java
+++ b/activemq-openwire-generator/src/main/java/org/apache/activemq/openwire/tool/CHeadersGenerator.java
@@ -169,9 +169,9 @@ public class CHeadersGenerator extends SingleSourceGenerator {
                 out.println("   ow_" + type + " " + name + ";");
             } else if (type.equals("byte[]")) {
                 out.println("   ow_byte_array *" + name + ";");
-            } else if (type.equals("org.apache.activeio.packet.ByteSequence")) {
+            } else if (type.equals("org.apache.activemq.store.journal.packet.ByteSequence")) {
                 out.println("   ow_byte_array *" + name + ";");
-            } else if (type.equals("org.apache.activeio.packet.ByteSequence")) {
+            } else if (type.equals("org.apache.activemq.store.journal.packet.ByteSequence")) {
                 out.println("   ow_byte_array *" + name + ";");
             } else if (type.equals("java.lang.String")) {
                 out.println("   ow_string *" + name + ";");

--- a/activemq-openwire-generator/src/main/java/org/apache/activemq/openwire/tool/CSourcesGenerator.java
+++ b/activemq-openwire-generator/src/main/java/org/apache/activemq/openwire/tool/CSourcesGenerator.java
@@ -146,7 +146,7 @@ public class CSourcesGenerator extends CHeadersGenerator {
                 if (size == null) {
                     out.println("   ow_bit_buffer_append(buffer,  object->" + propname + "!=0 );");
                 }
-            } else if (type.equals("org.apache.activeio.packet.ByteSequence")) {
+            } else if (type.equals("org.apache.activemq.store.journal.packet.ByteSequence")) {
                 if (size == null) {
                     out.println("   ow_bit_buffer_append(buffer,  object->" + propname + "!=0 );");
                 }
@@ -205,7 +205,7 @@ public class CSourcesGenerator extends CHeadersGenerator {
                 } else {
                     out.println("   SUCCESS_CHECK(ow_marshal2_byte_array(buffer, bitbuffer, object->" + propname + "));");
                 }
-            } else if (type.equals("org.apache.activeio.packet.ByteSequence")) {
+            } else if (type.equals("org.apache.activemq.store.journal.packet.ByteSequence")) {
                 if (size != null) {
                     out.println("   SUCCESS_CHECK(ow_marshal2_byte_array_const_size(buffer, object->" + propname + ", " + size.asInt() + "));");
                 } else {
@@ -268,7 +268,7 @@ public class CSourcesGenerator extends CHeadersGenerator {
                 } else {
                     out.println("   SUCCESS_CHECK(ow_unmarshal_byte_array(buffer, bitbuffer, &object->" + propname + ", pool));");
                 }
-            } else if (type.equals("org.apache.activeio.packet.ByteSequence")) {
+            } else if (type.equals("org.apache.activemq.store.journal.packet.ByteSequence")) {
                 if (size != null) {
                     out.println("   SUCCESS_CHECK(ow_unmarshal_byte_array_const_size(buffer, &object->" + propname + ", " + size.asInt() + ", pool));");
                 } else {

--- a/activemq-osgi/pom.xml
+++ b/activemq-osgi/pom.xml
@@ -174,7 +174,6 @@
               javax.resource*;resolution:=optional,
               javax.servlet*;resolution:=optional,
               com.thoughtworks.xstream*;resolution:=optional,
-              org.apache.activeio*;resolution:=optional,
               org.apache.camel*;version="${camel-version-range}";resolution:=optional,
               org.apache.camel.spring.handler;version="${camel-version-range}";resolution:=optional,
               org.apache.camel.spring.xml.handler;version="${camel-version-range}";resolution:=optional,

--- a/activemq-spring/pom.xml
+++ b/activemq-spring/pom.xml
@@ -69,11 +69,6 @@
       <artifactId>activemq-kahadb-store</artifactId>
       <optional>true</optional>
     </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>activeio-core</artifactId>
-      <optional>true</optional>
-    </dependency>
     
     <!-- add the optional replication deps -->
     <dependency>

--- a/activemq-tooling/activemq-maven-plugin/pom.xml
+++ b/activemq-tooling/activemq-maven-plugin/pom.xml
@@ -43,10 +43,6 @@
       <artifactId>activemq-console</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.activemq</groupId>
-      <artifactId>activeio-core</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.derby</groupId>
       <artifactId>derby</artifactId>
     </dependency>

--- a/activemq-tooling/activemq-memtest-maven-plugin/pom.xml
+++ b/activemq-tooling/activemq-memtest-maven-plugin/pom.xml
@@ -44,10 +44,6 @@
       <artifactId>activemq-console</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.activemq</groupId>
-      <artifactId>activeio-core</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.derby</groupId>
       <artifactId>derby</artifactId>
     </dependency>

--- a/activemq-tooling/activemq-perf-maven-plugin/pom.xml
+++ b/activemq-tooling/activemq-perf-maven-plugin/pom.xml
@@ -47,10 +47,6 @@
       <artifactId>activemq-console</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.activemq</groupId>
-      <artifactId>activeio-core</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.derby</groupId>
       <artifactId>derby</artifactId>
     </dependency>

--- a/activemq-unit-tests/pom.xml
+++ b/activemq-unit-tests/pom.xml
@@ -75,11 +75,6 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>activeio-core</artifactId>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
       <groupId>org.fusesource.mqtt-client</groupId>
       <artifactId>mqtt-client</artifactId>
     </dependency>

--- a/activemq-unit-tests/src/test/resources/org/apache/activemq/config/sample-conf/journal-example.xml
+++ b/activemq-unit-tests/src/test/resources/org/apache/activemq/config/sample-conf/journal-example.xml
@@ -47,7 +47,7 @@
     </amq:broker>
 
     <!-- The journal implementation that will be used -->
-    <bean id="myJournalImpl" class="org.apache.activeio.journal.active.JournalImpl">
+    <bean id="myJournalImpl" class="org.apache.activemq.store.journal.active.JournalImpl">
         <constructor-arg index="0">
             <bean id="myFile" class="java.io.File">
                 <constructor-arg index="0">

--- a/activemq-web-demo/pom.xml
+++ b/activemq-web-demo/pom.xml
@@ -176,16 +176,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>activeio-core</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>javax.servlet</groupId>
-          <artifactId>servlet-api</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>org.apache.activemq</groupId>
       <artifactId>activemq-jaas</artifactId>
       <optional>true</optional>

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -39,10 +39,6 @@
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>activeio-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
       <artifactId>activemq-client</artifactId>
     </dependency>
     <dependency>

--- a/assembly/src/main/descriptors/common-bin.xml
+++ b/assembly/src/main/descriptors/common-bin.xml
@@ -185,7 +185,6 @@
         <include>${pom.groupId}:activemq-pool</include>
         <include>${pom.groupId}:activemq-partition</include>
         <include>${pom.groupId}:activemq-shiro</include>
-        <include>${pom.groupId}:activeio-core</include>
         <include>commons-beanutils:commons-beanutils</include>
         <include>commons-collections:commons-collections</include>
         <include>commons-io:commons-io</include>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,6 @@
     <!-- for reproducible builds -->	
     <project.build.outputTimestamp>2022-03-01T14:36:07Z</project.build.outputTimestamp>
 
-    <activeio-version>3.1.4</activeio-version>
     <siteId>activemq-${project.version}</siteId>
     <projectName>Apache ActiveMQ</projectName>
     <!-- base url for site deployment.  See distribution management for full url.  Override this in settings.xml for staging -->
@@ -409,18 +408,6 @@
         <artifactId>activemq-web</artifactId>
         <version>${project.version}</version>
         <type>war</type>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.activemq</groupId>
-        <artifactId>activeio-core</artifactId>
-        <version>${activeio-version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.activemq</groupId>
-        <artifactId>activeio-core</artifactId>
-        <version>${activeio-version}</version>
-        <type>test-jar</type>
-        <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.activemq</groupId>


### PR DESCRIPTION
- [x] Relocate the subset of activeio classes used by jdbc journal to jdbc-store module
- [x] Remove activeio-core (no other module uses it)
- [x] Rename System properties activeio -> activemq.store.journal
- [x] Update javadoc @see: references
- [x] Deprecate JDBC Journal for removal

Note: The activeio classes are used by the JDBC Journal from 4.x era, not the more modern JDBCPersistenceAdapter.