### PR TITLE
[AMQ-9296] Add support of credentials to the docker image

### DIFF
--- a/assembly/src/docker/Dockerfile
+++ b/assembly/src/docker/Dockerfile
@@ -28,6 +28,8 @@ ENV PATH $PATH:$ACTIVEMQ_HOME/bin
 # activemq_dist can point to a directory or a tarball on the local system
 ARG activemq_dist=NOT_SET
 
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+
 # Install build dependencies and activemq
 ADD $activemq_dist $ACTIVEMQ_INSTALL_PATH
 RUN set -x && \
@@ -35,4 +37,5 @@ RUN set -x && \
 	rm -r $ACTIVEMQ_INSTALL_PATH/apache-activemq-*
 
 EXPOSE 8161 61616 5672 61613 1883 61614
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 CMD ["activemq", "console"]

--- a/assembly/src/docker/README.md
+++ b/assembly/src/docker/README.md
@@ -152,3 +152,10 @@ docker kill activemq
 * ActiveMQ WS connector on `61614`
 
 Edit the `docker-compose.yml` file to edit port settings.
+
+### Environment variables
+
+| Name              | Description                                                                   |
+|-------------------|-------------------------------------------------------------------------------|
+| ACTIVEMQ_USER     | User name to access the broker. If not set no user and password are required. |
+| ACTIVEMQ_PASSWORD | Password to access the broker. Only used if `ACTIVEMQ_USER` has been set.     |

--- a/assembly/src/docker/entrypoint.sh
+++ b/assembly/src/docker/entrypoint.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# Generate the configuration files according to the environment variables related
+# to the security that have been set
+configure_security() {
+  if [ -f "${ACTIVEMQ_HOME}/conf/activemq-security.xml" ]; then
+      echo "Security settings already configured"
+  else
+    echo "Configuring security settings"
+    read -r -d '' REPLACE << END
+            <plugins>
+                <simpleAuthenticationPlugin>
+                    <users>
+                        <authenticationUser username="$\{activemq.username}" password="$\{activemq.password}"/>
+                    </users>
+                </simpleAuthenticationPlugin>
+              </plugins>
+          </broker>
+END
+    REPLACE=${REPLACE//\//\\\/}
+    REPLACE=${REPLACE//$\\/$}
+    REPLACE=$(echo $REPLACE | tr '\n' ' ')
+    sed "s/<\/broker>/$REPLACE/" ${ACTIVEMQ_HOME}/conf/activemq.xml > ${ACTIVEMQ_HOME}/conf/activemq-security.xml
+    sed -i "s/credentials.properties/credentials-security.properties/" ${ACTIVEMQ_HOME}/conf/activemq-security.xml
+
+    cat > ${ACTIVEMQ_HOME}/conf/credentials-security.properties <<- END
+activemq.username=${ACTIVEMQ_USER}
+activemq.password=${ACTIVEMQ_PASSWORD}
+END
+  fi
+}
+if [[ $# -eq 2 ]] && [[ "$1" -eq activemq ]] && [[ "$2" -eq console ]] && [[ -n "${ACTIVEMQ_USER}" ]]; then
+  configure_security
+  activemq console xbean:activemq-security.xml
+else
+  exec "$@"
+fi


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/AMQ-9296

## Motivation

Since Docker images for Apache ActiveMQ are published, it would be great to support env vars for USER and PASSWORD.

## Modifications:

* Add an entry point script to generate the configuration files if the environment variable `ACTIVEMQ_USER` is set
* Describe the supported environment variables
