### PR TITLE
AMQ-9161 - Fix javadoc comment so Xbean parsing works

### DIFF
--- a/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/JournalPersistenceAdapter.java
+++ b/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/JournalPersistenceAdapter.java
@@ -82,13 +82,11 @@ import org.slf4j.LoggerFactory;
  * {@link Journal} and then check pointing asynchronously on a timeout with some
  * other long term persistent storage.
  *
+ *  @deprecated - Deprecated for removal as this PersistenceAdapter is no longer used and
+ *  replaced by the JDBCPersistenceAdapter.
+ *
  * @org.apache.xbean.XBean
  *
- */
-
-/**
- * Deprecated for removal as this PersistenceAdapter is no longer used and
- * replaced by the JDBCPersistenceAdapter.
  */
 @Deprecated(forRemoval = true)
 public class JournalPersistenceAdapter implements PersistenceAdapter, JournalEventListener, UsageListener, BrokerServiceAware {

--- a/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/JournalPersistenceAdapterFactory.java
+++ b/activemq-jdbc-store/src/main/java/org/apache/activemq/store/journal/JournalPersistenceAdapterFactory.java
@@ -36,14 +36,12 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Factory class that can create PersistenceAdapter objects.
- * 
- * @org.apache.xbean.XBean
- * 
- */
-
-/**
- * Deprecated for removal as this PersistenceAdapter is no longer used and
+ *
+ * @deprecated Deprecated for removal as this PersistenceAdapter is no longer used and
  * replaced by the JDBCPersistenceAdapter.
+ *
+ * @org.apache.xbean.XBean
+ *
  */
 @Deprecated(forRemoval = true)
 public class JournalPersistenceAdapterFactory extends DataSourceServiceSupport implements PersistenceAdapterFactory {


### PR DESCRIPTION
The previous comment added in PR #989 added a second javadoc comment which prevent Xbean from generating the correct schema