### PR TITLE
upgrade m-bundl-p: fixes RB issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
     <javaee-javadoc-url>http://download.oracle.com/javaee/6/api/</javaee-javadoc-url>
 
     <!-- Maven Plugin Version for this Project -->
-    <maven-bundle-plugin-version>5.1.8</maven-bundle-plugin-version>
+    <maven-bundle-plugin-version>5.1.9</maven-bundle-plugin-version>
     <maven-surefire-plugin-version>3.0.0-M8</maven-surefire-plugin-version>
     <maven-antrun-plugin-version>3.1.0</maven-antrun-plugin-version>
     <maven-assembly-plugin-version>3.4.2</maven-assembly-plugin-version>


### PR DESCRIPTION
last release was not fully reproducible: https://github.com/jvm-repo-rebuild/reproducible-central/blob/master/content/org/apache/activemq/README.md
one issue was https://issues.apache.org/jira/browse/FELIX-6602, fixed with maven-bundle-plugin 5.1.9

other issue remains to be studied and fixed: perhaps it's due to https://issues.apache.org/jira/browse/MNG-7750, which would mean that using Maven 3.9.2 would be necessary to have a Reproducible Build