### PR TITLE
[AMQ-8611] Describe message size limit init parameter

### DIFF
--- a/activemq-web-demo/src/main/webapp/WEB-INF/web.xml
+++ b/activemq-web-demo/src/main/webapp/WEB-INF/web.xml
@@ -68,6 +68,15 @@
                 <param-value>consumer.prefetchSize=1</param-value>
         </init-param> 
         -->
+        <!--
+        Uncomment this parameter if you plan to change the default max size of a message over REST. By default, it is set
+        to 100,000. Set it to -1 to disable the limitation but be aware that your AMQ instance could run out of memory if
+        the message is too big. See https://issues.apache.org/jira/browse/AMQ-8029 for more details.
+        <init-param>
+            <param-name>maxMessageSize</param-name>
+            <param-value>-1</param-value>
+        </init-param>
+        -->
     </servlet>
 
     <!-- the queue browse servlet -->

--- a/assembly/src/release/webapps/api/WEB-INF/web.xml
+++ b/assembly/src/release/webapps/api/WEB-INF/web.xml
@@ -35,6 +35,15 @@
                 <param-value>consumer.prefetchSize=1</param-value>
         </init-param>
         -->
+        <!--
+        Uncomment this parameter if you plan to change the default max size of a message over REST. By default, it is set
+        to 100,000. Set it to -1 to disable the limitation but be aware that your AMQ instance could run out of memory if
+        the message is too big. See https://issues.apache.org/jira/browse/AMQ-8029 for more details.
+        <init-param>
+            <param-name>maxMessageSize</param-name>
+            <param-value>-1</param-value>
+        </init-param>
+        -->
     </servlet>
 
     <!-- AMQ-9239 jakarta - jolokia does not support jakarta


### PR DESCRIPTION
Related to https://issues.apache.org/jira/browse/AMQ-8611

## Motivation

A message size limit has been added when sending messages over REST but it is not yet documented.

## Modifications:

* Add a comment with an example of `maxMessageSize` configuration to all existing configurations of `MessageServlet`
