### PR TITLE
Track scheduler activity

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/broker/BrokerService.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/BrokerService.java
@@ -231,6 +231,7 @@ public class BrokerService implements Service {
     private boolean forceStart = false;
     private IOExceptionHandler ioExceptionHandler;
     private boolean schedulerSupport = false;
+    private String schedulerActivityDestination = null;
     private int maxSchedulerRepeatAllowed = MAX_SCHEDULER_REPEAT_ALLOWED;
     private File schedulerDirectoryFile;
     private Scheduler scheduler;
@@ -1693,11 +1694,11 @@ public class BrokerService implements Service {
     }
     
     public boolean isEnableMessageExpirationOnActiveDurableSubs() {
-    	return enableMessageExpirationOnActiveDurableSubs;
+        return enableMessageExpirationOnActiveDurableSubs;
     }
     
     public void setEnableMessageExpirationOnActiveDurableSubs(boolean enableMessageExpirationOnActiveDurableSubs) {
-    	this.enableMessageExpirationOnActiveDurableSubs = enableMessageExpirationOnActiveDurableSubs;
+        this.enableMessageExpirationOnActiveDurableSubs = enableMessageExpirationOnActiveDurableSubs;
     }
 
     public boolean isUseVirtualTopics() {
@@ -2976,6 +2977,20 @@ public class BrokerService implements Service {
      */
     public void setSchedulerSupport(boolean schedulerSupport) {
         this.schedulerSupport = schedulerSupport;
+    }
+
+    /**
+     * @param schedulerActivityDestination the schedulerActivityDestination to set
+     */
+    public void setSchedulerActivityDestination(String schedulerActivityDestination) {
+        this.schedulerActivityDestination = schedulerActivityDestination;
+    }
+
+    /**
+     * @return the schedulerActivityDestination
+     */
+    public String getSchedulerActivityDestination() {
+        return schedulerActivityDestination;
     }
 
     /**

--- a/activemq-client/src/main/java/org/apache/activemq/ScheduledMessage.java
+++ b/activemq-client/src/main/java/org/apache/activemq/ScheduledMessage.java
@@ -78,4 +78,19 @@ public interface ScheduledMessage {
      */
     public static final String AMQ_SCHEDULER_ACTION_END_TIME = "ACTION_END_TIME";
 
+    /**
+     *  Used to specify which scheduler activity was performed on a Scheduled Message
+     */
+    public static final String AMQ_SCHEDULER_ACTIVITY = "AMQ_SCHEDULER_ACTIVITY";
+
+    /**
+     *  Scheduled Message was scheduled by the scheduler
+     */
+    public static final String AMQ_SCHEDULER_ACTIVITY_SCHEDULED = "SCHEDULED";
+
+    /**
+     *  Scheduled Message was dispatched by the scheduler
+     */
+    public static final String AMQ_SCHEDULER_ACTIVITY_DISPATCHED = "DISPATCHED";
+
 }


### PR DESCRIPTION
[AMQ-9188](https://issues.apache.org/jira/browse/AMQ-9188)

Augment scheduler to forward scheduled and dispatched messages to a destination, if such is configured.
e.g.
<broker ... schedulerSupport="true" schedulerActivityDestination="topic://ActiveMQ.Scheduler.Activity" >
If schedulerActivityDestination is not set, current behavior is unaffected.
Otherwise...
When message is successfully scheduled scheduler should set property AMQ_SCHEDULER_ACTIVITY to SCHEDULED and forward scheduled message to the schedulerActivityDestination
When message is successfully dispatched scheduler should set property AMQ_SCHEDULER_ACTIVITY to DISPATCHED and forward scheduled message to the schedulerActivityDestination

> Note: This adds a `schedulerActivityDestination` parameter and requires a schema change for a valid use. Until schema change becomes available, this feature can be used by turning validation off `bin/activemq console xbean:conf/activemq.xml?validate=false`
