### PR TITLE
WIP: [AMQ-9394] Tech Preview: Virtual Thread support

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/broker/BrokerService.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/BrokerService.java
@@ -222,6 +222,7 @@ public class BrokerService implements Service {
     private boolean monitorConnectionSplits = false;
     private int taskRunnerPriority = Thread.NORM_PRIORITY;
     private boolean dedicatedTaskRunner;
+    private boolean virtualThreadTaskRunner;
     private boolean cacheTempDestinations = false;// useful for failover
     private int timeBeforePurgeTempDestinations = 5000;
     private final List<Runnable> shutdownHooks = new ArrayList<>();
@@ -1263,7 +1264,7 @@ public class BrokerService implements Service {
     public TaskRunnerFactory getTaskRunnerFactory() {
         if (this.taskRunnerFactory == null) {
             this.taskRunnerFactory = new TaskRunnerFactory("ActiveMQ BrokerService["+getBrokerName()+"] Task", getTaskRunnerPriority(), true, 1000,
-                    isDedicatedTaskRunner());
+                    isDedicatedTaskRunner(), isVirtualThreadTaskRunner());
             this.taskRunnerFactory.setThreadClassLoader(this.getClass().getClassLoader());
         }
         return this.taskRunnerFactory;
@@ -1274,9 +1275,10 @@ public class BrokerService implements Service {
     }
 
     public TaskRunnerFactory getPersistenceTaskRunnerFactory() {
+        // [AMQ-9394] Should we have a separate config flag for virtualThread for persistence task runner?
         if (taskRunnerFactory == null) {
             persistenceTaskRunnerFactory = new TaskRunnerFactory("Persistence Adaptor Task", persistenceThreadPriority,
-                    true, 1000, isDedicatedTaskRunner());
+                    true, 1000, isDedicatedTaskRunner(), isVirtualThreadTaskRunner());
         }
         return persistenceTaskRunnerFactory;
     }
@@ -1883,6 +1885,14 @@ public class BrokerService implements Service {
 
     public void setDedicatedTaskRunner(boolean dedicatedTaskRunner) {
         this.dedicatedTaskRunner = dedicatedTaskRunner;
+    }
+
+    public boolean isVirtualThreadTaskRunner() {
+        return virtualThreadTaskRunner;
+    }
+
+    public void setVirtualThreadTaskRunner(boolean virtualThreadTaskRunner) {
+        this.virtualThreadTaskRunner = virtualThreadTaskRunner;
     }
 
     public boolean isCacheTempDestinations() {

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/jmx/BrokerView.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/jmx/BrokerView.java
@@ -517,6 +517,16 @@ public class BrokerView implements BrokerViewMBean {
         return brokerService.isSlave();
     }
 
+    @Override
+    public boolean isDedicatedTaskRunner() {
+        return brokerService.isDedicatedTaskRunner();
+    }
+
+    @Override
+    public boolean isVirtualThreadTaskRunner() {
+        return brokerService.isVirtualThreadTaskRunner();
+    }
+
     private ManagedRegionBroker safeGetBroker() {
         if (broker == null) {
             throw new IllegalStateException("Broker is not yet started.");

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/jmx/BrokerViewMBean.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/jmx/BrokerViewMBean.java
@@ -327,4 +327,10 @@ public interface BrokerViewMBean extends Service {
     @MBeanInfo("JMSJobScheduler")
     ObjectName getJMSJobScheduler();
 
+    @MBeanInfo("Dedicated Task Runner enabled.")
+    boolean isDedicatedTaskRunner();
+
+    @MBeanInfo("Virtual Thread Task Runner enabled.")
+    boolean isVirtualThreadTaskRunner();
+
 }

--- a/activemq-client/pom.xml
+++ b/activemq-client/pom.xml
@@ -314,8 +314,51 @@
         </plugins>
     </pluginManagement>
   </build>
-
   <profiles>
+    <profile>
+      <id>jdk21</id>
+      <activation>
+        <jdk>21</jdk>
+      </activation>
+      <properties>
+          <source-version>21</source-version>
+          <target-version>21</target-version>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>build-helper-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>add-source-jdk21</id>
+                <phase>generate-sources</phase>
+                  <goals>
+                    <goal>add-source</goal>
+                  </goals>
+                  <configuration>
+                    <sources>
+                      <source>src/main/java-jdk21</source>
+                    </sources>
+                  </configuration>
+                </execution>
+                <execution>
+                  <id>add-test-source-jdk21</id>
+                  <phase>generate-test-sources</phase>
+                  <goals>
+                    <goal>add-test-source</goal>
+                  </goals>
+                  <configuration>
+                  <sources>
+                    <source>src/test/java-jdk21</source>
+                  </sources>
+                </configuration>
+              </execution>
+             </executions>
+           </plugin>
+        </plugins>
+      </build>
+    </profile>
     <!-- Execute with: mvn -P openwire-generate antrun:run -->
     <profile>
       <id>openwire-generate</id>

--- a/activemq-client/src/main/java-jdk21/org/apache/activemq/thread/VirtualThreadExecutor.java
+++ b/activemq-client/src/main/java-jdk21/org/apache/activemq/thread/VirtualThreadExecutor.java
@@ -1,0 +1,56 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.thread;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.slf4j.Logger;
+
+public class VirtualThreadExecutor {
+
+    private VirtualThreadExecutor() {}
+
+    public static ExecutorService createVirtualThreadExecutorService(final String name, final AtomicLong id, final Logger LOG) {
+
+        // [AMQ-9394] NOTE: Submitted JDK feature enhancement id: 9076243 to allow AtomicLong thread id param
+        // https://bugs.java.com/bugdatabase/view_bug?bug_id=JDK-8320377
+        Thread.Builder.OfVirtual threadBuilderOfVirtual = Thread.ofVirtual()
+                .name(name)
+                .uncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
+                @Override
+                    public void uncaughtException(final Thread t, final Throwable e) {
+                        LOG.error("Error in thread '{}'", t.getName(), e);
+                    }
+                });
+
+        // [AMQ-9394] Work around to have global thread id increment across ThreadFactories
+        ThreadFactory virtualThreadFactory = threadBuilderOfVirtual.factory();
+        ThreadFactory atomicThreadFactory = new ThreadFactory() {
+            @Override
+            public Thread newThread(Runnable r) {
+                Thread tmpThread = virtualThreadFactory.newThread(r);
+                tmpThread.setName(tmpThread.getName() + id.incrementAndGet());
+                return tmpThread;
+            }
+        };
+
+        return Executors.newThreadPerTaskExecutor(atomicThreadFactory); // [AMQ-9394] Same as newVirtualThreadPerTaskExecutor
+    }
+}

--- a/activemq-client/src/main/java/org/apache/activemq/ActiveMQConnectionFactory.java
+++ b/activemq-client/src/main/java/org/apache/activemq/ActiveMQConnectionFactory.java
@@ -168,6 +168,7 @@ public class ActiveMQConnectionFactory extends JNDIBaseStorable implements Conne
     private int auditDepth = ActiveMQMessageAudit.DEFAULT_WINDOW_SIZE;
     private int auditMaximumProducerNumber = ActiveMQMessageAudit.MAXIMUM_PRODUCER_COUNT;
     private boolean useDedicatedTaskRunner;
+    private boolean useVirtualThreadTaskRunner;
     private long consumerFailoverRedeliveryWaitPeriod = 0;
     private boolean checkForDuplicates = true;
     private ClientInternalExceptionListener clientInternalExceptionListener;
@@ -454,6 +455,7 @@ public class ActiveMQConnectionFactory extends JNDIBaseStorable implements Conne
         connection.setAuditDepth(getAuditDepth());
         connection.setAuditMaximumProducerNumber(getAuditMaximumProducerNumber());
         connection.setUseDedicatedTaskRunner(isUseDedicatedTaskRunner());
+        connection.setUseVirtualThreadTaskRunner(isUseVirtualThreadTaskRunner());
         connection.setConsumerFailoverRedeliveryWaitPeriod(getConsumerFailoverRedeliveryWaitPeriod());
         connection.setCheckForDuplicates(isCheckForDuplicates());
         connection.setMessagePrioritySupported(isMessagePrioritySupported());
@@ -1162,6 +1164,14 @@ public class ActiveMQConnectionFactory extends JNDIBaseStorable implements Conne
 
     public boolean isUseDedicatedTaskRunner() {
         return useDedicatedTaskRunner;
+    }
+
+    public void setUseVirtualThreadTaskRunner(boolean useVirtualThreadTaskRunner) {
+        this.useVirtualThreadTaskRunner = useVirtualThreadTaskRunner;
+    }
+
+    public boolean isUseVirtualThreadTaskRunner() {
+        return useVirtualThreadTaskRunner;
     }
 
     public void setConsumerFailoverRedeliveryWaitPeriod(long consumerFailoverRedeliveryWaitPeriod) {

--- a/activemq-client/src/main/java/org/apache/activemq/thread/TaskRunnerFactory.java
+++ b/activemq-client/src/main/java/org/apache/activemq/thread/TaskRunnerFactory.java
@@ -16,8 +16,11 @@
  */
 package org.apache.activemq.thread;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadFactory;
@@ -56,6 +59,9 @@ public class TaskRunnerFactory implements Executor {
     private RejectedExecutionHandler rejectedTaskHandler = null;
     private ClassLoader threadClassLoader;
 
+    // Virtual Thread support
+    private boolean virtualThreadTaskrunner = false;
+
     public TaskRunnerFactory() {
         this("ActiveMQ Task");
     }
@@ -72,13 +78,22 @@ public class TaskRunnerFactory implements Executor {
         this(name, priority, daemon, maxIterationsPerRun, dedicatedTaskRunner, getDefaultMaximumPoolSize());
     }
 
+    public TaskRunnerFactory(String name, int priority, boolean daemon, int maxIterationsPerRun, boolean dedicatedTaskRunner, boolean virtualThreadTaskRunner) {
+        this(name, priority, daemon, maxIterationsPerRun, dedicatedTaskRunner, getDefaultMaximumPoolSize(), virtualThreadTaskRunner);
+    }
+
     public TaskRunnerFactory(String name, int priority, boolean daemon, int maxIterationsPerRun, boolean dedicatedTaskRunner, int maxThreadPoolSize) {
+       this(name, priority, daemon, maxIterationsPerRun, dedicatedTaskRunner, maxThreadPoolSize, false);
+    }
+
+    public TaskRunnerFactory(String name, int priority, boolean daemon, int maxIterationsPerRun, boolean dedicatedTaskRunner, int maxThreadPoolSize, boolean virtualThreadTaskRunner) {
         this.name = name;
         this.priority = priority;
         this.daemon = daemon;
         this.maxIterationsPerRun = maxIterationsPerRun;
         this.dedicatedTaskRunner = dedicatedTaskRunner;
         this.maxThreadPoolSize = maxThreadPoolSize;
+        this.virtualThreadTaskrunner = virtualThreadTaskRunner;
     }
 
     public void init() {
@@ -90,7 +105,9 @@ public class TaskRunnerFactory implements Executor {
             synchronized(this) {
                 //need to recheck if initDone is true under the lock
                 if (!initDone.get()) {
-                    if (dedicatedTaskRunner || "true".equalsIgnoreCase(System.getProperty("org.apache.activemq.UseDedicatedTaskRunner"))) {
+                    if (virtualThreadTaskrunner || "true".equalsIgnoreCase(System.getProperty("org.apache.activemq.UseVirtualThreadTaskRunner")) ) {
+                        executorRef.compareAndSet(null, createVirtualThreadExecutor());
+                    } else if (dedicatedTaskRunner || "true".equalsIgnoreCase(System.getProperty("org.apache.activemq.UseDedicatedTaskRunner"))) {
                         executorRef.set(null);
                     } else {
                         executorRef.compareAndSet(null, createDefaultExecutor());
@@ -215,6 +232,27 @@ public class TaskRunnerFactory implements Executor {
         }
 
         return rc;
+    }
+
+    protected ExecutorService createVirtualThreadExecutor() {
+        if(!(Runtime.version().feature() >= 21)) {
+            LOG.error("Virtual Thread support requires JDK 21 or higher");
+            throw new IllegalStateException("Virtual Thread support requires JDK 21 or higher");
+        }
+
+        try {
+            Class<?> virtualThreadExecutorClass = Class.forName("org.apache.activemq.thread.VirtualThreadExecutor", false, threadClassLoader);
+            Method method = virtualThreadExecutorClass.getMethod("createVirtualThreadExecutorService", String.class, AtomicLong.class, Logger.class);
+            Object result = method.invoke(null, name, id, LOG);
+            if(!ExecutorService.class.isAssignableFrom(result.getClass())) {
+                throw new IllegalStateException("VirtualThreadExecutor not returned");
+            }
+            LOG.info("VirtualThreadExecutor initialized name:{}", name);
+            return ExecutorService.class.cast(result);
+        } catch (ClassNotFoundException | NoSuchMethodException | SecurityException | IllegalAccessException | InvocationTargetException e) {
+            LOG.error("VirtualThreadExecutor class failed to load", e);
+            throw new IllegalStateException(e);
+        }
     }
 
     public ExecutorService getExecutor() {

--- a/activemq-client/src/test/java/org/apache/activemq/thread/TaskRunnerTest.java
+++ b/activemq-client/src/test/java/org/apache/activemq/thread/TaskRunnerTest.java
@@ -91,7 +91,7 @@ public class TaskRunnerTest {
                         for (int i = 0; i < enqueueCount / workerCount; i++) {
                             queue.incrementAndGet();
                             runner.wakeup();
-                            yield();
+                            // yield(); // [AMQ-9394] JDK 21 does not allow yield(); invocation 
                         }
                     } catch (BrokenBarrierException e) {
                     } catch (InterruptedException e) {


### PR DESCRIPTION
TODO:
- [x] Throw exception if virtualThreadTaskRunner is enabled and JDK 21 (or higher) is not available
- [x] Breakout the Virtual Thread factory init so it only logs on JDK 17
- [x] Add webpage with instructions and implementation progress status (https://activemq.apache.org/virtual-threads)
- [ ] Add a VirtualThreadTaskRunner
- [ ] Consider separate config flag for persistenceAdapter TaskRunner
- [ ] Replace Thread.yield() usage with VirtualThread friendly alternative