### PR TITLE
AMQ-9436 - Ensure message audit in queue store cursor is shared

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/broker/region/cursors/StoreQueueCursor.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/region/cursors/StoreQueueCursor.java
@@ -53,7 +53,9 @@ public class StoreQueueCursor extends AbstractPendingMessageCursor {
 
     @Override
     public synchronized void start() throws Exception {
-        started = true;
+        if (isStarted()) {
+            return;
+        }
         super.start();
         if (nonPersistent == null) {
             if (broker.getBrokerService().isPersistent()) {
@@ -76,7 +78,9 @@ public class StoreQueueCursor extends AbstractPendingMessageCursor {
 
     @Override
     public synchronized void stop() throws Exception {
-        started = false;
+        if (!isStarted()) {
+            return;
+        }
         if (nonPersistent != null) {
           nonPersistent.destroy();
         }


### PR DESCRIPTION
This commit fixes the initialization of the StoreQueueCursor message audit object to make sure it's shared between the persistent and non persistent cursors. It also adds a check to ensure that duplicate calls to start will not try and init more than once.