### PR TITLE
AMQ-9435 - Ensure orderIndex next id is rolled back on duplicates

### DIFF
--- a/activemq-kahadb-store/src/main/java/org/apache/activemq/store/kahadb/MessageDatabase.java
+++ b/activemq-kahadb-store/src/main/java/org/apache/activemq/store/kahadb/MessageDatabase.java
@@ -1552,7 +1552,6 @@ public abstract class MessageDatabase extends ServiceSupport implements BrokerSe
                 }
                 metadata.lastUpdate = location;
             } else {
-
                 MessageKeys messageKeys = sd.orderIndex.get(tx, previous);
                 if (messageKeys != null && messageKeys.location.compareTo(location) < 0) {
                     // If the message ID is indexed, then the broker asked us to store a duplicate before the message was dispatched and acked, we ignore this add attempt
@@ -1560,6 +1559,8 @@ public abstract class MessageDatabase extends ServiceSupport implements BrokerSe
                 }
                 sd.messageIdIndex.put(tx, command.getMessageId(), previous);
                 sd.locationIndex.remove(tx, location);
+                // ensure sequence is not broken
+                sd.orderIndex.revertNextMessageId();
                 id = -1;
             }
         } else {


### PR DESCRIPTION
This commit fixes a bug in KahaDB that caused gaps in sequence ack tracking for durables that would lead to the appearance of stuck messages on durable subs if duplicate messages were detected. The sequence is now correctly rolled back so that there is no gap if the message is not added to the order index