### PR TITLE
[AMQ-9543] Replace use of deprecated setInactiveTimoutBeforeGC in unit tests

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/broker/region/policy/PolicyEntry.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/region/policy/PolicyEntry.java
@@ -1037,7 +1037,7 @@ public class PolicyEntry extends DestinationMapEntry {
     /**
      * @return the amount of time spent inactive before GC of the destination kicks in.
      *
-     * @deprecated use getInactiveTimeoutBeforeGC instead.
+     * @deprecated use {@link #getInactiveTimeoutBeforeGC} instead.
      */
     @Deprecated
     public long getInactiveTimoutBeforeGC() {
@@ -1050,7 +1050,7 @@ public class PolicyEntry extends DestinationMapEntry {
      * @param inactiveTimoutBeforeGC
      *        time in milliseconds to configure as the inactive timeout.
      *
-     * @deprecated use getInactiveTimeoutBeforeGC instead.
+     * @deprecated use {@link #setInactiveTimeoutBeforeGC} instead.
      */
     @Deprecated
     public void setInactiveTimoutBeforeGC(long inactiveTimoutBeforeGC) {

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/bugs/AMQ3157Test.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/bugs/AMQ3157Test.java
@@ -122,7 +122,7 @@ public class AMQ3157Test extends EmbeddedBrokerTestSupport {
 
         PolicyEntry entry = new PolicyEntry();
         entry.setGcInactiveDestinations(true);
-        entry.setInactiveTimoutBeforeGC(5000);
+        entry.setInactiveTimeoutBeforeGC(5000);
         entry.setProducerFlowControl(true);
         PolicyMap map = new PolicyMap();
         map.setDefaultEntry(entry);

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/bugs/AMQ3324Test.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/bugs/AMQ3324Test.java
@@ -127,7 +127,7 @@ public class AMQ3324Test {
 
         PolicyEntry entry = new PolicyEntry();
         entry.setGcInactiveDestinations(true);
-        entry.setInactiveTimoutBeforeGC(2000);
+        entry.setInactiveTimeoutBeforeGC(2000);
         entry.setProducerFlowControl(true);
         entry.setAdvisoryForConsumed(true);
         entry.setAdvisoryForFastProducers(true);

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/usecases/RequestReplyNoAdvisoryNetworkTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/usecases/RequestReplyNoAdvisoryNetworkTest.java
@@ -270,7 +270,7 @@ public class RequestReplyNoAdvisoryNetworkTest extends JmsMultipleBrokersTestSup
         tempReplyQPolicy.setOptimizedDispatch(true);
         tempReplyQPolicy.setGcInactiveDestinations(true);
         tempReplyQPolicy.setGcWithNetworkConsumers(true);
-        tempReplyQPolicy.setInactiveTimoutBeforeGC(1000);
+        tempReplyQPolicy.setInactiveTimeoutBeforeGC(1000);
         map.put(replyQWildcard, tempReplyQPolicy);
         broker.setDestinationPolicy(map);
 


### PR DESCRIPTION
``PolicyEntry.setInactiveTimoutBeforeGC(long inactiveTimoutBeforeGC)`` is deprecated, and the deprecation note suggests using ``PolicyEntry.setInactiveTimeoutBeforeGC(long setInactiveTimeoutBeforeGC)``.

The deprecation note has a typo, it says to use the ``getInactiveTimeoutBeforeGC`` for the deprecated ``setInactiveTimoutBeforeGC``, but should be ``setInactiveTimeoutBeforeGC``