### PR TITLE
AMQ-9418 - Support converting jakarta jms exceptions to javax

### DIFF
--- a/activemq-client-jakarta/pom.xml
+++ b/activemq-client-jakarta/pom.xml
@@ -108,18 +108,50 @@
                         <goals>
                             <goal>replace</goal>
                         </goals>
+                        <configuration>
+                            <includes>
+                                <include>${project.build.directory}/copied-sources/activemq-client/**/*.java</include>
+                            </includes>
+                            <excludes>
+                                <exclude>${project.build.directory}/copied-sources/activemq-client/**/openwire/OpenWireUtil.java</exclude>
+                            </excludes>
+                            <token>javax.jms</token>
+                            <value>jakarta.jms</value>
+                            <regexFlags>
+                                <regexFlag>MULTILINE</regexFlag>
+                            </regexFlags>
+                        </configuration>
+                    </execution>
+                    <!-- Special case to handle OpenWireUtil which will do conversions for JMS exception types -->
+                    <execution>
+                        <id>jms-package-to-replace</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>replace</goal>
+                        </goals>
+                        <configuration>
+                            <includes>
+                                <include>${project.build.directory}/copied-sources/activemq-client/**/openwire/OpenWireUtil.java</include>
+                            </includes>
+                            <token>jmsPackageToReplace = "jakarta.jms"</token>
+                            <value>jmsPackageToReplace = "javax.jms"</value>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>jms-package-to-use</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>replace</goal>
+                        </goals>
+                        <configuration>
+                            <includes>
+                                <include>${project.build.directory}/copied-sources/activemq-client/**/openwire/OpenWireUtil.java</include>
+                            </includes>
+                            <token>jmsPackageToUse = "javax.jms"</token>
+                            <value>jmsPackageToUse = "jakarta.jms"</value>
+                        </configuration>
                     </execution>
                 </executions>
-                <configuration>
-                    <includes>
-                        <include>${project.build.directory}/copied-sources/activemq-client/**/*.java</include>
-                    </includes>
-                    <token>javax.jms</token>
-                    <value>jakarta.jms</value>
-                    <regexFlags>
-                        <regexFlag>MULTILINE</regexFlag>
-                    </regexFlags>
-                </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-resources-plugin</artifactId>

--- a/activemq-client/src/main/java/org/apache/activemq/openwire/OpenWireUtil.java
+++ b/activemq-client/src/main/java/org/apache/activemq/openwire/OpenWireUtil.java
@@ -18,6 +18,9 @@ package org.apache.activemq.openwire;
 
 public class OpenWireUtil {
 
+    private static final String jmsPackageToReplace = "jakarta.jms";
+    private static final String jmsPackageToUse = "javax.jms";
+
     /**
      * Verify that the provided class extends {@link Throwable} and throw an
      * {@link IllegalArgumentException} if it does not.
@@ -29,4 +32,19 @@ public class OpenWireUtil {
             throw new IllegalArgumentException("Class " + clazz + " is not assignable to Throwable");
         }
     }
+
+    /**
+     * This method can be used to convert from javax -> jakarta or
+     * vice versa depending on the version used by the client
+     *
+     * @param className
+     * @return
+     */
+    public static String convertJmsPackage(String className) {
+        if (className != null && className.startsWith(jmsPackageToReplace)) {
+            return className.replace(jmsPackageToReplace, jmsPackageToUse);
+        }
+        return className;
+    }
+
 }

--- a/activemq-client/src/main/java/org/apache/activemq/openwire/v12/BaseDataStreamMarshaller.java
+++ b/activemq-client/src/main/java/org/apache/activemq/openwire/v12/BaseDataStreamMarshaller.java
@@ -16,6 +16,8 @@
  */
 package org.apache.activemq.openwire.v12;
 
+import static org.apache.activemq.openwire.OpenWireUtil.convertJmsPackage;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -197,7 +199,7 @@ public abstract class BaseDataStreamMarshaller implements DataStreamMarshaller {
                     for (int i = 0; i < ss.length; i++) {
                         try {
                             ss[i] = (StackTraceElement)STACK_TRACE_ELEMENT_CONSTRUCTOR
-                                .newInstance(new Object[] {tightUnmarshalString(dataIn, bs),
+                                .newInstance(new Object[] {convertJmsPackage(tightUnmarshalString(dataIn, bs)),
                                                            tightUnmarshalString(dataIn, bs),
                                                            tightUnmarshalString(dataIn, bs),
                                                            Integer.valueOf(dataIn.readInt())});
@@ -227,6 +229,7 @@ public abstract class BaseDataStreamMarshaller implements DataStreamMarshaller {
 
     private Throwable createThrowable(String className, String message) {
         try {
+            className = convertJmsPackage(className);
             Class clazz = Class.forName(className, false, BaseDataStreamMarshaller.class.getClassLoader());
             OpenWireUtil.validateIsThrowable(clazz);
             Constructor constructor = clazz.getConstructor(new Class[] {String.class});
@@ -521,7 +524,7 @@ public abstract class BaseDataStreamMarshaller implements DataStreamMarshaller {
                     for (int i = 0; i < ss.length; i++) {
                         try {
                             ss[i] = (StackTraceElement)STACK_TRACE_ELEMENT_CONSTRUCTOR
-                                .newInstance(new Object[] {looseUnmarshalString(dataIn),
+                                .newInstance(new Object[] {convertJmsPackage(looseUnmarshalString(dataIn)),
                                                            looseUnmarshalString(dataIn),
                                                            looseUnmarshalString(dataIn),
                                                            Integer.valueOf(dataIn.readInt())});


### PR DESCRIPTION
This fixes the OpenWire v12 marshaller so that if an exception is received by a jakarta based broker the client will convert back to a javax jms exception type.

This commit also updates activemq-client-jakarta to do the proper mapping in the reverse.