### PR TITLE
Code Janitor task: Replace use of depricated WildcardFileFilter constructor in unit tests

### DIFF
--- a/activemq-unit-tests/src/test/java/org/apache/activemq/bugs/AMQ6131Test.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/bugs/AMQ6131Test.java
@@ -25,7 +25,7 @@ import static org.junit.Assert.assertTrue;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
-import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -111,7 +111,7 @@ public class AMQ6131Test {
         TopicSubscriber durable = jmsSession.createDurableSubscriber(new ActiveMQTopic("durable.sub"), "sub");
         final MessageProducer producer = jmsSession.createProducer(new ActiveMQTopic("durable.sub"));
 
-        final int original = new ArrayList<File>(FileUtils.listFiles(persistentDir, new WildcardFileFilter("*.log"), TrueFileFilter.INSTANCE)).size();
+        final int original = listFiles(persistentDir, "*.log").size();
 
         // 100k messages
         final byte[] data = new byte[100000];
@@ -132,7 +132,7 @@ public class AMQ6131Test {
                     messageCount.getAndIncrement();
                 }
 
-                return new ArrayList<File>(FileUtils.listFiles(persistentDir, new WildcardFileFilter("*.log"), TrueFileFilter.INSTANCE)).size() > original;
+                return listFiles(persistentDir, "*.log").size() > original;
             }
         }));
 
@@ -159,7 +159,7 @@ public class AMQ6131Test {
 
             @Override
             public boolean isSatisified() throws Exception {
-                return new ArrayList<File>(FileUtils.listFiles(persistentDir, new WildcardFileFilter("*.log"), TrueFileFilter.INSTANCE)).size() == original;
+                return listFiles(persistentDir, "*.log").size() == original;
             }
         }, 5000, 500));
 
@@ -169,7 +169,7 @@ public class AMQ6131Test {
 
         // delete the index so that the durables are gone from the index
         // The test passes if you take out this delete section
-        for (File index : FileUtils.listFiles(persistentDir, new WildcardFileFilter("db.*"), TrueFileFilter.INSTANCE)) {
+        for (File index : listFiles(persistentDir, "db.*")) {
             FileUtils.deleteQuietly(index);
         }
 
@@ -208,7 +208,7 @@ public class AMQ6131Test {
         TopicSubscriber durable = jmsSession.createDurableSubscriber(new ActiveMQTopic("durable.sub"), "sub");
         final MessageProducer producer = jmsSession.createProducer(new ActiveMQTopic("durable.sub"));
 
-        final int original = new ArrayList<File>(FileUtils.listFiles(persistentDir, new WildcardFileFilter("*.log"), TrueFileFilter.INSTANCE)).size();
+        final int original = listFiles(persistentDir, "*.log").size();
 
         // 100k messages
         final byte[] data = new byte[100000];
@@ -229,7 +229,7 @@ public class AMQ6131Test {
                     messageCount.getAndIncrement();
                 }
 
-                return new ArrayList<File>(FileUtils.listFiles(persistentDir, new WildcardFileFilter("*.log"), TrueFileFilter.INSTANCE)).size() > original;
+                return listFiles(persistentDir, "*.log").size() > original;
             }
         }));
 
@@ -255,7 +255,7 @@ public class AMQ6131Test {
 
             @Override
             public boolean isSatisified() throws Exception {
-                return new ArrayList<File>(FileUtils.listFiles(persistentDir, new WildcardFileFilter("*.log"), TrueFileFilter.INSTANCE)).size() == original;
+                return listFiles(persistentDir, "*.log").size() == original;
             }
         }));
 
