### PR TITLE
[AMQ-9447] Added Logic to check underlying transport connector limits

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/broker/jmx/HealthView.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/jmx/HealthView.java
@@ -29,8 +29,10 @@ import javax.management.openmbean.TabularDataSupport;
 import javax.management.openmbean.TabularType;
 
 import org.apache.activemq.broker.BrokerService;
+import org.apache.activemq.broker.TransportConnector;
 import org.apache.activemq.broker.scheduler.JobSchedulerStore;
 import org.apache.activemq.store.PersistenceAdapter;
+import org.apache.activemq.transport.tcp.TcpTransportServer;
 import org.apache.activemq.usage.SystemUsage;
 
 public class HealthView implements HealthViewMBean {
@@ -165,6 +167,25 @@ public class HealthView implements HealthViewMBean {
                     }
                 }
             }
+        }
+
+        /**
+         * Check The Transport Connector limits
+         */
+
+        if (brokerService != null && !brokerService.getTransportConnectors().isEmpty()) {
+        	for(TransportConnector tc: brokerService.getTransportConnectors()) {
+        		if(tc.getServer() instanceof TcpTransportServer) {
+        			int connectionUsage = (int) (((TcpTransportServer)tc.getServer()).getCurrentTransportCount().get() * 100 ) / ((TcpTransportServer)tc.getServer()).getMaximumConnections();
+        			if(((TcpTransportServer)tc.getServer()).getCurrentTransportCount().get() >= ((TcpTransportServer)tc.getServer()).getMaximumConnections()) {
+        				String message = "Exceeded the maximum number of allowed client connections: " + ((TcpTransportServer)tc.getServer()).getMaximumConnections();
+        				answer.add(new HealthStatus("org.apache.activemq.transport.tcp.TcpTransportServer", "ERROR", message, tc.getName()));
+        			} else if(connectionUsage > 90) {
+        				String message = "The Current connection count is within  " + connectionUsage + "% of MaximumConnections limit";
+        				answer.add(new HealthStatus("org.apache.activemq.transport.tcp.TcpTransportServer", "WARNING", message, tc.getName()));
+        			}
+        		}	
+        	}
         }
 
         StringBuilder currentState = new StringBuilder();


### PR DESCRIPTION
(Re-Opened)
Hello Team,

With Regards to Transport Connector, Have added a check based on the connection count.

Also in the ticket, With regards to JDBC Persistence Check, We may need to have JDBC persistence associated classes in activemq-broker,jar, Post that we can have a logic something like following:

`
        if (brokerService != null && brokerService.getPersistenceAdapter() != null 
        		&& brokerService.getPersistenceAdapter() instanceof JDBCPersistenceAdapter ) {
        	JDBCPersistenceAdapter jdbcAdapter = (JDBCPersistenceAdapter) brokerService.getPersistenceAdapter();
			String message = "Issue with Persistence layer";
            try {
            	ResultSet rs = null;
            	Statement stmt = jdbcAdapter.getDataSource().getConnection().createStatement();
            	rs = stmt.executeQuery("SELECT 1");
				String message = 
            	if(rs.next())
					if(rs.getInt(1)!=1)
						answer.add(new HealthStatus("org.apache.activemq.store.jdbc.JDBCPersistenceAdapterIssue", "ERROR", message, jdbcAdapter.toString()));
            } catch(Exception e) {
            	answer.add(new HealthStatus("org.apache.activemq.store.jdbc.JDBCPersistenceAdapterIssue", "ERROR", message, jdbcAdapter.toString()));
            }            
        }
`


Ive Tested the above and it works as expected. But again that would require whole jdbc persistence adapter code.
