### PR TITLE
[AMQ-9305] Adapt the docker-related files to Java 17

### DIFF
--- a/assembly/src/docker/Dockerfile
+++ b/assembly/src/docker/Dockerfile
@@ -16,7 +16,7 @@
 # limitations under the License.
 ################################################################################
 
-FROM eclipse-temurin:11-jre
+FROM eclipse-temurin:17-jre
 
 # ActiveMQ environment variables
 ENV ACTIVEMQ_INSTALL_PATH /opt

--- a/assembly/src/docker/README.md
+++ b/assembly/src/docker/README.md
@@ -32,7 +32,7 @@ On macOS, an easy way to install `buildx` is to install [Docker Desktop Edge](ht
 
 ## Build
 
-Images are based on the Docker official [Eclipse Temurin 11 JRE](https://hub.docker.com/_/eclipse-temurin/tags?page=1&name=11-jre) image. If you want to
+Images are based on the Docker official [Eclipse Temurin 17 JRE](https://hub.docker.com/_/eclipse-temurin/tags?page=1&name=17-jre) image. If you want to
 build the ActiveMQ image you have the following choices:
 
 1. Create the docker image from a local distribution package
@@ -50,7 +50,7 @@ Usage:
 
   If the --image-name flag is not used the built image name will be 'activemq'.
   Check the supported build platforms; you can verify with this command: docker buildx ls
-  The supported platforms (OS/Arch) depend on the build's base image, in this case [eclipse-temurin:11-jre](https://hub.docker.com/_/eclipse-temurin).
+  The supported platforms (OS/Arch) depend on the build's base image, in this case [eclipse-temurin:17-jre](https://hub.docker.com/_/eclipse-temurin).
 ```
 
 To create the docker image from local distribution) you can execute the command

--- a/assembly/src/docker/build.sh
+++ b/assembly/src/docker/build.sh
@@ -27,7 +27,7 @@ Usage:
 
   If the --image-name flag is not used the built image name will be 'activemq'.
   Check the supported build platforms; you can verify with this command: docker buildx ls
-  The supported platforms (OS/Arch) depend on the build's base image, in this case [eclipse-temurin:11-jre](https://hub.docker.com/_/eclipse-temurin).
+  The supported platforms (OS/Arch) depend on the build's base image, in this case [eclipse-temurin:17-jre](https://hub.docker.com/_/eclipse-temurin).
 
 HERE
   exit 1


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/AMQ-9305

## Motivation

The Dockerfile and corresponding README need to be adapted to Java 17 in order to be able to launch a snapshot of ActiveMQ 5.19 inside a Docker container.

## Modifications

* Use `eclipse-temurin:17-jre` as new root image
* Modify the documentation to refer to the new root image used