### PR TITLE
[AMQ-9532] Convert DestinationMapNode from recursion to loops.

### DIFF
--- a/activemq-client/src/main/java/org/apache/activemq/filter/DestinationMap.java
+++ b/activemq-client/src/main/java/org/apache/activemq/filter/DestinationMap.java
@@ -100,7 +100,7 @@ public class DestinationMap {
             return;
         }
         String[] paths = key.getDestinationPaths();
-        getRootNode(key).add(paths, 0, value);
+        getRootNode(key).add(paths, value);
     }
 
 
@@ -123,7 +123,7 @@ public class DestinationMap {
             return;
         }
         String[] paths = key.getDestinationPaths();
-        getRootNode(key).remove(paths, 0, value);
+        getRootNode(key).remove(paths, value);
 
     }
 


### PR DESCRIPTION
Because destinations are parsed recursively, it's possible to trigger `java.lang.StackOverflowError` if a destination has too many nodes.
the PR is converting the recursion to loops.

Ran `DestinationMapTest.java` to make sure the behavior of the class stays the same. There is no need for additional testing in my opinion, because the behavior is supposed to stay the same as it was before the change.