### PR TITLE
AMQ-8398 - Add missing super.tearDown() call to Stomp NIOSSLLargeMessageTest

### DIFF
--- a/activemq-stomp/src/test/java/org/apache/activemq/transport/stomp/StompNIOSSLLargeMessageTest.java
+++ b/activemq-stomp/src/test/java/org/apache/activemq/transport/stomp/StompNIOSSLLargeMessageTest.java
@@ -103,6 +103,7 @@ public class StompNIOSSLLargeMessageTest extends StompTestSupport {
 
     @Override
     public void tearDown() throws Exception {
+        super.tearDown();
         // unregister Log4J appender
         org.apache.logging.log4j.core.Logger rootLogger = (org.apache.logging.log4j.core.Logger) org.apache.logging.log4j.LogManager.getRootLogger();
         rootLogger.removeAppender(appender);


### PR DESCRIPTION
CI build started failing after https://github.com/apache/activemq/pull/1290 had been merged:
* this PR - https://ci-builds.apache.org/job/ActiveMQ/job/ActiveMQ/job/PR-1290/2/cloudbees-pipeline-explorer/#line-12002
* 5.18.x - https://ci-builds.apache.org/job/ActiveMQ/job/ActiveMQ/job/activemq-5.18.x/141/cloudbees-pipeline-explorer/#line-12166
* 6.11.x - https://ci-builds.apache.org/job/ActiveMQ/job/ActiveMQ/job/activemq-6.1.x/14/cloudbees-pipeline-explorer/#line-11963
* main - https://ci-builds.apache.org/job/ActiveMQ/job/ActiveMQ/job/main/482/cloudbees-pipeline-explorer/#line-11996

However, after some local troubleshooting, I believe the problem is not particularly related to those changes. The root cause seems to be related to a missing tear down logic in one of tests.