### PR TITLE
 [AMQ-9545] Set cache-control to no-store by default for stronger security

### DIFF
--- a/assembly/src/release/conf/jetty.xml
+++ b/assembly/src/release/conf/jetty.xml
@@ -74,6 +74,11 @@
                   <property name="name" value="X-Content-Type-Options"/>
                   <property name="value" value="nosniff"/>
                 </bean>
+                <bean id="header" class="org.eclipse.jetty.rewrite.handler.HeaderPatternRule">
+                    <property name="pattern" value="*"/>
+                    <property name="name" value="Cache-Control"/>
+                    <property name="value" value="no-store"/>
+                </bean>
             </list>
         </property>
     </bean>


### PR DESCRIPTION
Unspecified Cache-Control HTTP header is vulnerable. Set it to no-store to avoid caching sensitive data for stronger security. It should be the default unless users override it.

Reference: https://www.virtuesecurity.com/kb/cache-controls-explained/

> Note: this PR was approved at https://github.com/apache/activemq/pull/1238 However, the branch history for that PR was messed up due to wrong operation with git. I closed that one and opened a new one (this one). Please approve again, thank you so much.
