### PR TITLE
[AMQ-9459]: Added JVM Arg to open sun.nio.ch

### DIFF
--- a/assembly/src/release/bin/activemq
+++ b/assembly/src/release/bin/activemq
@@ -346,6 +346,7 @@ invokeJar(){
               --add-opens java.rmi/sun.rmi.transport.tcp=ALL-UNNAMED \
               --add-opens java.base/java.util.concurrent=ALL-UNNAMED \
               --add-opens java.base/java.util.concurrent.atomic=ALL-UNNAMED \
+              --add-opens java.base/sun.nio.ch=ALL-UNNAMED \
               --add-exports=java.base/sun.net.www.protocol.http=ALL-UNNAMED \
               --add-exports=java.base/sun.net.www.protocol.https=ALL-UNNAMED \
               --add-exports=java.base/sun.net.www.protocol.jar=ALL-UNNAMED \
@@ -375,6 +376,7 @@ invokeJar(){
             --add-opens java.rmi/sun.rmi.transport.tcp=ALL-UNNAMED \
             --add-opens java.base/java.util.concurrent=ALL-UNNAMED \
             --add-opens java.base/java.util.concurrent.atomic=ALL-UNNAMED \
+            --add-opens java.base/sun.nio.ch=ALL-UNNAMED \
             --add-exports=java.base/sun.net.www.protocol.http=ALL-UNNAMED \
             --add-exports=java.base/sun.net.www.protocol.https=ALL-UNNAMED \
             --add-exports=java.base/sun.net.www.protocol.jar=ALL-UNNAMED \
@@ -402,6 +404,7 @@ invokeJar(){
           --add-opens java.rmi/sun.rmi.transport.tcp=ALL-UNNAMED \
           --add-opens java.base/java.util.concurrent=ALL-UNNAMED \
           --add-opens java.base/java.util.concurrent.atomic=ALL-UNNAMED \
+          --add-opens java.base/sun.nio.ch=ALL-UNNAMED \
           --add-exports=java.base/sun.net.www.protocol.http=ALL-UNNAMED \
           --add-exports=java.base/sun.net.www.protocol.https=ALL-UNNAMED \
           --add-exports=java.base/sun.net.www.protocol.jar=ALL-UNNAMED \

--- a/assembly/src/release/bin/linux-x86-64/wrapper.conf
+++ b/assembly/src/release/bin/linux-x86-64/wrapper.conf
@@ -26,7 +26,7 @@ set.default.ACTIVEMQ_CONF=%ACTIVEMQ_BASE%/conf
 set.default.ACTIVEMQ_DATA=%ACTIVEMQ_BASE%/data
 
 # JDK 9+ modules
-set.JDK_JAVA_OPTIONS=--add-reads=java.xml=java.logging --add-opens java.base/java.security=ALL-UNNAMED --add-opens java.base/java.net=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.naming/javax.naming.spi=ALL-UNNAMED --add-opens java.rmi/sun.rmi.transport.tcp=ALL-UNNAMED --add-exports=java.base/sun.net.www.protocol.http=ALL-UNNAMED --add-exports=java.base/sun.net.www.protocol.https=ALL-UNNAMED --add-exports=java.base/sun.net.www.protocol.jar=ALL-UNNAMED --add-exports=jdk.xml.dom/org.w3c.dom.html=ALL-UNNAMED --add-exports=jdk.naming.rmi/com.sun.jndi.url.rmi=ALL-UNNAMED
+set.JDK_JAVA_OPTIONS=--add-reads=java.xml=java.logging --add-opens java.base/java.security=ALL-UNNAMED --add-opens java.base/java.net=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.naming/javax.naming.spi=ALL-UNNAMED --add-opens java.rmi/sun.rmi.transport.tcp=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-exports=java.base/sun.net.www.protocol.http=ALL-UNNAMED --add-exports=java.base/sun.net.www.protocol.https=ALL-UNNAMED --add-exports=java.base/sun.net.www.protocol.jar=ALL-UNNAMED --add-exports=jdk.xml.dom/org.w3c.dom.html=ALL-UNNAMED --add-exports=jdk.naming.rmi/com.sun.jndi.url.rmi=ALL-UNNAMED
 
 wrapper.working.dir=.
 

--- a/assembly/src/release/bin/macosx/wrapper.conf
+++ b/assembly/src/release/bin/macosx/wrapper.conf
@@ -26,7 +26,7 @@ set.default.ACTIVEMQ_CONF=%ACTIVEMQ_BASE%/conf
 set.default.ACTIVEMQ_DATA=%ACTIVEMQ_BASE%/data
 
 # JDK 9+ modules
-set.JDK_JAVA_OPTIONS=--add-reads=java.xml=java.logging --add-opens java.base/java.security=ALL-UNNAMED --add-opens java.base/java.net=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.naming/javax.naming.spi=ALL-UNNAMED --add-opens java.rmi/sun.rmi.transport.tcp=ALL-UNNAMED --add-exports=java.base/sun.net.www.protocol.http=ALL-UNNAMED --add-exports=java.base/sun.net.www.protocol.https=ALL-UNNAMED --add-exports=java.base/sun.net.www.protocol.jar=ALL-UNNAMED --add-exports=jdk.xml.dom/org.w3c.dom.html=ALL-UNNAMED --add-exports=jdk.naming.rmi/com.sun.jndi.url.rmi=ALL-UNNAMED
+set.JDK_JAVA_OPTIONS=--add-reads=java.xml=java.logging --add-opens java.base/java.security=ALL-UNNAMED --add-opens java.base/java.net=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.naming/javax.naming.spi=ALL-UNNAMED --add-opens java.rmi/sun.rmi.transport.tcp=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-exports=java.base/sun.net.www.protocol.http=ALL-UNNAMED --add-exports=java.base/sun.net.www.protocol.https=ALL-UNNAMED --add-exports=java.base/sun.net.www.protocol.jar=ALL-UNNAMED --add-exports=jdk.xml.dom/org.w3c.dom.html=ALL-UNNAMED --add-exports=jdk.naming.rmi/com.sun.jndi.url.rmi=ALL-UNNAMED
 
 wrapper.working.dir=.
 

--- a/assembly/src/release/bin/win64/wrapper.conf
+++ b/assembly/src/release/bin/win64/wrapper.conf
@@ -27,7 +27,7 @@ set.default.ACTIVEMQ_DATA=%ACTIVEMQ_BASE%/data
 set.default.JOLOKIA_CONF=file:..\\..\\conf\\jolokia-access.xml
 
 # JDK 9+ modules
-set.JDK_JAVA_OPTIONS=--add-reads=java.xml=java.logging --add-opens java.base/java.security=ALL-UNNAMED --add-opens java.base/java.net=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.util.concurrent=ALL-UNNAMED --add-opens java.base/java.util.concurrent.atomic=ALL-UNNAMED --add-opens java.naming/javax.naming.spi=ALL-UNNAMED --add-opens java.rmi/sun.rmi.transport.tcp=ALL-UNNAMED --add-exports=java.base/sun.net.www.protocol.http=ALL-UNNAMED --add-exports=java.base/sun.net.www.protocol.https=ALL-UNNAMED --add-exports=java.base/sun.net.www.protocol.jar=ALL-UNNAMED --add-exports=jdk.xml.dom/org.w3c.dom.html=ALL-UNNAMED --add-exports=jdk.naming.rmi/com.sun.jndi.url.rmi=ALL-UNNAMED
+set.JDK_JAVA_OPTIONS=--add-reads=java.xml=java.logging --add-opens java.base/java.security=ALL-UNNAMED --add-opens java.base/java.net=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.util.concurrent=ALL-UNNAMED --add-opens java.base/java.util.concurrent.atomic=ALL-UNNAMED --add-opens java.naming/javax.naming.spi=ALL-UNNAMED --add-opens java.rmi/sun.rmi.transport.tcp=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-exports=java.base/sun.net.www.protocol.http=ALL-UNNAMED --add-exports=java.base/sun.net.www.protocol.https=ALL-UNNAMED --add-exports=java.base/sun.net.www.protocol.jar=ALL-UNNAMED --add-exports=jdk.xml.dom/org.w3c.dom.html=ALL-UNNAMED --add-exports=jdk.naming.rmi/com.sun.jndi.url.rmi=ALL-UNNAMED
 
 wrapper.working.dir=.
 


### PR DESCRIPTION
When ActiveMQ running ActiveMQ on Java 17 or later JRE, it encounters following exception:

```
ERROR | Could not set property soTimeout on ServerSocket[addr=/0:0:0:0:0:0:0:0,localport=xxxxx] | org.apache.activemq.util.IntrospectionSupport | main
java.lang.reflect.InaccessibleObjectException: Unable to make public void sun.nio.ch.ServerSocketAdaptor.setSoTimeout(int) throws java.net.SocketException accessible: module java.base does not "opens sun.nio.ch" to unnamed module @4739cd70
	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:354)
	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:297)
	at java.base/java.lang.reflect.Method.checkCanSetAccessible(Method.java:199)
	at java.base/java.lang.reflect.Method.setAccessible(Method.java:193)
	at org.apache.activemq.util.IntrospectionSupport.setProperty(IntrospectionSupport.java:179)
	at org.apache.activemq.util.IntrospectionSupport.setProperties(IntrospectionSupport.java:155)
	at org.apache.activemq.transport.tcp.TcpTransportServer.configureServerSocket(TcpTransportServer.java:202)
	at org.apache.activemq.transport.tcp.TcpTransportServer.bind(TcpTransportServer.java:144)
	at org.apache.activemq.transport.auto.nio.AutoNioSslTransportFactory.doBind(AutoNioSslTransportFactory.java:122)
	at org.apache.activemq.transport.TransportFactorySupport.bind(TransportFactorySupport.java:40)
	at org.apache.activemq.broker.TransportConnector.createTransportServer(TransportConnector.java:340)
	at org.apache.activemq.broker.TransportConnector.getServer(TransportConnector.java:148)
	at org.apache.activemq.broker.TransportConnector.asManagedConnector(TransportConnector.java:113)
	at org.apache.activemq.broker.BrokerService.registerConnectorMBean(BrokerService.java:2241)
	at org.apache.activemq.broker.BrokerService.startTransportConnector(BrokerService.java:2728)
	at org.apache.activemq.broker.BrokerService.startAllConnectors(BrokerService.java:2624)
	at org.apache.activemq.broker.BrokerService.doStartBroker(BrokerService.java:762)
	at org.apache.activemq.broker.BrokerService.startBroker(BrokerService.java:724)
	at org.apache.activemq.broker.BrokerService.start(BrokerService.java:622) 
```
According to Oracle, with [JEP 403 (link1)](https://openjdk.java.net/jeps/403) and [JEP 403 (link2)](https://bugs.openjdk.java.net/browse/JDK-8263547) which has been decided to be delivered from JDK 17 and onwards , the setAccessible approach which was introduced as part of https://issues.apache.org/jira/browse/AMQ-7121 wont work.

 

