### PR TITLE
Remove JDK_JAVA_OPTIONS usage in wrapper.conf. Moved to wrapper.java.additional.x options

### DIFF
--- a/assembly/src/release/bin/linux-x86-64/wrapper.conf
+++ b/assembly/src/release/bin/linux-x86-64/wrapper.conf
@@ -25,9 +25,6 @@ set.default.ACTIVEMQ_BASE=../..
 set.default.ACTIVEMQ_CONF=%ACTIVEMQ_BASE%/conf
 set.default.ACTIVEMQ_DATA=%ACTIVEMQ_BASE%/data
 
-# JDK 9+ modules
-set.JDK_JAVA_OPTIONS=--add-reads=java.xml=java.logging --add-opens java.base/java.security=ALL-UNNAMED --add-opens java.base/java.net=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.naming/javax.naming.spi=ALL-UNNAMED --add-opens java.rmi/sun.rmi.transport.tcp=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-exports=java.base/sun.net.www.protocol.http=ALL-UNNAMED --add-exports=java.base/sun.net.www.protocol.https=ALL-UNNAMED --add-exports=java.base/sun.net.www.protocol.jar=ALL-UNNAMED --add-exports=jdk.xml.dom/org.w3c.dom.html=ALL-UNNAMED --add-exports=jdk.naming.rmi/com.sun.jndi.url.rmi=ALL-UNNAMED
-
 wrapper.working.dir=.
 
 # Java Application
@@ -62,6 +59,23 @@ wrapper.java.additional.10=-Dactivemq.conf=%ACTIVEMQ_CONF%
 wrapper.java.additional.11=-Dactivemq.data=%ACTIVEMQ_DATA%
 wrapper.java.additional.12=-Djava.security.auth.login.config=%ACTIVEMQ_CONF%/login.config
 wrapper.java.additional.13=-Djolokia.conf=file:%ACTIVEMQ_CONF%/jolokia-access.xml
+
+## ------------------------------------------------------------------
+## Java Platform Module System (JPMS) - Java 9+.
+## ------------------------------------------------------------------
+wrapper.java.additional.20=--add-reads=java.xml=java.logging
+wrapper.java.additional.21=--add-opens=java.base/java.security=ALL-UNNAMED
+wrapper.java.additional.22=--add-opens=java.base/java.net=ALL-UNNAMED
+wrapper.java.additional.23=--add-opens=java.base/java.lang=ALL-UNNAMED
+wrapper.java.additional.25=--add-opens=java.base/java.util=ALL-UNNAMED
+wrapper.java.additional.26=--add-opens=java.naming/javax.naming.spi=ALL-UNNAMED
+wrapper.java.additional.27=--add-opens=java.rmi/sun.rmi.transport.tcp=ALL-UNNAMED
+wrapper.java.additional.28=--add-opens=java.base/sun.nio.ch=ALL-UNNAMED
+wrapper.java.additional.29=--add-exports=java.base/sun.net.www.protocol.http=ALL-UNNAMED
+wrapper.java.additional.30=--add-exports=java.base/sun.net.www.protocol.https=ALL-UNNAMED
+wrapper.java.additional.31=--add-exports=java.base/sun.net.www.protocol.jar=ALL-UNNAMED
+wrapper.java.additional.32=--add-exports=jdk.xml.dom/org.w3c.dom.html=ALL-UNNAMED
+wrapper.java.additional.33=--add-exports=jdk.naming.rmi/com.sun.jndi.url.rmi=ALL-UNNAMED
 
 # Uncomment to enable jmx
 #wrapper.java.additional.n=-Dcom.sun.management.jmxremote.port=1616

--- a/assembly/src/release/bin/macosx/wrapper.conf
+++ b/assembly/src/release/bin/macosx/wrapper.conf
@@ -25,9 +25,6 @@ set.default.ACTIVEMQ_BASE=../..
 set.default.ACTIVEMQ_CONF=%ACTIVEMQ_BASE%/conf
 set.default.ACTIVEMQ_DATA=%ACTIVEMQ_BASE%/data
 
-# JDK 9+ modules
-set.JDK_JAVA_OPTIONS=--add-reads=java.xml=java.logging --add-opens java.base/java.security=ALL-UNNAMED --add-opens java.base/java.net=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.naming/javax.naming.spi=ALL-UNNAMED --add-opens java.rmi/sun.rmi.transport.tcp=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-exports=java.base/sun.net.www.protocol.http=ALL-UNNAMED --add-exports=java.base/sun.net.www.protocol.https=ALL-UNNAMED --add-exports=java.base/sun.net.www.protocol.jar=ALL-UNNAMED --add-exports=jdk.xml.dom/org.w3c.dom.html=ALL-UNNAMED --add-exports=jdk.naming.rmi/com.sun.jndi.url.rmi=ALL-UNNAMED
-
 wrapper.working.dir=.
 
 # Java Application
@@ -62,6 +59,23 @@ wrapper.java.additional.10=-Dactivemq.conf=%ACTIVEMQ_CONF%
 wrapper.java.additional.11=-Dactivemq.data=%ACTIVEMQ_DATA%
 wrapper.java.additional.12=-Djava.security.auth.login.config=%ACTIVEMQ_CONF%/login.config
 wrapper.java.additional.13=-Djolokia.conf=file:%ACTIVEMQ_CONF%/jolokia-access.xml
