### PR TITLE
AMQ-9544 Deprecated WildcardFileFilter constructor

### DIFF
--- a/activemq-unit-tests/src/test/java/org/apache/activemq/bugs/AMQ6131Test.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/bugs/AMQ6131Test.java
@@ -56,6 +56,9 @@ import org.junit.Test;
  */
 public class AMQ6131Test {
 
+    private final static WildcardFileFilter LOG_FILE_FILTER = WildcardFileFilter.builder().setWildcards("*.log").get();
+    private final static WildcardFileFilter DB_FILE_FILTER = WildcardFileFilter.builder().setWildcards("db.*").get();
+
     protected BrokerService broker;
     protected URI brokerConnectURI;
 
@@ -111,7 +114,7 @@ public class AMQ6131Test {
         TopicSubscriber durable = jmsSession.createDurableSubscriber(new ActiveMQTopic("durable.sub"), "sub");
         final MessageProducer producer = jmsSession.createProducer(new ActiveMQTopic("durable.sub"));
 
-        final int original = new ArrayList<File>(FileUtils.listFiles(persistentDir, new WildcardFileFilter("*.log"), TrueFileFilter.INSTANCE)).size();
+        final int original = new ArrayList<File>(FileUtils.listFiles(persistentDir, LOG_FILE_FILTER, TrueFileFilter.INSTANCE)).size();
 
         // 100k messages
         final byte[] data = new byte[100000];
@@ -132,7 +135,7 @@ public class AMQ6131Test {
                     messageCount.getAndIncrement();
                 }
 
-                return new ArrayList<File>(FileUtils.listFiles(persistentDir, new WildcardFileFilter("*.log"), TrueFileFilter.INSTANCE)).size() > original;
+                return new ArrayList<File>(FileUtils.listFiles(persistentDir, LOG_FILE_FILTER, TrueFileFilter.INSTANCE)).size() > original;
             }
         }));
 
@@ -159,7 +162,7 @@ public class AMQ6131Test {
 
             @Override
             public boolean isSatisified() throws Exception {
-                return new ArrayList<File>(FileUtils.listFiles(persistentDir, new WildcardFileFilter("*.log"), TrueFileFilter.INSTANCE)).size() == original;
+                return new ArrayList<File>(FileUtils.listFiles(persistentDir, LOG_FILE_FILTER, TrueFileFilter.INSTANCE)).size() == original;
             }
         }, 5000, 500));
 
@@ -169,7 +172,7 @@ public class AMQ6131Test {
 
         // delete the index so that the durables are gone from the index
         // The test passes if you take out this delete section
-        for (File index : FileUtils.listFiles(persistentDir, new WildcardFileFilter("db.*"), TrueFileFilter.INSTANCE)) {
+        for (File index : FileUtils.listFiles(persistentDir, DB_FILE_FILTER, TrueFileFilter.INSTANCE)) {
             FileUtils.deleteQuietly(index);
         }
 
@@ -208,7 +211,7 @@ public class AMQ6131Test {
         TopicSubscriber durable = jmsSession.createDurableSubscriber(new ActiveMQTopic("durable.sub"), "sub");
         final MessageProducer producer = jmsSession.createProducer(new ActiveMQTopic("durable.sub"));
 
-        final int original = new ArrayList<File>(FileUtils.listFiles(persistentDir, new WildcardFileFilter("*.log"), TrueFileFilter.INSTANCE)).size();
+        final int original = new ArrayList<File>(FileUtils.listFiles(persistentDir, LOG_FILE_FILTER, TrueFileFilter.INSTANCE)).size();
 
         // 100k messages
         final byte[] data = new byte[100000];
@@ -229,7 +232,7 @@ public class AMQ6131Test {
                     messageCount.getAndIncrement();
                 }
 
-                return new ArrayList<File>(FileUtils.listFiles(persistentDir, new WildcardFileFilter("*.log"), TrueFileFilter.INSTANCE)).size() > original;
+                return new ArrayList<File>(FileUtils.listFiles(persistentDir, LOG_FILE_FILTER, TrueFileFilter.INSTANCE)).size() > original;
             }
         }));
 
