### PR TITLE
Improve test reliability by resolving nondeterministic order of Json

### DIFF
--- a/activemq-stomp/pom.xml
+++ b/activemq-stomp/pom.xml
@@ -53,6 +53,11 @@
       <artifactId>jettison</artifactId>
       <optional>true</optional>
     </dependency>
+      <dependency>
+          <groupId>com.fasterxml.jackson.dataformat</groupId>
+          <artifactId>jackson-dataformat-xml</artifactId>
+          <optional>true</optional>
+      </dependency>
 
     <!-- =============================== -->
     <!-- Testing Dependencies            -->

--- a/activemq-stomp/pom.xml
+++ b/activemq-stomp/pom.xml
@@ -53,11 +53,11 @@
       <artifactId>jettison</artifactId>
       <optional>true</optional>
     </dependency>
-      <dependency>
-          <groupId>com.fasterxml.jackson.dataformat</groupId>
-          <artifactId>jackson-dataformat-xml</artifactId>
-          <optional>true</optional>
-      </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-xml</artifactId>
+      <optional>true</optional>
+    </dependency>
 
     <!-- =============================== -->
     <!-- Testing Dependencies            -->

--- a/activemq-stomp/src/test/java/org/apache/activemq/transport/stomp/SamplePojo.java
+++ b/activemq-stomp/src/test/java/org/apache/activemq/transport/stomp/SamplePojo.java
@@ -52,4 +52,16 @@ public class SamplePojo implements Serializable {
     public void setName(String name) {
         this.name = name;
     }
+
+    //implement equals
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof SamplePojo) {
+            SamplePojo other = (SamplePojo) obj;
+            return name.equals(other.name) && city.equals(other.city);
+        }
+        return false;
+    }
+
 }

--- a/activemq-stomp/src/test/java/org/apache/activemq/transport/stomp/StompTest.java
+++ b/activemq-stomp/src/test/java/org/apache/activemq/transport/stomp/StompTest.java
@@ -37,7 +37,7 @@ import java.util.regex.Pattern;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.xml.*;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import jakarta.jms.BytesMessage;
 import jakarta.jms.Connection;
 import jakarta.jms.JMSException;

--- a/activemq-stomp/src/test/java/org/apache/activemq/transport/stomp/StompTest.java
+++ b/activemq-stomp/src/test/java/org/apache/activemq/transport/stomp/StompTest.java
@@ -1092,9 +1092,8 @@ public class StompTest extends StompTestSupport {
         stompConnection.sendFrame(frame);
 
         frame = stompConnection.receiveFrame();
-        String xmlReceived = frame.trim().substring(frame.indexOf("<pojo>"));
 
-        compareXML(xmlReceived, xmlObject);
+        compareFrameXML(frame, xmlObject);
     }
 
     @Test(timeout = 60000)
@@ -1114,9 +1113,7 @@ public class StompTest extends StompTestSupport {
 
         frame = stompConnection.receiveFrame();
 
-        String receivedJson = frame.trim().substring(frame.indexOf("{\"pojo\":{"));
-
-        compareJson(receivedJson, jsonObject);
+        compareFrameJson(frame, jsonObject);
     }
 
     @Test(timeout = 60000)
@@ -1137,8 +1134,7 @@ public class StompTest extends StompTestSupport {
 
         frame = stompConnection.receiveFrame();
 
-        String xmlReceived = frame.trim().substring(frame.indexOf("<pojo>"));
-        compareXML(xmlReceived, xmlObject);
+        compareFrameXML(frame, xmlObject);
     }
 
     @Test(timeout = 60000)
@@ -1159,19 +1155,22 @@ public class StompTest extends StompTestSupport {
 
         frame = stompConnection.receiveFrame();
 
-        String xmlReceived = frame.trim().substring(frame.indexOf("<pojo>"));
 
-        compareXML(xmlReceived, xmlObject);
+
+        compareFrameXML(frame, xmlObject);
     }
 
