### PR TITLE
WIP: [AMQ-8398] Fix conversion of 4-byte unicode characters between JMS and STOMP

### DIFF
--- a/activemq-client/src/main/java/org/apache/activemq/util/DataByteArrayInputStream.java
+++ b/activemq-client/src/main/java/org/apache/activemq/util/DataByteArrayInputStream.java
@@ -264,8 +264,7 @@ public final class DataByteArrayInputStream extends InputStream implements DataI
         if (pos + length > buf.length) {
             throw new UTFDataFormatException("bad string");
         }
-        char chararr[] = new char[length];
-        String result = MarshallingSupport.convertUTF8WithBuf(buf, chararr, pos, length);
+        String result = MarshallingSupport.convertUTF8WithBuf(buf, pos, length);
         pos += length;
         return result;
     }

--- a/activemq-client/src/main/java/org/apache/activemq/util/DataByteArrayOutputStream.java
+++ b/activemq-client/src/main/java/org/apache/activemq/util/DataByteArrayOutputStream.java
@@ -210,7 +210,6 @@ public final class DataByteArrayOutputStream extends OutputStream implements Dat
         ensureEnoughBuffer((int)(pos + encodedsize + 2));
         writeShort((int)encodedsize);
 
-        byte[] buffer = new byte[(int)encodedsize];
         MarshallingSupport.writeUTFBytesToBuffer(text, (int) encodedsize, buf, pos);
         pos += encodedsize;
     }

--- a/activemq-client/src/test/java/org/apache/activemq/util/MarshallingSupportTest.java
+++ b/activemq-client/src/test/java/org/apache/activemq/util/MarshallingSupportTest.java
@@ -16,8 +16,14 @@
  */
 package org.apache.activemq.util;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutput;
+import java.io.DataOutputStream;
 import java.util.Properties;
 
 import org.junit.Test;
@@ -41,5 +47,21 @@ public class MarshallingSupportTest {
         String str = MarshallingSupport.propertiesToString(props);
         Properties props2 = MarshallingSupport.stringToProperties(str);
         assertEquals(props, props2);
+    }
+
+    @Test
+    public void testReadWriteUtf8() throws Exception {
+        byte[] bytes = {0, 0, 0, 10, 33, -62, -82, -32, -79, -87, -16, -97, -103, -126};
+        String str = "!®౩\uD83D\uDE42";
+
+        DataInputStream dataIn = new DataInputStream(new ByteArrayInputStream(bytes));
+        String resultStr = MarshallingSupport.readUTF8(dataIn);
+        assertEquals(str, resultStr);
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        DataOutput dataOut = new DataOutputStream(baos);
+        MarshallingSupport.writeUTF8(dataOut, str);
+        byte[] resultBytes = baos.toByteArray();
+        assertArrayEquals(bytes, resultBytes);
     }
 }

--- a/activemq-kahadb-store/src/main/java/org/apache/activemq/store/kahadb/disk/util/DataByteArrayInputStream.java
+++ b/activemq-kahadb-store/src/main/java/org/apache/activemq/store/kahadb/disk/util/DataByteArrayInputStream.java
@@ -290,8 +290,7 @@ public final class DataByteArrayInputStream extends InputStream implements DataI
         if (pos + length > buf.length) {
             throw new UTFDataFormatException("bad string");
         }
-        char chararr[] = new char[length];
-        String result = MarshallingSupport.convertUTF8WithBuf(buf, chararr, pos, length);
+        String result = MarshallingSupport.convertUTF8WithBuf(buf, pos, length);
         pos += length;
         return result;
     }

--- a/activemq-kahadb-store/src/main/java/org/apache/activemq/store/kahadb/disk/util/DataByteArrayOutputStream.java
+++ b/activemq-kahadb-store/src/main/java/org/apache/activemq/store/kahadb/disk/util/DataByteArrayOutputStream.java
@@ -237,7 +237,6 @@ public class DataByteArrayOutputStream extends OutputStream implements DataOutpu
         ensureEnoughBuffer((int)(pos + encodedsize + 2));
         writeShort((int)encodedsize);
 
-        byte[] buffer = new byte[(int)encodedsize];
         MarshallingSupport.writeUTFBytesToBuffer(text, (int) encodedsize, buf, pos);
         pos += encodedsize;
         onWrite();


### PR DESCRIPTION
Jira ticket: https://issues.apache.org/jira/browse/AMQ-8398

## Overview

