### PR TITLE
AMQ-9547 - Remove setLength() and usage from RecoverableRandomAccessFile

### DIFF
--- a/activemq-kahadb-store/src/main/java/org/apache/activemq/store/kahadb/disk/page/PageFile.java
+++ b/activemq-kahadb-store/src/main/java/org/apache/activemq/store/kahadb/disk/page/PageFile.java
@@ -423,7 +423,8 @@ public class PageFile {
             }
 
             if (writeFile.length() < PAGE_FILE_HEADER_SIZE) {
-                writeFile.setLength(PAGE_FILE_HEADER_SIZE);
+                throw new IllegalStateException("File " + file + " is corrupt, length of "
+                    + writeFile.length() + " is less than page file header size of " + PAGE_FILE_HEADER_SIZE);
             }
             nextFreePageId.set((writeFile.length() - PAGE_FILE_HEADER_SIZE) / pageSize);
 
@@ -1165,12 +1166,6 @@ public class PageFile {
                     recoveryFile.write(w.getDiskBound(tmpFilesForRemoval), 0, pageSize);
                 }
 
-                // Can we shrink the recovery buffer??
-                if (recoveryPageCount > recoveryFileMaxPageCount) {
-                    int t = Math.max(recoveryFileMinPageCount, batch.size());
-                    recoveryFile.setLength(recoveryFileSizeForPages(t));
-                }
-
                 // Record the page writes in the recovery buffer.
                 recoveryFile.seek(0);
                 // Store the next tx id...
@@ -1262,8 +1257,6 @@ public class PageFile {
         if (recoveryFile.length() == 0) {
             // Write an empty header..
             recoveryFile.write(new byte[RECOVERY_FILE_HEADER_SIZE]);
-            // Preallocate the minium size for better performance.
-            recoveryFile.setLength(recoveryFileSizeForPages(recoveryFileMinPageCount));
             return 0;
         }
 

--- a/activemq-kahadb-store/src/main/java/org/apache/activemq/util/RecoverableRandomAccessFile.java
+++ b/activemq-kahadb-store/src/main/java/org/apache/activemq/util/RecoverableRandomAccessFile.java
@@ -374,10 +374,6 @@ public class RecoverableRandomAccessFile implements java.io.DataOutput, java.io.
         }
     }
 
-    public void setLength(long length) throws IOException {
-        throw new IllegalStateException("File size is pre allocated");
-    }
-
     public void seek(long pos) throws IOException {
         try {
             getRaf().seek(pos);


### PR DESCRIPTION
This method always throws an exception so it should be removed and no longer used. Places in `PageFile` that called the method have been updated to either remove the usage or throw an error.

Update: I was able to add a test in `PageFileTest` to verify there's no more exception if the recovery file is missing as the page file no longer calls setLength() and will continue