+
+## ------------------------------------------------------------------
+## Java Platform Module System (JPMS) - Java 9+.
+## ------------------------------------------------------------------
+wrapper.java.additional.20=--add-reads=java.xml=java.logging
+wrapper.java.additional.21=--add-opens=java.base/java.security=ALL-UNNAMED
+wrapper.java.additional.22=--add-opens=java.base/java.net=ALL-UNNAMED
+wrapper.java.additional.23=--add-opens=java.base/java.lang=ALL-UNNAMED
+wrapper.java.additional.25=--add-opens=java.base/java.util=ALL-UNNAMED
+wrapper.java.additional.26=--add-opens=java.naming/javax.naming.spi=ALL-UNNAMED
+wrapper.java.additional.27=--add-opens=java.rmi/sun.rmi.transport.tcp=ALL-UNNAMED
+wrapper.java.additional.28=--add-opens=java.base/sun.nio.ch=ALL-UNNAMED
+wrapper.java.additional.29=--add-exports=java.base/sun.net.www.protocol.http=ALL-UNNAMED
+wrapper.java.additional.30=--add-exports=java.base/sun.net.www.protocol.https=ALL-UNNAMED
+wrapper.java.additional.31=--add-exports=java.base/sun.net.www.protocol.jar=ALL-UNNAMED
+wrapper.java.additional.32=--add-exports=jdk.xml.dom/org.w3c.dom.html=ALL-UNNAMED
+wrapper.java.additional.33=--add-exports=jdk.naming.rmi/com.sun.jndi.url.rmi=ALL-UNNAMED
 
 # Uncomment to enable jmx
 #wrapper.java.additional.n=-Dcom.sun.management.jmxremote.port=1616

--- a/assembly/src/release/bin/win64/wrapper.conf
+++ b/assembly/src/release/bin/win64/wrapper.conf
@@ -26,9 +26,6 @@ set.default.ACTIVEMQ_CONF=%ACTIVEMQ_BASE%/conf
 set.default.ACTIVEMQ_DATA=%ACTIVEMQ_BASE%/data
 set.default.JOLOKIA_CONF=file:..\\..\\conf\\jolokia-access.xml
 
-# JDK 9+ modules
-set.JDK_JAVA_OPTIONS=--add-reads=java.xml=java.logging --add-opens java.base/java.security=ALL-UNNAMED --add-opens java.base/java.net=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.util.concurrent=ALL-UNNAMED --add-opens java.base/java.util.concurrent.atomic=ALL-UNNAMED --add-opens java.naming/javax.naming.spi=ALL-UNNAMED --add-opens java.rmi/sun.rmi.transport.tcp=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-exports=java.base/sun.net.www.protocol.http=ALL-UNNAMED --add-exports=java.base/sun.net.www.protocol.https=ALL-UNNAMED --add-exports=java.base/sun.net.www.protocol.jar=ALL-UNNAMED --add-exports=jdk.xml.dom/org.w3c.dom.html=ALL-UNNAMED --add-exports=jdk.naming.rmi/com.sun.jndi.url.rmi=ALL-UNNAMED
-
 wrapper.working.dir=.
 
 # Java Application
@@ -63,6 +60,23 @@ wrapper.java.additional.10=-Dactivemq.conf="%ACTIVEMQ_CONF%"
 wrapper.java.additional.11=-Dactivemq.data="%ACTIVEMQ_DATA%"
 wrapper.java.additional.12=-Djava.security.auth.login.config="%ACTIVEMQ_CONF%/login.config"
 wrapper.java.additional.13=-Djolokia.conf="%JOLOKIA_CONF%"
+
+## ------------------------------------------------------------------
+## Java Platform Module System (JPMS) - Java 9+.
+## ------------------------------------------------------------------
+wrapper.java.additional.20=--add-reads=java.xml=java.logging
+wrapper.java.additional.21=--add-opens=java.base/java.security=ALL-UNNAMED
+wrapper.java.additional.22=--add-opens=java.base/java.net=ALL-UNNAMED
+wrapper.java.additional.23=--add-opens=java.base/java.lang=ALL-UNNAMED
+wrapper.java.additional.25=--add-opens=java.base/java.util=ALL-UNNAMED
+wrapper.java.additional.26=--add-opens=java.naming/javax.naming.spi=ALL-UNNAMED
+wrapper.java.additional.27=--add-opens=java.rmi/sun.rmi.transport.tcp=ALL-UNNAMED
+wrapper.java.additional.28=--add-opens=java.base/sun.nio.ch=ALL-UNNAMED
+wrapper.java.additional.29=--add-exports=java.base/sun.net.www.protocol.http=ALL-UNNAMED
+wrapper.java.additional.30=--add-exports=java.base/sun.net.www.protocol.https=ALL-UNNAMED
+wrapper.java.additional.31=--add-exports=java.base/sun.net.www.protocol.jar=ALL-UNNAMED
+wrapper.java.additional.32=--add-exports=jdk.xml.dom/org.w3c.dom.html=ALL-UNNAMED
+wrapper.java.additional.33=--add-exports=jdk.naming.rmi/com.sun.jndi.url.rmi=ALL-UNNAMED
 
 # Uncomment to enable remote jmx
 #wrapper.java.additional.n=-Dcom.sun.management.jmxremote.port=1616


### PR DESCRIPTION
All wrapper.conf files use `JDK_JAVA_OPTIONS` env variable to configure the Java Platform Module System (JPMS). Use the `wrapper.java.additional.x` instead.