### PR TITLE
AMQ-9481 - Correctly complete async servlet request on timeout

### DIFF
--- a/activemq-web/src/main/java/org/apache/activemq/web/async/AsyncServletRequest.java
+++ b/activemq-web/src/main/java/org/apache/activemq/web/async/AsyncServletRequest.java
@@ -115,10 +115,10 @@ public class AsyncServletRequest implements AsyncListener  {
         }
 
         final AsyncContext context = event.getAsyncContext();
-        if (context != null) {
-            // We must call complete and then set the status code to prevent a 500
-            // error. The spec requires a 500 error on timeout unless complete() is called.
-            context.complete();
+        if (context != null && event.getSuppliedRequest().isAsyncStarted()) {
+            // We must call dispatch to finish the request on timeout.
+            // then set the status code to prevent a 500 error.
+            context.dispatch();
             final ServletResponse response = context.getResponse();
             if (response instanceof HttpServletResponse) {
                 ((HttpServletResponse) response).setStatus(HttpServletResponse.SC_NO_CONTENT);


### PR DESCRIPTION
This fixes AsyncServletRequest to correctly call context.dispatch() when the async request times out so that the consumer can be re-used.