### PR TITLE
[AMQ-9199] Fixed race condition in creating store directory

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/util/IOHelper.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/util/IOHelper.java
@@ -328,6 +328,10 @@ public final class IOHelper {
 
         } else {
             if (!dir.mkdirs()) {
+                if ( dir.exists() && dir.isDirectory() ) {
+                    // Directory created in parallel
+                    return;
+                }
                 throw new IOException("Failed to create directory '" + dir + "'");
             }
         }

--- a/activemq-kahadb-store/src/test/java/org/apache/activemq/store/kahadb/MessageDatabaseTest.java
+++ b/activemq-kahadb-store/src/test/java/org/apache/activemq/store/kahadb/MessageDatabaseTest.java
@@ -17,10 +17,13 @@
 
 package org.apache.activemq.store.kahadb;
 
-import static org.apache.activemq.store.kahadb.disk.journal.Journal.DEFAULT_MAX_WRITE_BATCH_SIZE;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import org.apache.activemq.ActiveMQMessageAuditNoSync;
+import org.apache.activemq.broker.BrokerService;
+import org.apache.activemq.store.kahadb.disk.journal.Journal;
+import org.apache.activemq.util.ByteSequence;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
@@ -29,13 +32,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.activemq.ActiveMQMessageAuditNoSync;
-import org.apache.activemq.broker.BrokerService;
-import org.apache.activemq.store.kahadb.disk.journal.Journal;
-import org.apache.activemq.util.ByteSequence;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import static org.apache.activemq.store.kahadb.disk.journal.Journal.DEFAULT_MAX_WRITE_BATCH_SIZE;
+import static org.junit.Assert.*;
 
 public class MessageDatabaseTest {
 


### PR DESCRIPTION
A store directory is created by `MessageDatabase.getPageFile()` which is called in two cases:
1. `KahaDBStore.start()` when creating a queue
2. `KahaDBStore.size()` which is performed when sending any persistent message

If both methods are called concurrently it's possible to get an IOException thrown from the `IOHelper.mkdirs()` method.