### PR TITLE
Added additional logging on BrokerService startup

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/broker/BrokerService.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/BrokerService.java
@@ -668,10 +668,13 @@ public class BrokerService implements Service {
         persistenceAdapterToStart.setBrokerName(getBrokerName());
         LOG.info("Using Persistence Adapter: {}", persistenceAdapterToStart);
         if (deleteAllMessagesOnStartup) {
+            LOG.info("Deleting all messages on startup, because deleteAllMessagesOnStartup is true");
             deleteAllMessages();
         }
+        LOG.info("Starting Persistence Adapter: {}", persistenceAdapterToStart);
         persistenceAdapterToStart.start();
 
+        LOG.info("Starting Temp Data Store");
         getTempDataStore();
         if (tempDataStore != null) {
             try {
@@ -685,6 +688,7 @@ public class BrokerService implements Service {
             }
         }
 
+        LOG.info("Starting Job Scheduler Store");
         getJobSchedulerStore();
         if (jobSchedulerStore != null) {
             try {


### PR DESCRIPTION
### Description
Adding some logging on startup of BrokerService. We had an occurrence where broker was stuck on startup for 33 minutes with the following logs: 
```
2022-10-24 12:33:01,972 | INFO  | Using Persistence Adapter: KahaDBPersistenceAdapter[/data/kahadb] | org.apache.activemq.broker.BrokerService | main
// ~33 mins between these 2 logs 
2022-10-24 13:06:23,710 | INFO  | KahaDB is version 6 | org.apache.activemq.store.kahadb.MessageDatabase | main
```
Normally, loading time between these 2 log entries is several seconds.
This logs supposed to give more insights during the next occurrence of the issue on where broker spent this time.