### PR TITLE
[AMQ-9306] Make the WebConsole accessible from outside the container

### DIFF
--- a/assembly/src/docker/Dockerfile
+++ b/assembly/src/docker/Dockerfile
@@ -23,6 +23,8 @@ ENV ACTIVEMQ_INSTALL_PATH /opt
 ENV ACTIVEMQ_HOME $ACTIVEMQ_INSTALL_PATH/apache-activemq
 ENV ACTIVEMQ_EXEC exec
 ENV PATH $PATH:$ACTIVEMQ_HOME/bin
+# Make the Web console accesible from outside the container
+ENV ACTIVEMQ_OPTS $ACTIVEMQ_OPTS -Djetty.host=0.0.0.0
 #WORKDIR $ACTIVEMQ_HOME
 
 # activemq_dist can point to a directory or a tarball on the local system


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/AMQ-9306

## Motivation

Due to [AMQ-7007](https://issues.apache.org/jira/browse/AMQ-7007), the WebConsole is not accessible from outside a Docker container so even if a port is opened on the host to access the WebConsole, an empty response is returned whatever the HTTP request sent.

## Modifications

* Set `0.0.0.0` as Jetty host to make the WebConsole accessible