@@ -255,7 +258,7 @@ public class AMQ6131Test {
 
             @Override
             public boolean isSatisified() throws Exception {
-                return new ArrayList<File>(FileUtils.listFiles(persistentDir, new WildcardFileFilter("*.log"), TrueFileFilter.INSTANCE)).size() == original;
+                return new ArrayList<File>(FileUtils.listFiles(persistentDir, LOG_FILE_FILTER, TrueFileFilter.INSTANCE)).size() == original;
             }
         }));
 
@@ -265,7 +268,7 @@ public class AMQ6131Test {
 
         // delete the index so that the durables are gone from the index
         // The test passes if you take out this delete section
-        for (File index : FileUtils.listFiles(persistentDir, new WildcardFileFilter("db.*"), TrueFileFilter.INSTANCE)) {
+        for (File index : FileUtils.listFiles(persistentDir, DB_FILE_FILTER, TrueFileFilter.INSTANCE)) {
             FileUtils.deleteQuietly(index);
         }
 

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/bugs/AMQ6133PersistJMSRedeliveryTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/bugs/AMQ6133PersistJMSRedeliveryTest.java
@@ -117,8 +117,9 @@ public class AMQ6133PersistJMSRedeliveryTest {
         broker.stop();
         broker.waitUntilStopped();
 
+        final WildcardFileFilter fileFilter = WildcardFileFilter.builder().setWildcards("db.*").get();
         // delete the index so that it needs to be rebuilt from replay
-        for (File index : FileUtils.listFiles(persistenceDir, new WildcardFileFilter("db.*"), TrueFileFilter.INSTANCE)) {
+        for (File index : FileUtils.listFiles(persistenceDir, fileFilter, TrueFileFilter.INSTANCE)) {
             FileUtils.deleteQuietly(index);
         }
 
@@ -201,9 +202,8 @@ public class AMQ6133PersistJMSRedeliveryTest {
     }
 
     private int getLogFileCount() throws Exception {
-        return new ArrayList<File>(
-                FileUtils.listFiles(getPersistentDir(),
-                    new WildcardFileFilter("*.log"), TrueFileFilter.INSTANCE)).size();
+        final WildcardFileFilter fileFilter = WildcardFileFilter.builder().setWildcards("*.log").get();
+        return new ArrayList<File>(FileUtils.listFiles(getPersistentDir(), fileFilter, TrueFileFilter.INSTANCE)).size();
     }
 
     private File getPersistentDir() throws IOException {

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/store/kahadb/AbstractKahaDBMessageStoreSizeTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/store/kahadb/AbstractKahaDBMessageStoreSizeTest.java
@@ -124,7 +124,8 @@ public abstract class AbstractKahaDBMessageStoreSizeTest extends AbstractMessage
             FileUtils.deleteDirectory(new File(dataDirectory));
         FileUtils.copyDirectory(new File(getVersion5Dir()),
                 dataDir);
-        for (File index : FileUtils.listFiles(new File(dataDirectory), new WildcardFileFilter("*.data"), TrueFileFilter.INSTANCE)) {
+        final WildcardFileFilter fileFilter = WildcardFileFilter.builder().setWildcards("*.data").get();
+        for (File index : FileUtils.listFiles(new File(dataDirectory), fileFilter, TrueFileFilter.INSTANCE)) {
             FileUtils.deleteQuietly(index);
         }
 

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/store/kahadb/AbstractMultiKahaDBDeletionTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/store/kahadb/AbstractMultiKahaDBDeletionTest.java
@@ -44,6 +44,7 @@ import org.slf4j.LoggerFactory;
 
 
 public abstract class AbstractMultiKahaDBDeletionTest {
+    private final static WildcardFileFilter DB_FILE_FILTER = WildcardFileFilter.builder().setWildcards("db*").get();
     protected static final Logger LOG = LoggerFactory
             .getLogger(MultiKahaDBTopicDeletionTest.class);
 
@@ -131,7 +132,7 @@ public abstract class AbstractMultiKahaDBDeletionTest {
         // try and create a consumer on dest2, before AMQ-5875 this
         //would cause an IllegalStateException for Topics
         createConsumer(dest2);
-        Collection<File> storeFiles = FileUtils.listFiles(storeDir, new WildcardFileFilter("db*"), getStoreFileFilter());
+        Collection<File> storeFiles = FileUtils.listFiles(storeDir, DB_FILE_FILTER, getStoreFileFilter());
         assertTrue("Store index should still exist", storeFiles.size() >= 1);
     }
 
@@ -151,7 +152,7 @@ public abstract class AbstractMultiKahaDBDeletionTest {
         // try and create a consumer on dest1, before AMQ-5875 this
         //would cause an IllegalStateException for Topics
         createConsumer(dest1);
-        Collection<File> storeFiles = FileUtils.listFiles(storeDir, new WildcardFileFilter("db*"), getStoreFileFilter());
+        Collection<File> storeFiles = FileUtils.listFiles(storeDir, DB_FILE_FILTER, getStoreFileFilter());
         assertTrue("Store index should still exist", storeFiles.size() >= 1);
     }
 
@@ -170,7 +171,7 @@ public abstract class AbstractMultiKahaDBDeletionTest {
         broker.removeDestination(brokerService.getAdminConnectionContext(), dest2, 100);
 
         //Assert that with no more destinations attached to a store that it has been cleaned up
-        Collection<File> storeFiles = FileUtils.listFiles(storeDir, new WildcardFileFilter("db*"), getStoreFileFilter());
+        Collection<File> storeFiles = FileUtils.listFiles(storeDir, DB_FILE_FILTER, getStoreFileFilter());
         assertEquals("Store files should be deleted", 0, storeFiles.size());
 
     }
@@ -189,7 +190,7 @@ public abstract class AbstractMultiKahaDBDeletionTest {
         broker.removeDestination(brokerService.getAdminConnectionContext(), dest1, 100);
 
         //Assert that with no more destinations attached to a store that it has been cleaned up
-        Collection<File> storeFiles = FileUtils.listFiles(storeDir, new WildcardFileFilter("db*"), getStoreFileFilter());
+        Collection<File> storeFiles = FileUtils.listFiles(storeDir, DB_FILE_FILTER, getStoreFileFilter());
         assertEquals("Store files should be deleted", 0, storeFiles.size());
 
     }

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/store/kahadb/MultiKahaDBQueueDeletionTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/store/kahadb/MultiKahaDBQueueDeletionTest.java
@@ -85,7 +85,7 @@ public class MultiKahaDBQueueDeletionTest extends AbstractMultiKahaDBDeletionTes
      */
     @Override
     protected WildcardFileFilter getStoreFileFilter() {
-        return new WildcardFileFilter("queue*");
+        return WildcardFileFilter.builder().setWildcards("queue*").get();
     }
 
 }

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/store/kahadb/MultiKahaDBTopicDeletionTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/store/kahadb/MultiKahaDBTopicDeletionTest.java
@@ -80,7 +80,7 @@ public class MultiKahaDBTopicDeletionTest extends AbstractMultiKahaDBDeletionTes
 
     @Override
     protected WildcardFileFilter getStoreFileFilter() {
-        return new WildcardFileFilter("topic*");
+        return WildcardFileFilter.builder().setWildcards("topic*").get();
     }
 
 }

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/store/kahadb/SubscriptionRecoveryTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/store/kahadb/SubscriptionRecoveryTest.java
@@ -81,7 +81,8 @@ public class SubscriptionRecoveryTest {
         pa.setCleanupInterval(TimeUnit.SECONDS.toMillis(5));
         //Delete the index files on recovery
         if (recover) {
-            for (File index : FileUtils.listFiles(dataFile, new WildcardFileFilter("*.data"), TrueFileFilter.INSTANCE)) {
+            final WildcardFileFilter fileFilter = WildcardFileFilter.builder().setWildcards("*.data").get();
+            for (File index : FileUtils.listFiles(dataFile, fileFilter, TrueFileFilter.INSTANCE)) {
                 LOG.info("deleting: " + index);
                 FileUtils.deleteQuietly(index);
             }


### PR DESCRIPTION
**What problems does this PR solve?**
As per the [WildcardFileFilter docs](https://commons.apache.org/proper/commons-io/apidocs/org/apache/commons/io/filefilter/WildcardFileFilter.html#%3Cinit%3E(java.lang.String)) the `WildcardFileFilter(String wildcard)` constructor is deprecated. Replace this constructor with the recommended [Builder](https://commons.apache.org/proper/commons-io/apidocs/org/apache/commons/io/filefilter/WildcardFileFilter.Builder.html).

**Why is it beneficial to merge into ActiveMQ?**
Updates deprecated code with the recommended approach.

**How do you make sure this PR is well tested?**
Ran all of the tests that were updated to ensure they are still passing. 
For abstract test classes, tested the classes which extend them.