### PR TITLE
for loop can be replaced with enhanced for

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/broker/TransportConnection.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/TransportConnection.java
@@ -1214,8 +1214,7 @@ public class TransportConnection implements Connection, Task, CommandVisitor {
         // Run the MessageDispatch callbacks so that message references get
         // cleaned up.
         synchronized (dispatchQueue) {
-            for (Iterator<Command> iter = dispatchQueue.iterator(); iter.hasNext(); ) {
-                Command command = iter.next();
+            for (Command command : dispatchQueue) {
                 if (command.isMessageDispatch()) {
                     MessageDispatch md = (MessageDispatch) command;
                     TransmitCallback sub = md.getTransmitCallback();
@@ -1421,8 +1420,7 @@ public class TransportConnection implements Connection, Task, CommandVisitor {
                 String duplexNetworkConnectorId = config.getName() + "@" + info.getBrokerId();
                 CopyOnWriteArrayList<TransportConnection> connections = this.connector.getConnections();
                 synchronized (connections) {
-                    for (Iterator<TransportConnection> iter = connections.iterator(); iter.hasNext(); ) {
-                        TransportConnection c = iter.next();
+                    for (TransportConnection c : connections) {
                         if ((c != this) && (duplexNetworkConnectorId.equals(c.getDuplexNetworkConnectorId()))) {
                             LOG.warn("Stopping an existing active duplex connection [{}] for network connector ({}).", c, duplexNetworkConnectorId);
                             c.stopAsync();


### PR DESCRIPTION
Iteration over collections or arrays  can be replaced with an enhanced for loop (foreach iteration syntax). 

```
The for-each construct gets rid of the clutter and the opportunity for error.
When should you use the for-each loop? Any time you can. It really beautifies your code.
```
See more details why : https://docs.oracle.com/javase/8/docs/technotes/guides/language/foreach.html
