### PR TITLE
WIP: [AMQ-8320] Add JMS 2.0 JMSProducer deliveryDelay support

### DIFF
--- a/activemq-client/src/main/java/org/apache/activemq/ActiveMQMessageConsumer.java
+++ b/activemq-client/src/main/java/org/apache/activemq/ActiveMQMessageConsumer.java
@@ -629,6 +629,9 @@ public class ActiveMQMessageConsumer implements MessageAvailableConsumer, StatsC
                 }
             });
         }
+        if (m.propertyExists(ActiveMQMessage.JMS_DELIVERY_TIME_PROPERTY)) {
+            m.setJMSDeliveryTime(m.getLongProperty(ActiveMQMessage.JMS_DELIVERY_TIME_PROPERTY));
+        }
         return m;
     }
 

--- a/activemq-client/src/main/java/org/apache/activemq/ActiveMQProducer.java
+++ b/activemq-client/src/main/java/org/apache/activemq/ActiveMQProducer.java
@@ -35,6 +35,7 @@ import jakarta.jms.MessageFormatRuntimeException;
 import jakarta.jms.ObjectMessage;
 import jakarta.jms.TextMessage;
 
+import org.apache.activemq.command.ActiveMQMessage;
 import org.apache.activemq.util.JMSExceptionSupport;
 import org.apache.activemq.util.TypeConversionSupport;
 
@@ -46,6 +47,7 @@ public class ActiveMQProducer implements JMSProducer {
     // QoS override of defaults on a per-JMSProducer instance basis
     private String correlationId = null;
     private byte[] correlationIdBytes = null;
+    private Long deliveryDelay = null;
     private Integer deliveryMode = null;
     private Boolean disableMessageID = false;
     private Boolean disableMessageTimestamp = false;
@@ -85,6 +87,13 @@ public class ActiveMQProducer implements JMSProducer {
                 for(Map.Entry<String, Object> propertyEntry : messageProperties.entrySet()) {
                     message.setObjectProperty(propertyEntry.getKey(), propertyEntry.getValue());
                 }
+            }
+
+            // Producer setting for deliveryDelay will override user-specified ActiveMQ Scheduled Delay property
+            if(this.deliveryDelay != null) {
+                long deliveryTimeMillis = System.currentTimeMillis() + this.deliveryDelay;
+                message.setLongProperty(ScheduledMessage.AMQ_SCHEDULED_DELAY, this.deliveryDelay);
+                message.setLongProperty(ActiveMQMessage.JMS_DELIVERY_TIME_PROPERTY, deliveryTimeMillis);
             }
 
             activemqMessageProducer.send(destination, message, getDeliveryMode(), getPriority(), getTimeToLive(), getDisableMessageID(), getDisableMessageTimestamp(), null);
@@ -243,12 +252,13 @@ public class ActiveMQProducer implements JMSProducer {
 
     @Override
     public JMSProducer setDeliveryDelay(long deliveryDelay) {
-        throw new UnsupportedOperationException("setDeliveryDelay(long) is not supported");
+        this.deliveryDelay = deliveryDelay;
+        return this;
     }
 
     @Override
     public long getDeliveryDelay() {
-        throw new UnsupportedOperationException("getDeliveryDelay() is not supported");
+        return this.deliveryDelay;
     }
 
     @Override

--- a/activemq-client/src/main/java/org/apache/activemq/command/ActiveMQMessage.java
+++ b/activemq-client/src/main/java/org/apache/activemq/command/ActiveMQMessage.java
@@ -48,6 +48,7 @@ public class ActiveMQMessage extends Message implements org.apache.activemq.Mess
     public static final byte DATA_STRUCTURE_TYPE = CommandTypes.ACTIVEMQ_MESSAGE;
     public static final String DLQ_DELIVERY_FAILURE_CAUSE_PROPERTY = "dlqDeliveryFailureCause";
     public static final String BROKER_PATH_PROPERTY = "JMSActiveMQBrokerPath";
+    public static final String JMS_DELIVERY_TIME_PROPERTY = "JMSDeliveryTime";
 
     private static final Map<String, PropertySetter> JMS_PROPERTY_SETERS = new HashMap<String, PropertySetter>();
 


### PR DESCRIPTION
1. DeliveryDelay producer value set to ActiveMQ header for scheduler
2. DeliveryTime value stored as message header on produce
3. DeliveryTime header removed on consume