### PR TITLE
[AMQ-9469] Removed JRMS-1.1 dependency from assembly pom.xml

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -481,11 +481,6 @@
 
     <!-- dependencies specific to this module -->
     <dependency>
-      <groupId>jrms</groupId>
-      <artifactId>jrms</artifactId>
-      <version>1.1</version>
-    </dependency>
-    <dependency>
       <groupId>xerces</groupId>
       <artifactId>xercesImpl</artifactId>
       <version>${xerces-version}</version>


### PR DESCRIPTION
The jrms-1.1 library has not seen any releases/updates since 2005 and [Maven](https://mvnrepository.com/artifact/jrms/jrms/usages) lists only ActiveMQ and Apache Camel as upstream usages.

After digging through ActiveMQ's mailing lists and commit history, I found that it [used to be listed](https://github.com/apache/activemq-web/blob/7a7d976c/2004/06/23/jgroups-and-jrms-support.xml) on ActiveMQ's [URI Protocols](https://activemq.apache.org/components/classic/documentation/uri-protocols) page, but was removed at some point. JRMS seems to be listed as a peer-to-peer option on the [topologies](https://activemq.apache.org/components/classic/documentation/topologies) page but is not discussed in either the [peer](https://activemq.apache.org/components/classic/documentation/peer-transport-reference) or [multicast](https://activemq.apache.org/components/classic/documentation/multicast-transport-reference) transport reference pages.

The [META-INF/services/org/apache/activemq/transport](https://github.com/apache/activemq/tree/main/activemq-client/src/main/resources/META-INF/services/org/apache/activemq/transport) folder under `activemq-client` (tested using v5.18.3) does not have a "jrms" file, so "jrms://" does not resolve to a supported ActiveMQ protocol.

More details in the JIRA issue - https://issues.apache.org/jira/browse/AMQ-9469