-    private void compareXML(String xmlReceived, String xmlObject) {
+    private void compareFrameXML(String frame, String xmlObject) {
+
+        String xmlReceived = frame.trim().substring(frame.indexOf("<pojo>"));
+
         try {
             //use jackson xml to compare
             XmlMapper xmlMapper = new XmlMapper();
             SamplePojo pojoReceived = xmlMapper.readValue(xmlReceived, SamplePojo.class);
             SamplePojo pojoObject = xmlMapper.readValue(xmlObject, SamplePojo.class);
 
-            assertEquals(pojoReceived.getName(), pojoObject.getName());
+            assertEquals(pojoReceived, pojoObject);
         } catch (Exception e) {
             fail("Exception while comparing XML: " + e.getMessage());
         }
@@ -1200,8 +1199,7 @@ public class StompTest extends StompTestSupport {
 
         frame = stompConnection.receiveFrame();
 
-        String receivedXml = frame.trim().substring(frame.indexOf("<pojo>"));
-        compareXML(receivedXml, xmlObject);
+        compareFrameXML(frame, xmlObject);
 
         StompFrame xmlFrame = stompConnection.receive();
 
@@ -1359,18 +1357,18 @@ public class StompTest extends StompTestSupport {
         stompConnection.sendFrame(frame);
 
         frame = stompConnection.receiveFrame();
-        String jsonReceived = frame.trim().substring(frame.indexOf("{\"pojo\":{"));
 
-        compareJson(jsonReceived, jsonObject);
+        compareFrameJson(frame, jsonObject);
     }
 
-    private void compareJson(String jsonReceived, String jsonObject) {
+    private void compareFrameJson(String frame, String jsonObject) {
+        String receivedJson = frame.trim().substring(frame.indexOf("{\"pojo\":{"));
         try {
             ObjectMapper mapper = new ObjectMapper();
-            JsonNode pojoReceived = mapper.readTree(jsonReceived);
+            JsonNode pojoReceived = mapper.readTree(receivedJson);
             JsonNode pojoObject = mapper.readTree(jsonObject);
 
-            assertTrue(pojoReceived.equals(pojoObject));
+            assertEquals(pojoReceived, pojoObject);
         } catch (Exception e) {
             fail("Exception while comparing JSON: " + e.getMessage());
         }

--- a/pom.xml
+++ b/pom.xml
@@ -612,6 +612,11 @@
         <artifactId>jackson-databind</artifactId>
         <version>${jackson-version}</version>
       </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.dataformat</groupId>
+        <artifactId>jackson-dataformat-xml</artifactId>
+        <version>${jackson-version}</version>
+      </dependency>
 
       <!-- Used to configure the activemq logs -->
       <dependency>


### PR DESCRIPTION
# Problem: 

The objects returned from the server was XML and Json format, but the XML and Json object did not guarantee the order from the server side, so to make the code more robust, we can use the Jackson library to help us to resolve the issue:

For example
```
2023-11-22 11:10:27,493 [me-limited test] - INFO  StompTest                      - hannah Received frame: MESSAGE
timestamp:1700673027477
JMSXUserID:system
message-id:ID:chis-MacBook-Pro.local-58943-1700673027288-5:1:1:1:1
transformation:jms-object-xml
destination:/queue/USERS.org.apache.activemq.transport.stomp.StompTest.testTransformationReceiveObject
persistent:true
priority:4
expires:0

<pojo>
  <city>Belgrade</city>
  <name>Dejan</name>
</pojo>

```

Here is what I received but it is expecting 

```
    private final String xmlObject = "<pojo>\n"
            + "  <name>Dejan</name>\n"
            + "  <city>Belgrade</city>\n"
            + "</pojo>";

```


The situation is same for the Json

# Solution:

I finished the "compare Json / XML" function with Jackson Library. 

I added the dependency `com.fasterxml.jackson.dataformat.xml` because the repo already use many dependencies from the jackson like Json (core) and YAML (extension) and have many other Jackson dependencies managed, one option without using the dependency is to parse and compare the XML file, which would be more cumbersome (but visible), and considering we already have many jackson dependencies managed, the jackson-xml extension would not cause too many other problem in the future.


# affected tests:

org.apache.activemq.transport.stomp.StompTest#testTransformationNotOverrideSubscription
org.apache.activemq.transport.stomp.StompTest#testTransformationReceiveJSONObject
org.apache.activemq.transport.stomp.StompTest#testTransformationReceiveObject
org.apache.activemq.transport.stomp.StompTest#testTransformationReceiveXMLObject
org.apache.activemq.transport.stomp.StompTest#testTransformationReceiveXMLObjectAndMap
org.apache.activemq.transport.stomp.StompTest#testTransformationSubscribeXML

And their child tests:

org.apache.activemq.transport.stomp.auto.StompAutoNioTest#testTransformationNotOverrideSubscription
org.apache.activemq.transport.stomp.StompNIOSSLTest#testTransformationNotOverrideSubscription
org.apache.activemq.transport.stomp.StompSslAuthTest#testTransformationNotOverrideSubscription
org.apache.activemq.transport.stomp.auto.StompAutoSslTest#testTransformationNotOverrideSubscription
org.apache.activemq.transport.stomp.auto.StompAutoNioSslTest#testTransformationNotOverrideSubscription
org.apache.activemq.transport.stomp.StompNIOTest#testTransformationNotOverrideSubscription
org.apache.activemq.transport.stomp.auto.StompAutoTest#testTransformationReceiveJSONObject
org.apache.activemq.transport.stomp.StompNIOSSLTest#testTransformationReceiveJSONObject
org.apache.activemq.transport.stomp.StompSslAuthTest#testTransformationReceiveJSONObject
org.apache.activemq.transport.stomp.StompNIOTest#testTransformationReceiveJSONObject
org.apache.activemq.transport.stomp.StompSslTest#testTransformationReceiveJSONObject
org.apache.activemq.transport.stomp.auto.StompAutoNioTest#testTransformationReceiveJSONObject
org.apache.activemq.transport.stomp.auto.StompAutoNioSslTest#testTransformationReceiveJSONObject
org.apache.activemq.transport.stomp.StompNIOTest#testTransformationReceiveObject
org.apache.activemq.transport.stomp.auto.StompAutoNioTest#testTransformationReceiveObject
org.apache.activemq.transport.stomp.StompSslAuthTest#testTransformationReceiveObject
org.apache.activemq.transport.stomp.auto.StompAutoTest#testTransformationReceiveObject
org.apache.activemq.transport.stomp.StompSslTest#testTransformationReceiveObject
org.apache.activemq.transport.stomp.auto.StompAutoNioSslTest#testTransformationReceiveObject
org.apache.activemq.transport.stomp.auto.StompAutoSslTest#testTransformationReceiveObject
org.apache.activemq.transport.stomp.auto.StompAutoSslTest#testTransformationReceiveXMLObject
org.apache.activemq.transport.stomp.auto.StompAutoTest#testTransformationReceiveXMLObject
org.apache.activemq.transport.stomp.StompNIOSSLTest#testTransformationReceiveXMLObject
org.apache.activemq.transport.stomp.auto.StompAutoNioSslTest#testTransformationReceiveXMLObject
org.apache.activemq.transport.stomp.StompNIOTest#testTransformationReceiveXMLObject
org.apache.activemq.transport.stomp.StompSslAuthTest#testTransformationReceiveXMLObject
org.apache.activemq.transport.stomp.auto.StompAutoSslTest#testTransformationReceiveXMLObjectAndMap
org.apache.activemq.transport.stomp.StompSslTest#testTransformationReceiveXMLObjectAndMap
org.apache.activemq.transport.stomp.StompNIOSSLTest#testTransformationReceiveXMLObjectAndMap
org.apache.activemq.transport.stomp.auto.StompAutoNioSslTest#testTransformationReceiveXMLObjectAndMap
org.apache.activemq.transport.stomp.StompNIOTest#testTransformationReceiveXMLObjectAndMap
org.apache.activemq.transport.stomp.auto.StompAutoTest#testTransformationReceiveXMLObjectAndMap
org.apache.activemq.transport.stomp.StompSslAuthTest#testTransformationReceiveXMLObjectAndMap
org.apache.activemq.transport.stomp.auto.StompAutoSslTest#testTransformationSubscribeXML
org.apache.activemq.transport.stomp.StompSslTest#testTransformationSubscribeXML
org.apache.activemq.transport.stomp.StompNIOSSLTest#testTransformationSubscribeXML
org.apache.activemq.transport.stomp.auto.StompAutoNioSslTest#testTransformationSubscribeXML
org.apache.activemq.transport.stomp.StompNIOTest#testTransformationSubscribeXML
org.apache.activemq.transport.stomp.auto.StompAutoTest#testTransformationSubscribeXML
org.apache.activemq.transport.stomp.StompSslAuthTest#testTransformationSubscribeXML


# Reproduce
This error can be reproduced with the [NondexTool](https://github.com/TestingResearchIllinois/NonDex) with the following command (you can try that without modifying the pom, but feel free to use the plugin to protect your project and make it safer 😊 ), and this kind problem is widely documented in [International Dataset of Flaky Tests (IDoFT)](https://github.com/TestingResearchIllinois/idoft)


```
mvn edu.illinois:nondex-maven-plugin:2.1.7-SNAPSHOT:nondex -pl activemq-stomp -Dsurefire.useFile=false -
Dtest=org.apache.activemq.transport.stomp.StompTest#[methodName]

mvn edu.illinois:nondex-maven-plugin:2.1.7-SNAPSHOT:nondex -pl activemq-stomp -Dsurefire.useFile=false -
Dtest=org.apache.activemq.transport.stomp.[TestName]#[methodName]
```

Let's make the activeMQ better together 👩🏻‍🔧