The problem is actual for the cases when STOMP producer and JMS consumer OR TCP producer and STOMP consumer are in use. STOMP and TCP protocols treat 4-byte unicode characters differently. STOPM uses native Java logic (e.g. https://github.com/apache/activemq/blob/main/activemq-stomp/src/main/java/org/apache/activemq/transport/stomp/StompFrame.java#L79) whereas TCP uses custom logic. This PR adjusts the logic and adds support for 4-byte messages.

Basically here is a code snippet that demonstrates that current custom conversion logic is incorrect:
```
String str = "!®౩\uD83D\uDE42";
ByteArrayOutputStream baos = new ByteArrayOutputStream();
DataOutput dataOut = new DataOutputStream(baos);
MarshallingSupport.writeUTF8(dataOut, str);
byte[] resultBytes = baos.toByteArray();
System.out.println(Arrays.toString(resultBytes));
```

Here is the actual output: `[0, 0, 0, 12, 33, -62, -82, -32, -79, -87, -19, -96, -67, -19, -71, -126]` and the correct output: `[0, 0, 0, 10, 33, -62, -82, -32, -79, -87, -16, -97, -103, -126]`.

## Local Testing

### Publisher (Python STOMP)
```
import stomp
sync_conn = stomp.Connection(host_and_ports=[('localhost', 61613)], auto_content_length=False)
sync_conn.connect(username='admin', passcode='admin', wait=True)
sync_conn.send(body="🙃🙂", destination='test')
sync_conn.disconnect()
```

### Consumer before fix
```
./bin/activemq consumer --destination queue://test --messageCount 1                      
INFO: Loading '/Users/alekseizotov/opt/apache-activemq-5.16.3//bin/env'
INFO: Using java '/Users/alekseizotov/opt/jdk/current/Contents/Home/bin/java'
Extensions classpath:
  [/Users/alekseizotov/opt/apache-activemq-5.16.3/lib,/Users/alekseizotov/opt/apache-activemq-5.16.3/lib/camel,/Users/alekseizotov/opt/apache-activemq-5.16.3/lib/optional,/Users/alekseizotov/opt/apache-activemq-5.16.3/lib/web,/Users/alekseizotov/opt/apache-activemq-5.16.3/lib/extra]
ACTIVEMQ_HOME: /Users/alekseizotov/opt/apache-activemq-5.16.3
ACTIVEMQ_BASE: /Users/alekseizotov/opt/apache-activemq-5.16.3
ACTIVEMQ_CONF: /Users/alekseizotov/opt/apache-activemq-5.16.3/conf
ACTIVEMQ_DATA: /Users/alekseizotov/opt/apache-activemq-5.16.3/data
 INFO | Connecting to URL: failover://tcp://localhost:61616 as user: null
 INFO | Consuming queue://test
 INFO | Sleeping between receives 0 ms
 INFO | Running 1 parallel threads
 INFO | Successfully connected to tcp://localhost:61616
 INFO | consumer-1 wait until 1 messages are consumed
javax.jms.JMSException: java.io.UTFDataFormatException
  at org.apache.activemq.util.JMSExceptionSupport.create(JMSExceptionSupport.java:72)
  at org.apache.activemq.command.ActiveMQTextMessage.decodeContent(ActiveMQTextMessage.java:104)
  at org.apache.activemq.command.ActiveMQTextMessage.getText(ActiveMQTextMessage.java:84)
  at org.apache.activemq.util.ConsumerThread.run(ConsumerThread.java:64)
Caused by: java.io.UTFDataFormatException
  at org.apache.activemq.util.MarshallingSupport.convertUTF8WithBuf(MarshallingSupport.java:389)
  at org.apache.activemq.util.MarshallingSupport.readUTF8(MarshallingSupport.java:358)
  at org.apache.activemq.command.ActiveMQTextMessage.decodeContent(ActiveMQTextMessage.java:101)
  ... 2 more
 INFO | consumer-1 Consumed: 0 messages
 INFO | consumer-1 Consumer thread finished
```

### Consumer after fix
```
./bin/activemq consumer --destination queue://test --messageCount 1
INFO: Loading '/Users/alekseizotov/opt/apache-activemq-5.16.3//bin/env'
INFO: Using java '/Users/alekseizotov/opt/jdk/current/Contents/Home/bin/java'
Extensions classpath:
  [/Users/alekseizotov/opt/apache-activemq-5.16.3/lib,/Users/alekseizotov/opt/apache-activemq-5.16.3/lib/camel,/Users/alekseizotov/opt/apache-activemq-5.16.3/lib/optional,/Users/alekseizotov/opt/apache-activemq-5.16.3/lib/web,/Users/alekseizotov/opt/apache-activemq-5.16.3/lib/extra]
ACTIVEMQ_HOME: /Users/alekseizotov/opt/apache-activemq-5.16.3
ACTIVEMQ_BASE: /Users/alekseizotov/opt/apache-activemq-5.16.3
ACTIVEMQ_CONF: /Users/alekseizotov/opt/apache-activemq-5.16.3/conf
ACTIVEMQ_DATA: /Users/alekseizotov/opt/apache-activemq-5.16.3/data
 INFO | Connecting to URL: failover://tcp://localhost:61616 as user: null
 INFO | Consuming queue://test
 INFO | Sleeping between receives 0 ms
 INFO | Running 1 parallel threads
 INFO | Successfully connected to tcp://localhost:61616
 INFO | consumer-1 wait until 1 messages are consumed
 INFO | consumer-1 Received 🙃🙂
 INFO | consumer-1 Consumed: 1 messages
 INFO | consumer-1 Consumer thread finished
```
