### PR TITLE
[AMQ-9392] Prevent InactivityMonitor read check Timer leak when TCP connection fails

### DIFF
--- a/activemq-client/src/main/java/org/apache/activemq/transport/AbstractInactivityMonitor.java
+++ b/activemq-client/src/main/java/org/apache/activemq/transport/AbstractInactivityMonitor.java
@@ -437,6 +437,17 @@ public abstract class AbstractInactivityMonitor extends TransportFilter {
             synchronized (AbstractInactivityMonitor.class) {
                 READ_CHECK_TIMER.purge();
                 CHECKER_COUNTER--;
+                if (CHECKER_COUNTER == 0) {
+                    if (READ_CHECK_TIMER != null) {
+                        READ_CHECK_TIMER.cancel();
+                        READ_CHECK_TIMER = null;
+                    }
+                    try {
+                        ThreadPoolUtils.shutdownGraceful(ASYNC_TASKS, 0);
+                    } finally {
+                        ASYNC_TASKS = null;
+                    }
+                }
             }
         }
     }
@@ -497,10 +508,14 @@ public abstract class AbstractInactivityMonitor extends TransportFilter {
                 READ_CHECK_TIMER.purge();
                 CHECKER_COUNTER--;
                 if (CHECKER_COUNTER == 0) {
-                    WRITE_CHECK_TIMER.cancel();
-                    READ_CHECK_TIMER.cancel();
-                    WRITE_CHECK_TIMER = null;
-                    READ_CHECK_TIMER = null;
+                    if (WRITE_CHECK_TIMER != null) {
+                        WRITE_CHECK_TIMER.cancel();
+                        WRITE_CHECK_TIMER = null;
+                    }
+                    if (READ_CHECK_TIMER != null) {
+                        READ_CHECK_TIMER.cancel();
+                        READ_CHECK_TIMER = null;
+                    }
                     try {
                         ThreadPoolUtils.shutdownGraceful(ASYNC_TASKS, 0);
                     } finally {

--- a/activemq-client/src/main/java/org/apache/activemq/transport/InactivityMonitor.java
+++ b/activemq-client/src/main/java/org/apache/activemq/transport/InactivityMonitor.java
@@ -46,7 +46,7 @@ public class InactivityMonitor extends AbstractInactivityMonitor {
 
     @Override
     public void start() throws Exception {
-        if (!isMonitorStarted() && configuredOk()) {
+        if (!isMonitorStarted()) {
             startConnectCheckTask();
         }
         super.start();


### PR DESCRIPTION
### Context
Whenever the `InactivityMonitor` `TransportFilter` is used in a scenario that would return `false` from `AbstractInactivityMonitor#configuredOk`, then the [read check Timer is created](https://github.com/apache/activemq/blob/dfd35d89f62558881bda1ed4cf7a165502c5c989/activemq-client/src/main/java/org/apache/activemq/transport/InactivityMonitor.java#L50) but the call to [startMonitorThreads](https://github.com/apache/activemq/blob/main/activemq-client/src/main/java/org/apache/activemq/transport/AbstractInactivityMonitor.java#L173) [exits prematurely](https://github.com/apache/activemq/blob/dfd35d89f62558881bda1ed4cf7a165502c5c989/activemq-client/src/main/java/org/apache/activemq/transport/AbstractInactivityMonitor.java#L450), and the `monitorStarted` flag is never set.

### Consequence
The class `AbstractInactivityMonitor` retains a strong static reference to the read check `Timer` created in [startConnectCheckTast](https://github.com/apache/activemq/blob/dfd35d89f62558881bda1ed4cf7a165502c5c989/activemq-client/src/main/java/org/apache/activemq/transport/AbstractInactivityMonitor.java#L422).
This reference cannot be removed even by calling `stop` on the `TransportFilter`, because `stopMonitorThreads` [checks the monitorStarted flag before doing anything](https://github.com/apache/activemq/blob/dfd35d89f62558881bda1ed4cf7a165502c5c989/activemq-client/src/main/java/org/apache/activemq/transport/AbstractInactivityMonitor.java#L487).
Also, [stopConnectCheckTask](https://github.com/apache/activemq/blob/dfd35d89f62558881bda1ed4cf7a165502c5c989/activemq-client/src/main/java/org/apache/activemq/transport/AbstractInactivityMonitor.java#L431) does not cancel the `Timer` nor it removes the strong reference to it.
This reference to the `Timer` instance also implies a reference to the timer `Thread`, which will also retain the Thread Context ClassLoader (which may or may not be the same `ClassLoader` that loaded `AbstractInactivityMonitor`).

### Expectation
If the `AbstractInactivityMonitor` fires up a `Timer`, there should be a way to dispose of it when it is no longer needed. It looks like it should happen when calling `AbstractInactivityMonitor#stop`, but it is not the case for this particular scenario.
Ideally there should be no `Timer` created if the connection is not properly configured (following the same logic as for the "monitor threads").

### About this PR
This PR includes a simple test that allows for reproducing the issue to help maintainers with troubleshooting it.
Additionally there is a very naive solution proposed by someone who is a complete stranger with this library, so it should be examined very carefully (if even at all).