### PR TITLE
[AMQ-8354] Add helper methods needed for replica plugin.

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/broker/Broker.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/Broker.java
@@ -412,5 +412,5 @@ public interface Broker extends Region, Service {
 
     void networkBridgeStopped(BrokerInfo brokerInfo);
 
-
+    void queuePurged(ConnectionContext context, ActiveMQDestination destination);
 }

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/BrokerFilter.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/BrokerFilter.java
@@ -413,4 +413,9 @@ public class BrokerFilter implements Broker {
     public void networkBridgeStopped(BrokerInfo brokerInfo) {
         getNext().networkBridgeStopped(brokerInfo);
     }
+
+    @Override
+    public void queuePurged(ConnectionContext context, ActiveMQDestination destination) {
+        getNext().queuePurged(context, destination);
+    }
 }

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/ConnectionContext.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/ConnectionContext.java
@@ -245,7 +245,7 @@ public class ConnectionContext {
         return userName;
     }
 
-    protected void setUserName(String userName) {
+    public void setUserName(String userName) {
         this.userName = userName;
     }
 

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/EmptyBroker.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/EmptyBroker.java
@@ -359,4 +359,7 @@ public class EmptyBroker implements Broker {
         return null;
     }
 
+    @Override
+    public void queuePurged(ConnectionContext context, ActiveMQDestination destination) {
+    }
 }

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/ErrorBroker.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/ErrorBroker.java
@@ -410,4 +410,9 @@ public class ErrorBroker implements Broker {
     public void networkBridgeStopped(BrokerInfo brokerInfo) {
         throw new BrokerStoppedException(this.message);
     }
+
+    @Override
+    public void queuePurged(ConnectionContext context, ActiveMQDestination destination) {
+        throw new BrokerStoppedException(this.message);
+    }
 }

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/region/PrefetchSubscription.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/region/PrefetchSubscription.java
@@ -18,6 +18,7 @@ package org.apache.activemq.broker.region;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -163,6 +164,8 @@ public abstract class PrefetchSubscription extends AbstractSubscription {
     public void processMessageDispatchNotification(MessageDispatchNotification mdn) throws Exception {
         synchronized(pendingLock) {
             try {
+                okForAckAsDispatchDone.countDown();
+
                 pending.reset();
                 while (pending.hasNext()) {
                     MessageReference node = pending.next();
@@ -563,6 +566,12 @@ public abstract class PrefetchSubscription extends AbstractSubscription {
         if (this.pending!=null) {
             this.pending.setSystemUsage(usageManager);
             this.pending.setMemoryUsageHighWaterMark(getCursorMemoryHighWaterMark());
+        }
+    }
+
+    public List<MessageReference> getDispatched() {
+        synchronized(dispatchLock) {
+            return new ArrayList<>(dispatched);
         }
     }
 

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/scheduler/SchedulerBroker.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/scheduler/SchedulerBroker.java
@@ -24,11 +24,11 @@ import javax.jms.MessageFormatException;
 import org.apache.activemq.ScheduledMessage;
 import org.apache.activemq.advisory.AdvisorySupport;
 import org.apache.activemq.broker.Broker;
-import org.apache.activemq.broker.BrokerFilter;
 import org.apache.activemq.broker.BrokerService;
 import org.apache.activemq.broker.Connection;
 import org.apache.activemq.broker.ConnectionContext;
 import org.apache.activemq.broker.Connector;
+import org.apache.activemq.broker.MutableBrokerFilter;
 import org.apache.activemq.broker.ProducerBrokerExchange;
 import org.apache.activemq.broker.region.ConnectionStatistics;
 import org.apache.activemq.command.ActiveMQDestination;
@@ -54,7 +54,7 @@ import org.apache.activemq.wireformat.WireFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class SchedulerBroker extends BrokerFilter implements JobListener {
+public class SchedulerBroker extends MutableBrokerFilter implements JobListener {
     private static final Logger LOG = LoggerFactory.getLogger(SchedulerBroker.class);
     private static final IdGenerator ID_GENERATOR = new IdGenerator();
     private static final LongSequenceGenerator longGenerator = new LongSequenceGenerator();
@@ -462,7 +462,7 @@ public class SchedulerBroker extends BrokerFilter implements JobListener {
             producerExchange.setProducerState(new ProducerState(new ProducerInfo()));
             try {
                 context.setProducerFlowControl(false);
-                this.next.send(producerExchange, msg);
+                this.getNext().send(producerExchange, msg);
             } finally {
                 context.setProducerFlowControl(originalFlowControl);
             }


### PR DESCRIPTION
AMQ-8354

extracted internal changes from https://github.com/apache/activemq/pull/848 to make it easier to review.

Added some new methods that will be used only in replica plugin.
Updated `processDispatchNotification` and related methods to work correctly(it's not been used since pure master-slave feature was deleted). it will also be used in the plugin