### PR TITLE
Fix the schema location in web.xml files

### DIFF
--- a/activemq-http/src/webapp/WEB-INF/web.xml
+++ b/activemq-http/src/webapp/WEB-INF/web.xml
@@ -18,8 +18,7 @@
 
 <web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
-         web-app_5_0.xsd"
+         xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd"
          version="5.0">
 
     <display-name>ActiveMQ Message Broker Web Application</display-name>

--- a/activemq-web-console/src/main/webapp/WEB-INF/web.xml
+++ b/activemq-web-console/src/main/webapp/WEB-INF/web.xml
@@ -18,8 +18,7 @@
 
 <web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
-         web-app_5_0.xsd"
+         xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd"
          version="5.0">
 
   <description>
@@ -166,5 +165,5 @@
     <param-name>org.eclipse.jetty.servlet.Default.dirAllowed</param-name>
     <param-value>false</param-value>
   </context-param>
-  
+ 
 </web-app>

--- a/activemq-web-demo/src/main/webapp/WEB-INF/web.xml
+++ b/activemq-web-demo/src/main/webapp/WEB-INF/web.xml
@@ -17,8 +17,7 @@
 -->
 <web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
-         web-app_5_0.xsd"
+         xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd"
          version="5.0">
 
     <display-name>Apache ActiveMQ Web Demo</display-name>

--- a/assembly/src/release/webapps/api/WEB-INF/web.xml
+++ b/assembly/src/release/webapps/api/WEB-INF/web.xml
@@ -17,8 +17,7 @@
 -->
 <web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
-         web-app_5_0.xsd"
+         xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd"
          version="5.0">
 
     <display-name>Apache ActiveMQ REST API</display-name>


### PR DESCRIPTION
## Motivation

The schema location of the Jakarta namespace is not properly set which prevents the auto-completion in IDEs

## Modifications:

* Fix the schema location of the Jakarta namespace in all the web.xml files that have the same problem