### PR TITLE
AMQ-9418 - Support converting javax jms exceptions to jakarta

### DIFF
--- a/activemq-client/src/main/java/org/apache/activemq/openwire/OpenWireUtil.java
+++ b/activemq-client/src/main/java/org/apache/activemq/openwire/OpenWireUtil.java
@@ -18,6 +18,9 @@ package org.apache.activemq.openwire;
 
 public class OpenWireUtil {
 
+    private static final String jmsPackageToReplace = "javax.jms";
+    private static final String jmsPackageToUse = "jakarta.jms";
+
     /**
      * Verify that the provided class extends {@link Throwable} and throw an
      * {@link IllegalArgumentException} if it does not.
@@ -29,4 +32,19 @@ public class OpenWireUtil {
             throw new IllegalArgumentException("Class " + clazz + " is not assignable to Throwable");
         }
     }
+
+    /**
+     * This method can be used to convert from javax -> jakarta or
+     * vice versa depending on the version used by the client
+     *
+     * @param className
+     * @return
+     */
+    public static String convertJmsPackage(String className) {
+        if (className != null && className.startsWith(jmsPackageToReplace)) {
+            return className.replace(jmsPackageToReplace, jmsPackageToUse);
+        }
+        return className;
+    }
+
 }

--- a/activemq-client/src/main/java/org/apache/activemq/openwire/v12/BaseDataStreamMarshaller.java
+++ b/activemq-client/src/main/java/org/apache/activemq/openwire/v12/BaseDataStreamMarshaller.java
@@ -16,6 +16,8 @@
  */
 package org.apache.activemq.openwire.v12;
 
+import static org.apache.activemq.openwire.OpenWireUtil.convertJmsPackage;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -197,7 +199,7 @@ public abstract class BaseDataStreamMarshaller implements DataStreamMarshaller {
                     for (int i = 0; i < ss.length; i++) {
                         try {
                             ss[i] = (StackTraceElement)STACK_TRACE_ELEMENT_CONSTRUCTOR
-                                .newInstance(new Object[] {tightUnmarshalString(dataIn, bs),
+                                .newInstance(new Object[] {convertJmsPackage(tightUnmarshalString(dataIn, bs)),
                                                            tightUnmarshalString(dataIn, bs),
                                                            tightUnmarshalString(dataIn, bs),
                                                            dataIn.readInt()});
@@ -227,6 +229,7 @@ public abstract class BaseDataStreamMarshaller implements DataStreamMarshaller {
 
     private Throwable createThrowable(String className, String message) {
         try {
+            className = convertJmsPackage(className);
             Class clazz = Class.forName(className, false, BaseDataStreamMarshaller.class.getClassLoader());
             OpenWireUtil.validateIsThrowable(clazz);
             Constructor constructor = clazz.getConstructor(new Class[] {String.class});
@@ -521,7 +524,7 @@ public abstract class BaseDataStreamMarshaller implements DataStreamMarshaller {
                     for (int i = 0; i < ss.length; i++) {
                         try {
                             ss[i] = (StackTraceElement)STACK_TRACE_ELEMENT_CONSTRUCTOR
-                                .newInstance(new Object[] {looseUnmarshalString(dataIn),
+                                .newInstance(new Object[] {convertJmsPackage(looseUnmarshalString(dataIn)),
                                                            looseUnmarshalString(dataIn),
                                                            looseUnmarshalString(dataIn),
                                                            dataIn.readInt()});


### PR DESCRIPTION
This fixes the OpenWire v12 marshaller so that if an exception is received by a javax based broker the client will convert back to a jakarta jms exception type.