### PR TITLE
Change interface JobScheduler remove signatures to provide control me…

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/broker/jmx/JobSchedulerView.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/jmx/JobSchedulerView.java
@@ -153,25 +153,25 @@ public class JobSchedulerView implements JobSchedulerViewMBean {
 
     @Override
     public void removeAllJobs() throws Exception {
-        this.jobScheduler.removeAllJobs();
+        this.jobScheduler.removeAllJobs(null);
     }
 
     @Override
     public void removeAllJobs(String startTime, String finishTime) throws Exception {
         long start = JobSupport.getDataTime(startTime);
         long finish = JobSupport.getDataTime(finishTime);
-        this.jobScheduler.removeAllJobs(start, finish);
+        this.jobScheduler.removeAllJobs(start, finish, null);
     }
 
     @Override
     public void removeAllJobsAtScheduledTime(String time) throws Exception {
         long removeAtTime = JobSupport.getDataTime(time);
-        this.jobScheduler.remove(removeAtTime);
+        this.jobScheduler.remove(removeAtTime, null);
     }
 
     @Override
     public void removeJob(String jobId) throws Exception {
-        this.jobScheduler.remove(jobId);
+        this.jobScheduler.remove(jobId, null);
     }
 
     @Override

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/scheduler/JobScheduler.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/scheduler/JobScheduler.java
@@ -18,6 +18,7 @@ package org.apache.activemq.broker.scheduler;
 
 import java.util.List;
 
+import org.apache.activemq.command.Message;
 import org.apache.activemq.util.ByteSequence;
 
 public interface JobScheduler {
@@ -118,27 +119,34 @@ public interface JobScheduler {
      *
      * @param time
      *      The UTC time to use to remove a batch of scheduled Jobs.
+     * @param message
+     *      The message from management queue, that triggered the removal action
      *
      * @throws Exception
      */
-    void remove(long time) throws Exception;
+    void remove(long time, Message message) throws Exception;
 
     /**
      * remove a job with the matching jobId
      *
      * @param jobId
      *      The unique Job Id to search for and remove from the scheduled set of jobs.
+     * @param message
+     *      The message from management queue, that triggered the removal action
      *
      * @throws Exception if an error occurs while removing the Job.
      */
-    void remove(String jobId) throws Exception;
+    void remove(String jobId, Message message) throws Exception;
 
     /**
      * remove all the Jobs from the scheduler
      *
+     * @param message
+     *      The message from management queue, that triggered the removal action
+     *
      * @throws Exception
      */
-    void removeAllJobs() throws Exception;
+    void removeAllJobs(Message message) throws Exception;
 
     /**
      * remove all the Jobs from the scheduler that are due between the start and finish times
@@ -147,9 +155,11 @@ public interface JobScheduler {
      *            time in milliseconds
      * @param finish
      *            time in milliseconds
+     * @param message
+     *      The message from management queue, that triggered the removal action
      * @throws Exception
      */
-    void removeAllJobs(long start, long finish) throws Exception;
+    void removeAllJobs(long start, long finish, Message message) throws Exception;
 
     /**
      * Get the next time jobs will be fired

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/scheduler/JobSchedulerFacade.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/scheduler/JobSchedulerFacade.java
@@ -19,6 +19,7 @@ package org.apache.activemq.broker.scheduler;
 import java.util.Collections;
 import java.util.List;
 
+import org.apache.activemq.command.Message;
 import org.apache.activemq.util.ByteSequence;
 
 /**
@@ -89,34 +90,34 @@ public class JobSchedulerFacade implements JobScheduler {
     }
 
     @Override
-    public void remove(long time) throws Exception {
+    public void remove(long time, Message message) throws Exception {
         JobScheduler js = this.broker.getInternalScheduler();
         if (js != null) {
-            js.remove(time);
+            js.remove(time, message);
         }
     }
 
     @Override
-    public void remove(String jobId) throws Exception {
+    public void remove(String jobId, Message message) throws Exception {
         JobScheduler js = this.broker.getInternalScheduler();
         if (js != null) {
-            js.remove(jobId);
+            js.remove(jobId, message);
         }
     }
 
     @Override
-    public void removeAllJobs() throws Exception {
+    public void removeAllJobs(Message message) throws Exception {
         JobScheduler js = this.broker.getInternalScheduler();
         if (js != null) {
-            js.removeAllJobs();
+            js.removeAllJobs(message);
         }
     }
 
     @Override
-    public void removeAllJobs(long start, long finish) throws Exception {
+    public void removeAllJobs(long start, long finish, Message message) throws Exception {
         JobScheduler js = this.broker.getInternalScheduler();
         if (js != null) {
-            js.removeAllJobs(start, finish);
+            js.removeAllJobs(start, finish, message);
         }
     }
 

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/scheduler/SchedulerBroker.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/scheduler/SchedulerBroker.java
@@ -272,7 +272,7 @@ public class SchedulerBroker extends BrokerFilter implements JobListener {
                     }
                 }
                 if (jobId != null && action.equals(ScheduledMessage.AMQ_SCHEDULER_ACTION_REMOVE)) {
-                    scheduler.remove(jobId);
+                    scheduler.remove(jobId, messageSend);
                 } else if (action.equals(ScheduledMessage.AMQ_SCHEDULER_ACTION_REMOVEALL)) {
 
                     if (startTime != null && endTime != null) {
@@ -280,9 +280,9 @@ public class SchedulerBroker extends BrokerFilter implements JobListener {
                         long start = (Long) TypeConversionSupport.convert(startTime, Long.class);
                         long finish = (Long) TypeConversionSupport.convert(endTime, Long.class);
 
-                        scheduler.removeAllJobs(start, finish);
+                        scheduler.removeAllJobs(start, finish, messageSend);
                     } else {
-                        scheduler.removeAllJobs();
+                        scheduler.removeAllJobs(messageSend);
                     }
                 }
             }

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/scheduler/memory/InMemoryJobScheduler.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/scheduler/memory/InMemoryJobScheduler.java
@@ -129,22 +129,22 @@ public class InMemoryJobScheduler implements JobScheduler {
     }
 
     @Override
-    public void remove(long time) throws Exception {
+    public void remove(long time, Message message) throws Exception {
         doRemoveRange(time, time);
     }
 
     @Override
-    public void remove(String jobId) throws Exception {
+    public void remove(String jobId, Message message) throws Exception {
         doRemoveJob(jobId);
     }
 
     @Override
-    public void removeAllJobs() throws Exception {
+    public void removeAllJobs(Message message) throws Exception {
         doRemoveRange(0, Long.MAX_VALUE);
     }
 
     @Override
-    public void removeAllJobs(long start, long finish) throws Exception {
+    public void removeAllJobs(long start, long finish, Message message) throws Exception {
         doRemoveRange(start, finish);
     }
 


### PR DESCRIPTION
Use case:

When messages are deleted from the scheduler we need original message attributes, like `user`, `timestamp` etc.
So the resulting message can have an acting `user`, who cancels the schedule, and an old `user` who scheduled the message

The only way to access old messages is to change the signature of a JobScheduler, which is called from `SchedulerBroker.send(ProducerBrokerExchange producerExchange, final Message messageSend)` method

