### PR TITLE
Code Janitor task: Replace use of deprecated Class.newInstance()

### DIFF
--- a/activemq-unit-tests/src/test/java/org/apache/activemq/openwire/DataFileGenerator.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/openwire/DataFileGenerator.java
@@ -59,7 +59,7 @@ public abstract class DataFileGenerator extends org.junit.Assert {
                 String cn = file.getName();
                 cn = cn.substring(0, cn.length() - ".java".length());
                 Class<?> clazz = DataFileGenerator.class.getClassLoader().loadClass("org.apache.activemq.openwire." + cn);
-                l.add((DataFileGenerator)clazz.newInstance());
+                l.add((DataFileGenerator)clazz.getDeclaredConstructor().newInstance());
             }
         }
         return l;


### PR DESCRIPTION
This is a no-jira task, just some cleaning in activemq-unit-tests to minimize deprecated warnings when building.