### PR TITLE
AMQ-9388 - Exclude activemq-client-jakarta from camel-activemq

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -165,6 +165,15 @@
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-activemq</artifactId>
+      <exclusions>
+        <!-- Current version of Camel has a dependency on the removed
+        activemq-client-jakarta module. This exclusion can eventually be removed
+        when we upgrade to a version of camel-activemq that depends on 6.x -->
+        <exclusion>
+          <groupId>org.apache.activemq</groupId>
+          <artifactId>activemq-client-jakarta</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.camel</groupId>


### PR DESCRIPTION
The current version of camel pulls in the activemq-client-jakarta jar which is not necessary as it no longer exists with ActiveMQ 6.0.0

Furthermore the version being pulled in is 5.18.2 which contains a critical CVE that was fixed in 5.18.3