### PR TITLE
AdvisoryBroker#handleFireFailure: Remove unused placeholder in warn l…

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/advisory/AdvisoryBroker.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/advisory/AdvisoryBroker.java
@@ -851,8 +851,7 @@ public class AdvisoryBroker extends BrokerFilter {
     }
 
     private void handleFireFailure(String message, Throwable cause) {
-        LOG.warn("Failed to fire {} advisory, reason: {}", message, cause);
-        LOG.debug("{} detail: {}", message, cause, cause);
+        LOG.warn("Failed to fire {} advisory", message, cause);
     }
 
     protected void fireAdvisory(ConnectionContext context, ActiveMQTopic topic, Command command) throws Exception {


### PR DESCRIPTION
…og message. All information is already logged at warn level, so remove additional debug log message.

Before this change the warn log message was e.g. `Failed to fire slow consumer advisory, reason: {}`