### PR TITLE
Track scheduler activity

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/broker/BrokerService.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/BrokerService.java
@@ -231,6 +231,7 @@ public class BrokerService implements Service {
     private boolean forceStart = false;
     private IOExceptionHandler ioExceptionHandler;
     private boolean schedulerSupport = false;
+    private String schedulerActivityDestination = null;
     private int maxSchedulerRepeatAllowed = MAX_SCHEDULER_REPEAT_ALLOWED;
     private File schedulerDirectoryFile;
     private Scheduler scheduler;
@@ -1693,11 +1694,11 @@ public class BrokerService implements Service {
     }
     
     public boolean isEnableMessageExpirationOnActiveDurableSubs() {
-    	return enableMessageExpirationOnActiveDurableSubs;
+        return enableMessageExpirationOnActiveDurableSubs;
     }
     
     public void setEnableMessageExpirationOnActiveDurableSubs(boolean enableMessageExpirationOnActiveDurableSubs) {
-    	this.enableMessageExpirationOnActiveDurableSubs = enableMessageExpirationOnActiveDurableSubs;
+        this.enableMessageExpirationOnActiveDurableSubs = enableMessageExpirationOnActiveDurableSubs;
     }
 
     public boolean isUseVirtualTopics() {
@@ -2976,6 +2977,20 @@ public class BrokerService implements Service {
      */
     public void setSchedulerSupport(boolean schedulerSupport) {
         this.schedulerSupport = schedulerSupport;
+    }
+
+    /**
+     * @param schedulerActivityDestination the schedulerActivityDestination to set
+     */
+    public void setSchedulerActivityDestination(String schedulerActivityDestination) {
+        this.schedulerActivityDestination = schedulerActivityDestination;
+    }
+
+    /**
+     * @return the schedulerActivityDestination
+     */
+    public String getSchedulerActivityDestination() {
+        return schedulerActivityDestination;
     }
 
     /**

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/BrokerService.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/BrokerService.java
@@ -79,6 +79,7 @@ import org.apache.activemq.broker.region.virtual.VirtualDestination;
 import org.apache.activemq.broker.region.virtual.VirtualDestinationInterceptor;
 import org.apache.activemq.broker.region.virtual.VirtualTopic;
 import org.apache.activemq.broker.scheduler.JobSchedulerStore;
+import org.apache.activemq.broker.scheduler.JobSchedulerActivityListener;
 import org.apache.activemq.broker.scheduler.SchedulerBroker;
 import org.apache.activemq.broker.scheduler.memory.InMemoryJobSchedulerStore;
 import org.apache.activemq.command.ActiveMQDestination;
@@ -231,7 +232,6 @@ public class BrokerService implements Service {
     private boolean forceStart = false;
     private IOExceptionHandler ioExceptionHandler;
     private boolean schedulerSupport = false;
-    private String schedulerActivityDestination = null;
     private int maxSchedulerRepeatAllowed = MAX_SCHEDULER_REPEAT_ALLOWED;
     private File schedulerDirectoryFile;
     private Scheduler scheduler;
@@ -245,6 +245,7 @@ public class BrokerService implements Service {
     private boolean networkConnectorStartAsync = false;
     private boolean allowTempAutoCreationOnSend;
     private JobSchedulerStore jobSchedulerStore;
+    private JobSchedulerActivityListener jobSchedulerActivityListener;
     private final AtomicLong totalConnections = new AtomicLong();
     private final AtomicInteger currentConnections = new AtomicInteger();
 
@@ -1975,6 +1976,14 @@ public class BrokerService implements Service {
         configureService(jobSchedulerStore);
     }
 
+    public void setJobSchedulerActivityListener(JobSchedulerActivityListener jobSchedulerActivityListener) {
+        this.jobSchedulerActivityListener = jobSchedulerActivityListener;
+    }
+
+    public JobSchedulerActivityListener getJobSchedulerActivityListener() {
+        return jobSchedulerActivityListener;
+    }
+
     //
     // Implementation methods
     // -------------------------------------------------------------------------
@@ -2977,20 +2986,6 @@ public class BrokerService implements Service {
      */
     public void setSchedulerSupport(boolean schedulerSupport) {
         this.schedulerSupport = schedulerSupport;
-    }
-
-    /**
-     * @param schedulerActivityDestination the schedulerActivityDestination to set
-     */
-    public void setSchedulerActivityDestination(String schedulerActivityDestination) {
-        this.schedulerActivityDestination = schedulerActivityDestination;
-    }
-
-    /**
-     * @return the schedulerActivityDestination
-     */
-    public String getSchedulerActivityDestination() {
-        return schedulerActivityDestination;
     }
 
     /**

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/scheduler/JobSchedulerActivityListener.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/scheduler/JobSchedulerActivityListener.java
@@ -1,0 +1,24 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.broker.scheduler;
+
+import org.apache.activemq.command.Message;
+
+public interface JobSchedulerActivityListener {
+    public void scheduled(SchedulerBroker schedulerBroker, final Message messageSend) throws Exception;
+    public void dispatched(SchedulerBroker schedulerBroker, final Message messageSend) throws Exception;
+}

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/scheduler/JobSchedulerForwardingActivityListener.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/scheduler/JobSchedulerForwardingActivityListener.java
@@ -1,0 +1,76 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.broker.scheduler;
+
+import org.apache.activemq.ScheduledMessage;
+
+import org.apache.activemq.command.Message;
+import org.apache.activemq.command.ActiveMQDestination;
+
+/**
+ * Job Scheduler Activity listener that forwards scheduled and dispatched messages to a specified destination
+ */
+public class JobSchedulerForwardingActivityListener implements JobSchedulerActivityListener {
+
+    private ActiveMQDestination destination = ActiveMQDestination.createDestination(ScheduledMessage.AMQ_SCHEDULER_ACTIVITY_DESTINATION, ActiveMQDestination.TOPIC_TYPE);
+
+    private JobSchedulerForwardingActivityListenerMessageFormat format = new JobSchedulerForwardingActivityListenerAdvisoryMessageFormat();
+
+    @Override
+    public void scheduled(SchedulerBroker schedulerBroker, final Message messageSend) throws Exception {
+        Message msg = format.format(messageSend);
+        schedulerBroker.forwardMessage(schedulerBroker.getConnectionContext(), msg, destination);
+    }
+
+    @Override
+    public void dispatched(SchedulerBroker schedulerBroker, final Message messageSend) throws Exception {
+        Message msg = format.format(messageSend);
+        schedulerBroker.forwardMessage(schedulerBroker.getConnectionContext(), msg, destination);
+    }
+
+    /**
+    * @param destination the destination to set
+    */
+    public void setSchedulerActivityDestination(ActiveMQDestination destination) {
+        this.destination = destination;
+    }
+
+    /**
+     * @return the destination
+     */
+    public ActiveMQDestination getSchedulerActivityDestination() {
+        return destination;
+    }
+
+    /**
+    * @param format the format to set
+    */
+    public void setFormat(JobSchedulerForwardingActivityListenerMessageFormat format) {
+        this.format = format;
+    }
+
+    /**
+     * @return the format
+     */
+    public JobSchedulerForwardingActivityListenerMessageFormat getFormat() {
+        return format;
+    }
+
+	public String toString() {
+		return getClass().getName()+" "+destination+" "+format;
+	}
+}

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/scheduler/JobSchedulerForwardingActivityListenerAdvisoryMessageFormat.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/scheduler/JobSchedulerForwardingActivityListenerAdvisoryMessageFormat.java
@@ -1,0 +1,38 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.broker.scheduler;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.activemq.ScheduledMessage;
+
+/**
+ * Job Scheduler Forwarding Activity Listener Message Format that strips the body of the forwarded message 
+ */
+public class JobSchedulerForwardingActivityListenerAdvisoryMessageFormat extends JobSchedulerForwardingActivityListenerMetadataOnlyMessageFormat {
+
+    private static final List<String> ADVISORY_PROPERTIES = Arrays.asList(ScheduledMessage.AMQ_SCHEDULED_ID, ScheduledMessage.AMQ_SCHEDULER_ACTIVITY);
+
+    public JobSchedulerForwardingActivityListenerAdvisoryMessageFormat() {
+        setIncludes(ADVISORY_PROPERTIES);
+    }
+
+    public String toString() {
+        return getClass().getName()+" "+ADVISORY_PROPERTIES;
+    }
+}

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/scheduler/JobSchedulerForwardingActivityListenerAsIsMessageFormat.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/scheduler/JobSchedulerForwardingActivityListenerAsIsMessageFormat.java
@@ -1,0 +1,31 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.broker.scheduler;
+
+import org.apache.activemq.command.Message;
+
+/**
+ * Job Scheduler Forwarding Activity Listener Message Format that leaves the forwarded message as is
+ */
+public class JobSchedulerForwardingActivityListenerAsIsMessageFormat implements JobSchedulerForwardingActivityListenerMessageFormat {
+
+    @Override
+    public Message format(final Message messageSend) throws Exception {
+        return messageSend.copy();
+    }
+
+}

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/scheduler/JobSchedulerForwardingActivityListenerMessageFormat.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/scheduler/JobSchedulerForwardingActivityListenerMessageFormat.java
@@ -1,0 +1,23 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.broker.scheduler;
+
+import org.apache.activemq.command.Message;
+
+public interface JobSchedulerForwardingActivityListenerMessageFormat {
+    public Message format(final Message message) throws Exception;
+}

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/scheduler/JobSchedulerForwardingActivityListenerMetadataOnlyMessageFormat.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/scheduler/JobSchedulerForwardingActivityListenerMetadataOnlyMessageFormat.java
@@ -37,7 +37,19 @@ public class JobSchedulerForwardingActivityListenerMetadataOnlyMessageFormat imp
     public Message format(final Message messageSend) throws Exception {
         Message msg = messageSend.copy();
         msg.clearBody();
+
+        Set<String> allIncludes = new HashSet<>();
         if(includes != null) {
+            allIncludes.addAll(allIncludes);
+        }
+
+        String activityHeadersString = (String)msg.getProperty(ScheduledMessage.AMQ_SCHEDULER_ACTIVITY_FWD_HEADERS);
+        if(activityHeadersString != null) {
+            List<String> activityHeadersList = Arrays.asList(activityHeadersString.split("[ ,]"));
+            allIncludes.addAll(activityHeadersList);
+        }
+
+        if(allIncludes.size() > 0) {
             for(String key : msg.getProperties().keySet()) {
                 if(includes.contains(key)) {
                     continue;

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/scheduler/JobSchedulerForwardingActivityListenerMetadataOnlyMessageFormat.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/scheduler/JobSchedulerForwardingActivityListenerMetadataOnlyMessageFormat.java
@@ -1,0 +1,58 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.broker.scheduler;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.HashSet;
+
+import org.apache.activemq.ScheduledMessage;
+
+import org.apache.activemq.command.Message;
+
+/**
+ * Job Scheduler Forwarding Activity Listener Message Format that strips the body of the forwarded message 
+ * If includes are specified, only the specified metadata will be copied
+ */
+public class JobSchedulerForwardingActivityListenerMetadataOnlyMessageFormat implements JobSchedulerForwardingActivityListenerMessageFormat {
+
+    private Set<String> includes = null;
+
+    @Override
+    public Message format(final Message messageSend) throws Exception {
+        Message msg = messageSend.copy();
+        msg.clearBody();
+        if(includes != null) {
+            for(String key : msg.getProperties().keySet()) {
+                if(includes.contains(key)) {
+                    continue;
+                }
+                msg.removeProperty(key);
+            }
+        }
+        return msg;
+    }
+
+    public void setIncludes(String[] includes) {
+        setIncludes(Arrays.asList(includes));
+    }
+
+    public void setIncludes(List<String> includes) {
+        this.includes = new HashSet<>(includes);
+    }
+}

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/scheduler/JobSchedulerMultipleActivityListeners.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/scheduler/JobSchedulerMultipleActivityListeners.java
@@ -1,0 +1,64 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.broker.scheduler;
+
+import java.util.List;
+
+import org.apache.activemq.ScheduledMessage;
+
+import org.apache.activemq.command.Message;
+import org.apache.activemq.command.ActiveMQDestination;
+
+/**
+ * Job Scheduler Activity listener that forwards scheduled and dispatched messages to other listeners
+ */
+public class JobSchedulerMultipleActivityListeners implements JobSchedulerActivityListener {
+
+    private List <JobSchedulerActivityListener> listeners = null;
+
+    @Override
+    public void scheduled(SchedulerBroker schedulerBroker, final Message messageSend) throws Exception {
+		for(JobSchedulerActivityListener listener : listeners) {
+			listener.scheduled(schedulerBroker, messageSend);
+		}
+    }
+
+    @Override
+    public void dispatched(SchedulerBroker schedulerBroker, final Message messageSend) throws Exception {
+		for(JobSchedulerActivityListener listener : listeners) {
+			listener.dispatched(schedulerBroker, messageSend);
+		}
+    }
+
+    /**
+    * @param listeners the listeners to set
+    */
+    public void setListeners(List<JobSchedulerActivityListener> listeners) {
+        this.listeners = listeners;
+    }
+
+    /**
+     * @return the listeners
+     */
+    public List<JobSchedulerActivityListener> getListeners() {
+        return listeners;
+    }
+
+	public String toString() {
+		return getClass().getName()+" "+listeners;
+	}
+}

--- a/activemq-client/src/main/java/org/apache/activemq/ScheduledMessage.java
+++ b/activemq-client/src/main/java/org/apache/activemq/ScheduledMessage.java
@@ -81,6 +81,11 @@ public interface ScheduledMessage {
     /**
      *  Used to specify which scheduler activity was performed on a Scheduled Message
      */
+    public static final String AMQ_SCHEDULER_ACTIVITY_DESTINATION = "ActiveMQ.Scheduler.Activity";
+
+    /**
+     *  Used to specify which scheduler activity was performed on a Scheduled Message
+     */
     public static final String AMQ_SCHEDULER_ACTIVITY = "AMQ_SCHEDULER_ACTIVITY";
 
     /**

--- a/activemq-client/src/main/java/org/apache/activemq/ScheduledMessage.java
+++ b/activemq-client/src/main/java/org/apache/activemq/ScheduledMessage.java
@@ -84,6 +84,11 @@ public interface ScheduledMessage {
     public static final String AMQ_SCHEDULER_ACTIVITY_DESTINATION = "ActiveMQ.Scheduler.Activity";
 
     /**
+     *  Used to specify desired activity properties 
+     */
+    public static final String AMQ_SCHEDULER_ACTIVITY_FWD_HEADERS = "AMQ_SCHEDULER_ACTIVITY_FWD_HEADERS";
+
+    /**
      *  Used to specify which scheduler activity was performed on a Scheduled Message
      */
     public static final String AMQ_SCHEDULER_ACTIVITY = "AMQ_SCHEDULER_ACTIVITY";

--- a/activemq-client/src/main/java/org/apache/activemq/ScheduledMessage.java
+++ b/activemq-client/src/main/java/org/apache/activemq/ScheduledMessage.java
@@ -78,4 +78,19 @@ public interface ScheduledMessage {
      */
     public static final String AMQ_SCHEDULER_ACTION_END_TIME = "ACTION_END_TIME";
 
+    /**
+     *  Used to specify which scheduler activity was performed on a Scheduled Message
+     */
+    public static final String AMQ_SCHEDULER_ACTIVITY = "AMQ_SCHEDULER_ACTIVITY";
+
+    /**
+     *  Scheduled Message was scheduled by the scheduler
+     */
+    public static final String AMQ_SCHEDULER_ACTIVITY_SCHEDULED = "SCHEDULED";
+
+    /**
+     *  Scheduled Message was dispatched by the scheduler
+     */
+    public static final String AMQ_SCHEDULER_ACTIVITY_DISPATCHED = "DISPATCHED";
+
 }


### PR DESCRIPTION
[AMQ-9188](https://issues.apache.org/jira/browse/AMQ-9188)
Augment scheduler to forward scheduled and dispatched messages to a destination, if such is configured.
e.g.
<broker ... schedulerSupport="true" schedulerActivityDestination="topic://ActiveMQ.Scheduler.Activity" >
If schedulerActivityDestination is not set, current behavior is unaffected.
Otherwise...
When message is successfully scheduled scheduler should set property AMQ_SCHEDULER_ACTIVITY to SCHEDULED and forward scheduled message to the schedulerActivityDestination
When message is successfully dispatched scheduler should set property AMQ_SCHEDULER_ACTIVITY to DISPATCHED and forward scheduled message to the schedulerActivityDestination