### PR TITLE
AMQ-9552: Add metric lastMessageTimestamp to StatisticsBroker based o…

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/plugin/StatisticsBroker.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/plugin/StatisticsBroker.java
@@ -160,6 +160,9 @@ public class StatisticsBroker extends BrokerFilter {
                                 tempFirstMessage.clear();
                             }
                         }
+                        // NOTICE: Client-side, you may get the broker "now" Timestamp by msg.getJMSTimestamp()
+                        // This allows for calculating inactivity.
+                        statsMessage.setLong("lastMessageTimestamp", stats.getEnqueues().getLastSampleTime());
                         statsMessage.setJMSCorrelationID(messageSend.getCorrelationId());
                         sendStats(producerExchange.getConnectionContext(), statsMessage, replyTo);
                     }

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/plugin/BrokerStatisticsPluginTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/plugin/BrokerStatisticsPluginTest.java
@@ -218,6 +218,7 @@ public class BrokerStatisticsPluginTest extends TestCase{
         assertEquals(1, reply.getLong("size"));
         assertTrue(reply.getJMSTimestamp() > 0);
         assertTrue(reply.getLong("firstMessageTimestamp") > 0);
+        assertTrue(reply.getLong("lastMessageTimestamp") >= msg.getJMSTimestamp());
         // Assert that we got the brokerInTime for the first message in queue as value of key "firstMessageTimestamp"
         assertTrue(System.currentTimeMillis() >= reply.getLong("firstMessageTimestamp"));
         assertEquals(Message.DEFAULT_PRIORITY, reply.getJMSPriority());


### PR DESCRIPTION
Add metric lastMessageTimestamp to StatisticsBroker based on modification time of metric enqueues:


```
// NOTICE: Client-side, you may get the broker "now" Timestamp by msg.getJMSTimestamp()
// This allows for calculating inactivity.
statsMessage.setLong("lastMessageTimestamp", stats.getEnqueues().getLastSampleTime()); 

```