@@ -265,7 +265,7 @@ public class AMQ6131Test {
 
         // delete the index so that the durables are gone from the index
         // The test passes if you take out this delete section
-        for (File index : FileUtils.listFiles(persistentDir, new WildcardFileFilter("db.*"), TrueFileFilter.INSTANCE)) {
+        for (File index : listFiles(persistentDir, "db.*")) {
             FileUtils.deleteQuietly(index);
         }
 
@@ -287,5 +287,10 @@ public class AMQ6131Test {
         assertEquals(1, broker.getAdminView().getDurableTopicSubscribers().length);
 
         assertNull(durable2.receive(500));
+    }
+
+    private Collection<File> listFiles(File directory, String filterPattern) {
+        WildcardFileFilter filter = WildcardFileFilter.builder().setWildcards(filterPattern).get();
+        return FileUtils.listFiles(directory, filter, TrueFileFilter.INSTANCE);
     }
 }

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/bugs/AMQ6133PersistJMSRedeliveryTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/bugs/AMQ6133PersistJMSRedeliveryTest.java
@@ -22,7 +22,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
+import java.util.Collection;
 import java.util.concurrent.TimeUnit;
 
 import jakarta.jms.BytesMessage;
@@ -118,7 +118,7 @@ public class AMQ6133PersistJMSRedeliveryTest {
         broker.waitUntilStopped();
 
         // delete the index so that it needs to be rebuilt from replay
-        for (File index : FileUtils.listFiles(persistenceDir, new WildcardFileFilter("db.*"), TrueFileFilter.INSTANCE)) {
+        for (File index : listFiles(persistenceDir, "db.*")) {
             FileUtils.deleteQuietly(index);
         }
 
@@ -201,13 +201,16 @@ public class AMQ6133PersistJMSRedeliveryTest {
     }
 
     private int getLogFileCount() throws Exception {
-        return new ArrayList<File>(
-                FileUtils.listFiles(getPersistentDir(),
-                    new WildcardFileFilter("*.log"), TrueFileFilter.INSTANCE)).size();
+        return listFiles(getPersistentDir(), "*.log").size();
     }
 
     private File getPersistentDir() throws IOException {
         return broker.getPersistenceAdapter().getDirectory();
+    }
+
+    private Collection<File> listFiles(File directory, String filterPattern) {
+        WildcardFileFilter filter = WildcardFileFilter.builder().setWildcards(filterPattern).get();
+        return FileUtils.listFiles(directory, filter, TrueFileFilter.INSTANCE);
     }
 
     protected QueueViewMBean getProxyToQueue(String name) throws MalformedObjectNameException, JMSException {

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/store/kahadb/AbstractKahaDBMessageStoreSizeTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/store/kahadb/AbstractKahaDBMessageStoreSizeTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.util.Collection;
 
 import org.apache.activemq.store.AbstractMessageStoreSizeTest;
 import org.apache.activemq.store.MessageStore;
@@ -124,7 +125,9 @@ public abstract class AbstractKahaDBMessageStoreSizeTest extends AbstractMessage
             FileUtils.deleteDirectory(new File(dataDirectory));
         FileUtils.copyDirectory(new File(getVersion5Dir()),
                 dataDir);
-        for (File index : FileUtils.listFiles(new File(dataDirectory), new WildcardFileFilter("*.data"), TrueFileFilter.INSTANCE)) {
+        WildcardFileFilter fileFilter = WildcardFileFilter.builder().setWildcards("*.data").get();
+        Collection<File> files = FileUtils.listFiles(new File(dataDirectory), fileFilter, TrueFileFilter.INSTANCE);
+        for (File index : files) {
             FileUtils.deleteQuietly(index);
         }
 

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/store/kahadb/AbstractMultiKahaDBDeletionTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/store/kahadb/AbstractMultiKahaDBDeletionTest.java
@@ -131,7 +131,8 @@ public abstract class AbstractMultiKahaDBDeletionTest {
         // try and create a consumer on dest2, before AMQ-5875 this
         //would cause an IllegalStateException for Topics
         createConsumer(dest2);
-        Collection<File> storeFiles = FileUtils.listFiles(storeDir, new WildcardFileFilter("db*"), getStoreFileFilter());
+        WildcardFileFilter fileFilter = WildcardFileFilter.builder().setWildcards("db*").get();
+        Collection<File> storeFiles = FileUtils.listFiles(storeDir, fileFilter, getStoreFileFilter());
         assertTrue("Store index should still exist", storeFiles.size() >= 1);
     }
 
@@ -151,7 +152,8 @@ public abstract class AbstractMultiKahaDBDeletionTest {
         // try and create a consumer on dest1, before AMQ-5875 this
         //would cause an IllegalStateException for Topics
         createConsumer(dest1);
-        Collection<File> storeFiles = FileUtils.listFiles(storeDir, new WildcardFileFilter("db*"), getStoreFileFilter());
+        WildcardFileFilter fileFilter = WildcardFileFilter.builder().setWildcards("db*").get();
+        Collection<File> storeFiles = FileUtils.listFiles(storeDir, fileFilter, getStoreFileFilter());
         assertTrue("Store index should still exist", storeFiles.size() >= 1);
     }
 
@@ -170,7 +172,8 @@ public abstract class AbstractMultiKahaDBDeletionTest {
         broker.removeDestination(brokerService.getAdminConnectionContext(), dest2, 100);
 
         //Assert that with no more destinations attached to a store that it has been cleaned up
-        Collection<File> storeFiles = FileUtils.listFiles(storeDir, new WildcardFileFilter("db*"), getStoreFileFilter());
+        WildcardFileFilter fileFilter = WildcardFileFilter.builder().setWildcards("db*").get();
+        Collection<File> storeFiles = FileUtils.listFiles(storeDir, fileFilter, getStoreFileFilter());
         assertEquals("Store files should be deleted", 0, storeFiles.size());
 
     }
@@ -189,9 +192,9 @@ public abstract class AbstractMultiKahaDBDeletionTest {
         broker.removeDestination(brokerService.getAdminConnectionContext(), dest1, 100);
 
         //Assert that with no more destinations attached to a store that it has been cleaned up
-        Collection<File> storeFiles = FileUtils.listFiles(storeDir, new WildcardFileFilter("db*"), getStoreFileFilter());
+        WildcardFileFilter fileFilter = WildcardFileFilter.builder().setWildcards("db*").get();
+        Collection<File> storeFiles = FileUtils.listFiles(storeDir, fileFilter, getStoreFileFilter());
         assertEquals("Store files should be deleted", 0, storeFiles.size());
-
     }
 
 

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/store/kahadb/MultiKahaDBQueueDeletionTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/store/kahadb/MultiKahaDBQueueDeletionTest.java
@@ -85,7 +85,7 @@ public class MultiKahaDBQueueDeletionTest extends AbstractMultiKahaDBDeletionTes
      */
     @Override
     protected WildcardFileFilter getStoreFileFilter() {
-        return new WildcardFileFilter("queue*");
+        return WildcardFileFilter.builder().setWildcards("queue*").get();
     }
 
 }

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/store/kahadb/SubscriptionRecoveryTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/store/kahadb/SubscriptionRecoveryTest.java
@@ -81,7 +81,8 @@ public class SubscriptionRecoveryTest {
         pa.setCleanupInterval(TimeUnit.SECONDS.toMillis(5));
         //Delete the index files on recovery
         if (recover) {
-            for (File index : FileUtils.listFiles(dataFile, new WildcardFileFilter("*.data"), TrueFileFilter.INSTANCE)) {
+            WildcardFileFilter fileFilter = WildcardFileFilter.builder().setWildcards("*.data").get();
+            for (File index : FileUtils.listFiles(dataFile, fileFilter, TrueFileFilter.INSTANCE)) {
                 LOG.info("deleting: " + index);
                 FileUtils.deleteQuietly(index);
             }


### PR DESCRIPTION
This is a no-jira task, just some cleaning in activemq-unit-tests to minimize deprecated warnings when building.
``new WildcardFileFilter(String  wildcard)`` is depricated, and the deprication note suggest using builder ``builder()``.