### PR TITLE
Added additional logging on BrokerService startup

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/broker/BrokerService.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/BrokerService.java
@@ -668,10 +668,13 @@ public class BrokerService implements Service {
         persistenceAdapterToStart.setBrokerName(getBrokerName());
         LOG.info("Using Persistence Adapter: {}", persistenceAdapterToStart);
         if (deleteAllMessagesOnStartup) {
+            LOG.info("Deleting all messages on startup because deleteAllMessagesOnStartup configuration has been provided");
             deleteAllMessages();
         }
+        LOG.info("Starting Persistence Adapter: {}", persistenceAdapterToStart);
         persistenceAdapterToStart.start();
 
+        LOG.info("Starting Temp Data Store");
         getTempDataStore();
         if (tempDataStore != null) {
             try {
@@ -685,6 +688,7 @@ public class BrokerService implements Service {
             }
         }
 
+        LOG.info("Starting Job Scheduler Store");
         getJobSchedulerStore();
         if (jobSchedulerStore != null) {
             try {
@@ -696,6 +700,7 @@ public class BrokerService implements Service {
                 throw exception;
             }
         }
+        LOG.info("Persistence Adapter successfully started");
     }
 
     private void startBroker(boolean async) throws Exception {

--- a/activemq-kahadb-store/src/main/java/org/apache/activemq/store/kahadb/KahaDBStore.java
+++ b/activemq-kahadb-store/src/main/java/org/apache/activemq/store/kahadb/KahaDBStore.java
@@ -207,8 +207,8 @@ public class KahaDBStore extends MessageDatabase implements PersistenceAdapter, 
     public void doStart() throws Exception {
         //configure the metadata before start, right now
         //this is just the open wire version
+        LOG.info("Starting KahaDBStore");
         configureMetadata();
-
         super.doStart();
 
         if (brokerService != null) {

--- a/activemq-kahadb-store/src/main/java/org/apache/activemq/store/kahadb/MessageDatabase.java
+++ b/activemq-kahadb-store/src/main/java/org/apache/activemq/store/kahadb/MessageDatabase.java
@@ -457,6 +457,7 @@ public abstract class MessageDatabase extends ServiceSupport implements BrokerSe
     }
 
     public void open() throws IOException {
+        LOG.info("Opening MessageDatabase");
         if( opened.compareAndSet(false, true) ) {
             getJournal().start();
             try {


### PR DESCRIPTION
### Description
Adding some logging on startup of BrokerService. We had an occurrence where broker was stuck on startup for 33 minutes with the following logs:
```
2022-10-24 12:33:01,972 | INFO  | Using Persistence Adapter: KahaDBPersistenceAdapter[/data/kahadb] | org.apache.activemq.broker.BrokerService | main
// ~33 mins between these 2 logs 
2022-10-24 13:06:23,710 | INFO  | KahaDB is version 6 | org.apache.activemq.store.kahadb.MessageDatabase | main
```
Normally, broker loading time between these 2 log entries is several seconds.
This logs supposed to give more insights during the next occurrence of the issue on where broker spent this time.