### PR TITLE
[AMQ-9207] Upgrade various dependencies

### DIFF
--- a/activemq-rar/pom.xml
+++ b/activemq-rar/pom.xml
@@ -110,8 +110,8 @@
           <artifactId>junit</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>regexp</groupId>
-          <artifactId>regexp</artifactId>
+          <groupId>jakarta-regexp</groupId>
+          <artifactId>jakarta-regexp</artifactId>
         </exclusion>
         <exclusion>
           <groupId>javax.jmdns</groupId>

--- a/activemq-unit-tests/pom.xml
+++ b/activemq-unit-tests/pom.xml
@@ -240,8 +240,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>regexp</groupId>
-      <artifactId>regexp</artifactId>
+      <groupId>jakarta-regexp</groupId>
+      <artifactId>jakarta-regexp</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -44,14 +44,14 @@
     <activemq-protobuf-version>1.1</activemq-protobuf-version>
     <activesoap-version>1.3</activesoap-version>
     <annogen-version>0.1.0</annogen-version>
-    <ant-version>1.10.12</ant-version>
+    <ant-version>1.10.13</ant-version>
     <aries-version>1.1.0</aries-version>
     <axion-version>1.0-M3-dev</axion-version>
     <camel-version>2.25.4</camel-version>
     <camel-version-range>[2.20,4)</camel-version-range>
     <commons-beanutils-version>1.9.4</commons-beanutils-version>
     <commons-collections-version>3.2.2</commons-collections-version>
-    <commons-daemon-version>1.3.2</commons-daemon-version>
+    <commons-daemon-version>1.3.3</commons-daemon-version>
     <commons-dbcp2-version>2.9.0</commons-dbcp2-version>
     <commons-io-version>2.11.0</commons-io-version>
     <commons-logging-version>1.2</commons-logging-version>
@@ -63,8 +63,8 @@
     <hadoop-version>1.2.1</hadoop-version>
     <hawtbuf-version>1.11</hawtbuf-version>
     <hawtdispatch-version>1.22</hawtdispatch-version>
-    <httpclient-version>4.5.13</httpclient-version>
-    <httpcore-version>4.4.15</httpcore-version>
+    <httpclient-version>4.5.14</httpclient-version>
+    <httpcore-version>4.4.16</httpcore-version>
     <insight-version>1.2.0.Beta4</insight-version>
     <jackson-version>2.14.0</jackson-version>
     <jasypt-version>1.9.3</jasypt-version>
@@ -73,7 +73,7 @@
     <jetty-version>${jetty9-version}</jetty-version>
     <jmdns-version>3.4.1</jmdns-version>
     <tomcat-api-version>9.0.65</tomcat-api-version>
-    <jettison-version>1.5.2</jettison-version>
+    <jettison-version>1.5.3</jettison-version>
     <jmock-version>2.5.1</jmock-version>
     <jolokia-version>1.7.1</jolokia-version>
     <josql-version>1.5_5</josql-version>
@@ -93,16 +93,16 @@
     <qpid-proton-version>0.33.10</qpid-proton-version>
     <qpid-jms-version>1.6.0</qpid-jms-version>
     <netty-version>4.1.75.Final</netty-version>
-    <regexp-version>1.3</regexp-version>
+    <regexp-version>1.4</regexp-version>
     <rome-version>1.18.0</rome-version>
-    <shiro-version>1.10.1</shiro-version>
+    <shiro-version>1.11.0</shiro-version>
     <slf4j-version>1.7.36</slf4j-version>
     <snappy-version>1.1.2</snappy-version>
     <spring-version>5.3.23</spring-version>
     <taglibs-version>1.2.5</taglibs-version>
     <velocity-version>2.3</velocity-version>
     <xpp3-version>1.1.4c</xpp3-version>
-    <xstream-version>1.4.19</xstream-version>
+    <xstream-version>1.4.20</xstream-version>
     <xbean-version>4.22</xbean-version>
     <xerces-version>2.12.2</xerces-version>
     <jaxb-basics-version>0.12.0</jaxb-basics-version>
@@ -906,8 +906,8 @@
       </dependency>
 
       <dependency>
-        <groupId>regexp</groupId>
-        <artifactId>regexp</artifactId>
+        <groupId>jakarta-regexp</groupId>
+        <artifactId>jakarta-regexp</artifactId>
         <version>${regexp-version}</version>
       </dependency>
 


### PR DESCRIPTION
Dependency updates:

com.thoughtworks.xstream:xstream .................... 1.4.19 -> 1.4.20 
commons-daemon:commons-daemon ......................... 1.3.2 -> 1.3.3 
org.apache.ant:ant ................................ 1.10.12 -> 1.10.13 
org.apache.shiro:shiro-core ......................... 1.10.1 -> 1.11.0 
org.apache.shiro:shiro-spring ....................... 1.10.1 -> 1.11.0 
org.codehaus.jettison:jettison ........................ 1.5.2 -> 1.5.3 
regexp:regexp ............................................. 1.3 -> 1.5 
org.apache.httpcomponents:httpclient ................ 4.5.13 -> 4.5.14 
org.apache.httpcomponents:httpcore .................. 4.4.15 -> 4.4.16