### PR TITLE
[AMQ-9591] Fix file not exist error when running jetty demo in 6.1.3

### DIFF
--- a/activemq-all/pom.xml
+++ b/activemq-all/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>org.apache.activemq</groupId>
     <artifactId>activemq-parent</artifactId>
-    <version>6.1.3-SNAPSHOT</version>
+    <version>6.1.3</version>
   </parent>
 
   <artifactId>activemq-all</artifactId>

--- a/activemq-amqp/pom.xml
+++ b/activemq-amqp/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.activemq</groupId>
     <artifactId>activemq-parent</artifactId>
-    <version>6.1.3-SNAPSHOT</version>
+    <version>6.1.3</version>
   </parent>
 
   <artifactId>activemq-amqp</artifactId>

--- a/activemq-blueprint/pom.xml
+++ b/activemq-blueprint/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.activemq</groupId>
     <artifactId>activemq-parent</artifactId>
-    <version>6.1.3-SNAPSHOT</version>
+    <version>6.1.3</version>
   </parent>
 
   <artifactId>activemq-blueprint</artifactId>

--- a/activemq-broker/pom.xml
+++ b/activemq-broker/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.activemq</groupId>
     <artifactId>activemq-parent</artifactId>
-    <version>6.1.3-SNAPSHOT</version>
+    <version>6.1.3</version>
   </parent>
 
   <artifactId>activemq-broker</artifactId>

--- a/activemq-cf/pom.xml
+++ b/activemq-cf/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.activemq</groupId>
     <artifactId>activemq-parent</artifactId>
-    <version>6.1.3-SNAPSHOT</version>
+    <version>6.1.3</version>
   </parent>
 
   <artifactId>activemq-cf</artifactId>

--- a/activemq-client/pom.xml
+++ b/activemq-client/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.activemq</groupId>
     <artifactId>activemq-parent</artifactId>
-    <version>6.1.3-SNAPSHOT</version>
+    <version>6.1.3</version>
   </parent>
 
   <artifactId>activemq-client</artifactId>

--- a/activemq-console/pom.xml
+++ b/activemq-console/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.activemq</groupId>
     <artifactId>activemq-parent</artifactId>
-    <version>6.1.3-SNAPSHOT</version>
+    <version>6.1.3</version>
   </parent>
 
   <artifactId>activemq-console</artifactId>

--- a/activemq-console/src/main/java/org/apache/activemq/console/command/store/StoreExporter.java
+++ b/activemq-console/src/main/java/org/apache/activemq/console/command/store/StoreExporter.java
@@ -263,15 +263,15 @@ public class StoreExporter {
         return messageRecord;
     }
 
-    public File getFile() {
+    public File getFilehandle() {
         return file;
     }
 
     public void setFile(String file) {
-        setFile(new File(file));
+        setFilehandle(new File(file));
     }
 
-    public void setFile(File file) {
+    public void setFilehandle(File file) {
         this.file = file;
     }
 

--- a/activemq-http/pom.xml
+++ b/activemq-http/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.activemq</groupId>
     <artifactId>activemq-parent</artifactId>
-    <version>6.1.3-SNAPSHOT</version>
+    <version>6.1.3</version>
   </parent>
 
   <artifactId>activemq-http</artifactId>

--- a/activemq-jaas/pom.xml
+++ b/activemq-jaas/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.activemq</groupId>
     <artifactId>activemq-parent</artifactId>
-    <version>6.1.3-SNAPSHOT</version>
+    <version>6.1.3</version>
   </parent>
 
   <artifactId>activemq-jaas</artifactId>

--- a/activemq-jdbc-store/pom.xml
+++ b/activemq-jdbc-store/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.activemq</groupId>
     <artifactId>activemq-parent</artifactId>
-    <version>6.1.3-SNAPSHOT</version>
+    <version>6.1.3</version>
   </parent>
 
   <artifactId>activemq-jdbc-store</artifactId>

--- a/activemq-jms-pool/pom.xml
+++ b/activemq-jms-pool/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.activemq</groupId>
     <artifactId>activemq-parent</artifactId>
-    <version>6.1.3-SNAPSHOT</version>
+    <version>6.1.3</version>
   </parent>
 
   <artifactId>activemq-jms-pool</artifactId>

--- a/activemq-kahadb-store/pom.xml
+++ b/activemq-kahadb-store/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.activemq</groupId>
     <artifactId>activemq-parent</artifactId>
-    <version>6.1.3-SNAPSHOT</version>
+    <version>6.1.3</version>
   </parent>
 
   <artifactId>activemq-kahadb-store</artifactId>

--- a/activemq-karaf-itest/pom.xml
+++ b/activemq-karaf-itest/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.activemq</groupId>
     <artifactId>activemq-parent</artifactId>
-    <version>6.1.3-SNAPSHOT</version>
+    <version>6.1.3</version>
   </parent>
 
   <artifactId>activemq-karaf-itest</artifactId>

--- a/activemq-karaf/pom.xml
+++ b/activemq-karaf/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.activemq</groupId>
     <artifactId>activemq-parent</artifactId>
-    <version>6.1.3-SNAPSHOT</version>
+    <version>6.1.3</version>
   </parent>
 
   <artifactId>activemq-karaf</artifactId>

--- a/activemq-log4j-appender/pom.xml
+++ b/activemq-log4j-appender/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.activemq</groupId>
     <artifactId>activemq-parent</artifactId>
-    <version>6.1.3-SNAPSHOT</version>
+    <version>6.1.3</version>
   </parent>
 
   <artifactId>activemq-log4j-appender</artifactId>

--- a/activemq-mqtt/pom.xml
+++ b/activemq-mqtt/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.activemq</groupId>
     <artifactId>activemq-parent</artifactId>
-    <version>6.1.3-SNAPSHOT</version>
+    <version>6.1.3</version>
   </parent>
 
   <artifactId>activemq-mqtt</artifactId>

--- a/activemq-openwire-generator/pom.xml
+++ b/activemq-openwire-generator/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.activemq</groupId>
     <artifactId>activemq-parent</artifactId>
-    <version>6.1.3-SNAPSHOT</version>
+    <version>6.1.3</version>
   </parent>
 
   <artifactId>activemq-openwire-generator</artifactId>

--- a/activemq-openwire-legacy/pom.xml
+++ b/activemq-openwire-legacy/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.activemq</groupId>
     <artifactId>activemq-parent</artifactId>
-    <version>6.1.3-SNAPSHOT</version>
+    <version>6.1.3</version>
   </parent>
 
   <artifactId>activemq-openwire-legacy</artifactId>

--- a/activemq-osgi/pom.xml
+++ b/activemq-osgi/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.activemq</groupId>
     <artifactId>activemq-parent</artifactId>
-    <version>6.1.3-SNAPSHOT</version>
+    <version>6.1.3</version>
   </parent>
 
   <artifactId>activemq-osgi</artifactId>

--- a/activemq-osgi/src/main/resources/META-INF/spring.schemas
+++ b/activemq-osgi/src/main/resources/META-INF/spring.schemas
@@ -88,6 +88,7 @@ http\://activemq.apache.org/schema/core/activemq-core-6.0.1.xsd=activemq.xsd
 http\://activemq.apache.org/schema/core/activemq-core-6.1.0.xsd=activemq.xsd
 http\://activemq.apache.org/schema/core/activemq-core-6.1.1.xsd=activemq.xsd
 http\://activemq.apache.org/schema/core/activemq-core-6.1.2.xsd=activemq.xsd
+http\://activemq.apache.org/schema/core/activemq-core-6.1.3.xsd=activemq.xsd
 
 http\://camel.apache.org/schema/spring/camel-spring.xsd=camel-spring.xsd
 

--- a/activemq-pool/pom.xml
+++ b/activemq-pool/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.activemq</groupId>
     <artifactId>activemq-parent</artifactId>
-    <version>6.1.3-SNAPSHOT</version>
+    <version>6.1.3</version>
   </parent>
 
   <artifactId>activemq-pool</artifactId>

--- a/activemq-ra/pom.xml
+++ b/activemq-ra/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.activemq</groupId>
     <artifactId>activemq-parent</artifactId>
-    <version>6.1.3-SNAPSHOT</version>
+    <version>6.1.3</version>
   </parent>
 
   <artifactId>activemq-ra</artifactId>

--- a/activemq-rar/pom.xml
+++ b/activemq-rar/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.activemq</groupId>
     <artifactId>activemq-parent</artifactId>
-    <version>6.1.3-SNAPSHOT</version>
+    <version>6.1.3</version>
   </parent>
 
   <artifactId>activemq-rar</artifactId>

--- a/activemq-run/pom.xml
+++ b/activemq-run/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.activemq</groupId>
     <artifactId>activemq-parent</artifactId>
-    <version>6.1.3-SNAPSHOT</version>
+    <version>6.1.3</version>
   </parent>
 
   <artifactId>activemq-run</artifactId>

--- a/activemq-runtime-config/pom.xml
+++ b/activemq-runtime-config/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.activemq</groupId>
     <artifactId>activemq-parent</artifactId>
-    <version>6.1.3-SNAPSHOT</version>
+    <version>6.1.3</version>
   </parent>
 
   <artifactId>activemq-runtime-config</artifactId>

--- a/activemq-shiro/pom.xml
+++ b/activemq-shiro/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.activemq</groupId>
         <artifactId>activemq-parent</artifactId>
-        <version>6.1.3-SNAPSHOT</version>
+        <version>6.1.3</version>
     </parent>
 
     <artifactId>activemq-shiro</artifactId>

--- a/activemq-spring/pom.xml
+++ b/activemq-spring/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.activemq</groupId>
     <artifactId>activemq-parent</artifactId>
-    <version>6.1.3-SNAPSHOT</version>
+    <version>6.1.3</version>
   </parent>
 
   <artifactId>activemq-spring</artifactId>

--- a/activemq-spring/src/main/resources/META-INF/spring.schemas
+++ b/activemq-spring/src/main/resources/META-INF/spring.schemas
@@ -89,6 +89,7 @@ http\://activemq.apache.org/schema/core/activemq-core-6.0.1.xsd=activemq.xsd
 http\://activemq.apache.org/schema/core/activemq-core-6.1.0.xsd=activemq.xsd
 http\://activemq.apache.org/schema/core/activemq-core-6.1.1.xsd=activemq.xsd
 http\://activemq.apache.org/schema/core/activemq-core-6.1.2.xsd=activemq.xsd
+http\://activemq.apache.org/schema/core/activemq-core-6.1.3.xsd=activemq.xsd
 
 http\://camel.apache.org/schema/osgi/camel-osgi.xsd=camel-osgi.xsd
 http\://camel.apache.org/schema/spring/camel-spring.xsd=camel-spring.xsd

--- a/activemq-stomp/pom.xml
+++ b/activemq-stomp/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.activemq</groupId>
     <artifactId>activemq-parent</artifactId>
-    <version>6.1.3-SNAPSHOT</version>
+    <version>6.1.3</version>
   </parent>
 
   <artifactId>activemq-stomp</artifactId>

--- a/activemq-tooling/activemq-joram-jms-tests/pom.xml
+++ b/activemq-tooling/activemq-joram-jms-tests/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.activemq.tooling</groupId>
     <artifactId>activemq-tooling</artifactId>
-    <version>6.1.3-SNAPSHOT</version>
+    <version>6.1.3</version>
   </parent>
 
   <artifactId>activemq-joram-jms-tests</artifactId>

--- a/activemq-tooling/activemq-junit/pom.xml
+++ b/activemq-tooling/activemq-junit/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.activemq.tooling</groupId>
     <artifactId>activemq-tooling</artifactId>
-    <version>6.1.3-SNAPSHOT</version>
+    <version>6.1.3</version>
   </parent>
 
   <artifactId>activemq-junit</artifactId>

--- a/activemq-tooling/activemq-maven-plugin/pom.xml
+++ b/activemq-tooling/activemq-maven-plugin/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.activemq.tooling</groupId>
     <artifactId>activemq-tooling</artifactId>
-    <version>6.1.3-SNAPSHOT</version>
+    <version>6.1.3</version>
   </parent>
 
   <artifactId>activemq-maven-plugin</artifactId>

--- a/activemq-tooling/activemq-memtest-maven-plugin/pom.xml
+++ b/activemq-tooling/activemq-memtest-maven-plugin/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.activemq.tooling</groupId>
     <artifactId>activemq-tooling</artifactId>
-    <version>6.1.3-SNAPSHOT</version>
+    <version>6.1.3</version>
   </parent>
 
   <artifactId>activemq-memtest-maven-plugin</artifactId>

--- a/activemq-tooling/activemq-perf-maven-plugin/pom.xml
+++ b/activemq-tooling/activemq-perf-maven-plugin/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.activemq.tooling</groupId>
     <artifactId>activemq-tooling</artifactId>
-    <version>6.1.3-SNAPSHOT</version>
+    <version>6.1.3</version>
   </parent>
 
   <artifactId>activemq-perf-maven-plugin</artifactId>

--- a/activemq-tooling/pom.xml
+++ b/activemq-tooling/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.activemq</groupId>
     <artifactId>activemq-parent</artifactId>
-    <version>6.1.3-SNAPSHOT</version>
+    <version>6.1.3</version>
   </parent>
 
   <groupId>org.apache.activemq.tooling</groupId>

--- a/activemq-unit-tests/pom.xml
+++ b/activemq-unit-tests/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.activemq</groupId>
     <artifactId>activemq-parent</artifactId>
-    <version>6.1.3-SNAPSHOT</version>
+    <version>6.1.3</version>
   </parent>
 
   <artifactId>activemq-unit-tests</artifactId>

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/bugs/MultiKahaDBMultipleFilteredAdapterTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/bugs/MultiKahaDBMultipleFilteredAdapterTest.java
@@ -1,3 +1,19 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.activemq.bugs;
 
 import static org.junit.Assert.assertEquals;

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/bugs/MultiKahaDBMultipleFilteredAdapterTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/bugs/MultiKahaDBMultipleFilteredAdapterTest.java
@@ -1,0 +1,157 @@
+package org.apache.activemq.bugs;
+
+import static org.junit.Assert.assertEquals;
+
+import jakarta.jms.Connection;
+import jakarta.jms.DeliveryMode;
+import jakarta.jms.MessageProducer;
+import jakarta.jms.Session;
+import jakarta.jms.TextMessage;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.activemq.ActiveMQConnectionFactory;
+import org.apache.activemq.broker.BrokerService;
+import org.apache.activemq.broker.TransportConnector;
+import org.apache.activemq.broker.region.Queue;
+import org.apache.activemq.command.ActiveMQQueue;
+import org.apache.activemq.store.PersistenceAdapter;
+import org.apache.activemq.store.kahadb.FilteredKahaDBPersistenceAdapter;
+import org.apache.activemq.store.kahadb.KahaDBPersistenceAdapter;
+import org.apache.activemq.store.kahadb.MultiKahaDBPersistenceAdapter;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class MultiKahaDBMultipleFilteredAdapterTest {
+
+    private final static int maxFileLength = 1024*1024*32;
+    private static final String QUEUE_NAME = "QUEUE.amqMultiKahadbMultiFilteredAdapter";
+    private static final String TOPIC_NAME = "TOPIC.amqMultiKahadbMultiFilteredAdapter";
+    private static final int MESSAGE_COUNT = 100;
+
+    private  BrokerService broker;
+    private ActiveMQConnectionFactory cf;
+
+    @Before
+    public void setUp() throws Exception {
+        prepareBrokerWithMultiStore(true);
+        TransportConnector connector = broker.addConnector("tcp://localhost:0");
+        broker.start();
+        broker.waitUntilStarted();
+        cf = new ActiveMQConnectionFactory("failover://(" + connector.getConnectUri() + ")");
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        broker.stop();
+    }
+
+    @Test
+    public void testTopicWildcardAndPerDestinationFilteredAdapter() throws Exception {
+        //create one topic and queue and send messages
+        sendMessages(false);
+        sendMessages(true);
+
+        //the adapters will persist the data, topic will be by wildcard filtered adapter
+        //and queue will be by per destionation adapter
+
+        //stop broker and restart, the bug is that on restart wildcard filtered adapter adds one KahaDBPersistenceAdapter
+        // when calling MultiKahaDBPersistenceAdapter.setFilteredPersistenceAdapters
+        //and on the call to doStart of MultiKahaDBPersistenceAdapter it uses per destination filtered adapter to add
+        //another KahaDBPersistenceAdapter and fails on jmx bean registration
+        // the fix is to make sure to check the persistent adapter already exists or not when we do per destination
+        // filtered adapter processing and only add if one does not exists already
+        var multiKaha = (MultiKahaDBPersistenceAdapter) broker.getPersistenceAdapter();
+        // Verify 2 adapters created and not 3
+        assertEquals(2, multiKaha.getAdapters().size());
+        Set<File> dirs = multiKaha.getAdapters().stream().map(adapter -> adapter.getDirectory()).collect(
+            Collectors.toSet());
+        broker.stop();
+        broker.waitUntilStopped();
+
+        //restart should succeed with fix
+        prepareBrokerWithMultiStore(false);
+        broker.start();
+        broker.waitUntilStarted();
+
+        // Verify 2 adapters created and not 3 and same dirs
+        multiKaha = (MultiKahaDBPersistenceAdapter) broker.getPersistenceAdapter();
+        assertEquals(2, multiKaha.getAdapters().size());
+        assertEquals(dirs, multiKaha.getAdapters().stream().map(adapter -> adapter.getDirectory()).collect(
+            Collectors.toSet()));
+    }
+
+    private void sendMessages(boolean isTopic) throws Exception {
+        Connection connection = cf.createConnection();
+        Session session = connection.createSession();
+        MessageProducer producer = isTopic ? session.createProducer(session
+                .createTopic(TOPIC_NAME)) : session.createProducer(session
+                .createQueue(QUEUE_NAME));
+
+        producer.setDeliveryMode(DeliveryMode.PERSISTENT);
+        for (int i = 0; i < MESSAGE_COUNT; i++) {
+            TextMessage message = session
+                    .createTextMessage("Test message " + i);
+            producer.send(message);
+        }
+
+        producer.close();
+        session.close();
+        connection.close();
+
+        if(!isTopic) {
+            assertQueueLength(MESSAGE_COUNT);
+        }
+    }
+
+    private void assertQueueLength(int len) throws Exception, IOException {
+        Set<org.apache.activemq.broker.region.Destination> destinations = broker.getBroker().getDestinations(
+                new ActiveMQQueue(QUEUE_NAME));
+        org.apache.activemq.broker.region.Queue queue = (Queue) destinations.iterator().next();
+        assertEquals(len, queue.getMessageStore().getMessageCount());
+    }
+
+    protected BrokerService createBroker(PersistenceAdapter kaha) throws Exception {
+        BrokerService broker = new BrokerService();
+        broker.setUseJmx(true);
+        broker.setBrokerName("localhost");
+        broker.setPersistenceAdapter(kaha);
+        return broker;
+    }
+
+    protected KahaDBPersistenceAdapter createStore(boolean delete) throws IOException {
+        KahaDBPersistenceAdapter kaha = new KahaDBPersistenceAdapter();
+        kaha.setJournalMaxFileLength(maxFileLength);
+        kaha.setCleanupInterval(5000);
+        if (delete) {
+            kaha.deleteAllMessages();
+        }
+        return kaha;
+    }
+
+    public void prepareBrokerWithMultiStore(boolean deleteAllMessages) throws Exception {
+        MultiKahaDBPersistenceAdapter multiKahaDBPersistenceAdapter = new MultiKahaDBPersistenceAdapter();
+        if (deleteAllMessages) {
+            multiKahaDBPersistenceAdapter.deleteAllMessages();
+        }
+        ArrayList<FilteredKahaDBPersistenceAdapter> adapters = new ArrayList<>();
+
+        //have a topic wildcard filtered adapter
+        FilteredKahaDBPersistenceAdapter adapter1 = new FilteredKahaDBPersistenceAdapter();
+        adapter1.setPersistenceAdapter(createStore(deleteAllMessages));
+        adapter1.setTopic(">");
+        adapters.add(adapter1);
+
+        //have another per destination filtered adapter
+        FilteredKahaDBPersistenceAdapter adapter2 = new FilteredKahaDBPersistenceAdapter();
+        adapter2.setPersistenceAdapter(createStore(deleteAllMessages));
+        adapter2.setPerDestination(true);
+        adapters.add(adapter2);
+
+        multiKahaDBPersistenceAdapter.setFilteredPersistenceAdapters(adapters);
+        broker = createBroker(multiKahaDBPersistenceAdapter);
+    }
+}

--- a/activemq-web-console/pom.xml
+++ b/activemq-web-console/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.activemq</groupId>
     <artifactId>activemq-parent</artifactId>
-    <version>6.1.3-SNAPSHOT</version>
+    <version>6.1.3</version>
   </parent>
 
   <artifactId>activemq-web-console</artifactId>

--- a/activemq-web-demo/pom.xml
+++ b/activemq-web-demo/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.activemq</groupId>
     <artifactId>activemq-parent</artifactId>
-    <version>6.1.3-SNAPSHOT</version>
+    <version>6.1.3</version>
   </parent>
 
   <artifactId>activemq-web-demo</artifactId>

--- a/activemq-web/pom.xml
+++ b/activemq-web/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.activemq</groupId>
     <artifactId>activemq-parent</artifactId>
-    <version>6.1.3-SNAPSHOT</version>
+    <version>6.1.3</version>
   </parent>
 
   <artifactId>activemq-web</artifactId>

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.activemq</groupId>
     <artifactId>activemq-parent</artifactId>
-    <version>6.1.3-SNAPSHOT</version>
+    <version>6.1.3</version>
   </parent>
 
   <artifactId>apache-activemq</artifactId>

--- a/assembly/src/main/descriptors/common-bin.xml
+++ b/assembly/src/main/descriptors/common-bin.xml
@@ -145,6 +145,7 @@
         <include>jakarta.transaction:jakarta.transaction-api</include>
         <include>${pom.groupId}:activemq-web</include>
         <include>org.fusesource.hawtbuf:hawtbuf</include>
+        <include>org.fusesource.hawtbuf:hawtbuf-proto</include>
         <include>jakarta.xml.bind:jakarta.xml.bind-api</include>
         <include>org.glassfish.jaxb:jaxb-runtime</include>
         <include>org.glassfish.jaxb:jaxb-core</include>

--- a/assembly/src/release/conf/jetty-realm-5.x.properties
+++ b/assembly/src/release/conf/jetty-realm-5.x.properties
@@ -1,0 +1,21 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+## 
+## http://www.apache.org/licenses/LICENSE-2.0
+## 
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+# Defines users that can access the web (console, demo, etc.)
+# username: password [,rolename ...]
+admin: admin, admin
+user: user, user

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.apache.activemq</groupId>
        <artifactId>activemq-parent</artifactId>
-       <version>6.1.1-SNAPSHOT</version>
+       <version>6.1.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>activemq-bom</artifactId>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -32,151 +32,147 @@
     <name>ActiveMQ :: BOM </name>
     <description>ActiveMQ BOM (Bill of Materials)</description>
 
-    <properties>
-        <apache-activemq-version>${project.version}</apache-activemq-version>
-    </properties>
-
     <dependencyManagement>
         <dependencies>
             <dependency>
                 <groupId>org.apache.activemq</groupId>
                 <artifactId>activemq-all</artifactId>
-                <version>${apache-activemq-version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.activemq</groupId>
                 <artifactId>activemq-amqp</artifactId>
-                <version>${apache-activemq-version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.activemq</groupId>
                 <artifactId>activemq-blueprint</artifactId>
-                <version>${apache-activemq-version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.activemq</groupId>
                 <artifactId>activemq-broker</artifactId>
-                <version>${apache-activemq-version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.activemq</groupId>
                 <artifactId>activemq-client</artifactId>
-                <version>${apache-activemq-version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.activemq</groupId>
                 <artifactId>activemq-console</artifactId>
-                <version>${apache-activemq-version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.activemq</groupId>
                 <artifactId>activemq-http</artifactId>
-                <version>${apache-activemq-version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.activemq</groupId>
                 <artifactId>activemq-jaas</artifactId>
-                <version>${apache-activemq-version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.activemq</groupId>
                 <artifactId>activemq-jdbc-store</artifactId>
-                <version>${apache-activemq-version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.activemq</groupId>
                 <artifactId>activemq-kahadb-store</artifactId>
-                <version>${apache-activemq-version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.activemq</groupId>
                 <artifactId>activemq-karaf</artifactId>
-                <version>${apache-activemq-version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.activemq</groupId>
                 <artifactId>activemq-jms-pool</artifactId>
-                <version>${apache-activemq-version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.activemq</groupId>
                 <artifactId>activemq-log4j-appender</artifactId>
-                <version>${apache-activemq-version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.activemq</groupId>
                 <artifactId>activemq-mqtt</artifactId>
-                <version>${apache-activemq-version}</version>
+                <version>${project.version}</version>
             </dependency>
              <dependency>
                 <groupId>org.apache.activemq</groupId>
                 <artifactId>activemq-pool</artifactId>
-                <version>${apache-activemq-version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.activemq</groupId>
                 <artifactId>activemq-openwire-generator</artifactId>
-                <version>${apache-activemq-version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.activemq</groupId>
                 <artifactId>activemq-openwire-legacy</artifactId>
-                <version>${apache-activemq-version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.activemq</groupId>
                 <artifactId>activemq-osgi</artifactId>
-                <version>${apache-activemq-version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.activemq</groupId>
                 <artifactId>activemq-ra</artifactId>
-                <version>${apache-activemq-version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.activemq</groupId>
                 <artifactId>activemq-rar</artifactId>
-                <version>${apache-activemq-version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.activemq</groupId>
                 <artifactId>activemq-run</artifactId>
-                <version>${apache-activemq-version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.activemq</groupId>
                 <artifactId>activemq-runtime-config</artifactId>
-                <version>${apache-activemq-version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.activemq</groupId>
                 <artifactId>activemq-shiro</artifactId>
-                <version>${apache-activemq-version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.activemq</groupId>
                 <artifactId>activemq-spring</artifactId>
-                <version>${apache-activemq-version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.activemq</groupId>
                 <artifactId>activemq-stomp</artifactId>
-                <version>${apache-activemq-version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.activemq</groupId>
                 <artifactId>activemq-web</artifactId>
-                <version>${apache-activemq-version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.activemq</groupId>
                 <artifactId>activemq-web-console</artifactId>
-                <version>${apache-activemq-version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.activemq</groupId>
                 <artifactId>activemq-web-demo</artifactId>
-                <version>${apache-activemq-version}</version>
+                <version>${project.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -15,16 +15,14 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
        <groupId>org.apache.activemq</groupId>
        <artifactId>activemq-parent</artifactId>
-       <version>6.1.3-SNAPSHOT</version>
+       <version>6.1.3</version>
     </parent>
 
     <artifactId>activemq-bom</artifactId>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -1,0 +1,221 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+       <groupId>org.apache.activemq</groupId>
+       <artifactId>activemq-parent</artifactId>
+       <version>6.1.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>activemq-bom</artifactId>
+    <packaging>pom</packaging>
+    <name>ActiveMQ :: BOM </name>
+    <description>ActiveMQ BOM (Bill of Materials)</description>
+
+    <properties>
+        <apache-activemq-version>${project.version}</apache-activemq-version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>activemq-all</artifactId>
+                <version>${apache-activemq-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>activemq-amqp</artifactId>
+                <version>${apache-activemq-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>activemq-blueprint</artifactId>
+                <version>${apache-activemq-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>activemq-broker</artifactId>
+                <version>${apache-activemq-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>activemq-client</artifactId>
+                <version>${apache-activemq-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>activemq-console</artifactId>
+                <version>${apache-activemq-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>activemq-http</artifactId>
+                <version>${apache-activemq-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>activemq-jaas</artifactId>
+                <version>${apache-activemq-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>activemq-jdbc-store</artifactId>
+                <version>${apache-activemq-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>activemq-kahadb-store</artifactId>
+                <version>${apache-activemq-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>activemq-karaf</artifactId>
+                <version>${apache-activemq-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>activemq-jms-pool</artifactId>
+                <version>${apache-activemq-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>activemq-log4j-appender</artifactId>
+                <version>${apache-activemq-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>activemq-mqtt</artifactId>
+                <version>${apache-activemq-version}</version>
+            </dependency>
+             <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>activemq-pool</artifactId>
+                <version>${apache-activemq-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>activemq-openwire-generator</artifactId>
+                <version>${apache-activemq-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>activemq-openwire-legacy</artifactId>
+                <version>${apache-activemq-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>activemq-osgi</artifactId>
+                <version>${apache-activemq-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>activemq-ra</artifactId>
+                <version>${apache-activemq-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>activemq-rar</artifactId>
+                <version>${apache-activemq-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>activemq-run</artifactId>
+                <version>${apache-activemq-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>activemq-runtime-config</artifactId>
+                <version>${apache-activemq-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>activemq-shiro</artifactId>
+                <version>${apache-activemq-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>activemq-spring</artifactId>
+                <version>${apache-activemq-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>activemq-stomp</artifactId>
+                <version>${apache-activemq-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>activemq-web</artifactId>
+                <version>${apache-activemq-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>activemq-web-console</artifactId>
+                <version>${apache-activemq-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>activemq-web-demo</artifactId>
+                <version>${apache-activemq-version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>flatten</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                        <configuration>
+                            <updatePomFile>true</updatePomFile>
+                            <flattenMode>bom</flattenMode>
+                            <flattenedPomFilename>flattened-pom.xml</flattenedPomFilename>
+                            <outputDirectory>target</outputDirectory>
+                            <pomElements>
+                                <parent>remove</parent>
+                                <properties>keep</properties>
+                                <repositories>remove</repositories>
+                                <distributionManagement>remove</distributionManagement>
+                                <dependencyManagement>keep</dependencyManagement>
+                            </pomElements>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>flatten-clean</id>
+                        <phase>clean</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -49,9 +49,9 @@
     <camel-version>4.4.3</camel-version>
     <commons-beanutils-version>1.9.4</commons-beanutils-version>
     <commons-collections-version>3.2.2</commons-collections-version>
-    <commons-daemon-version>1.3.4</commons-daemon-version>
+    <commons-daemon-version>1.4.0</commons-daemon-version>
     <commons-dbcp2-version>2.12.0</commons-dbcp2-version>
-    <commons-io-version>2.15.1</commons-io-version>
+    <commons-io-version>2.16.1</commons-io-version>
     <commons-lang-version>3.14.0</commons-lang-version>
     <commons-logging-version>1.3.3</commons-logging-version>
     <commons-pool2-version>2.12.0</commons-pool2-version>

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
     <shiro-version>1.13.0</shiro-version>
     <slf4j-version>2.0.13</slf4j-version>
     <snappy-version>1.1.2</snappy-version>
-    <spring-version>6.1.10</spring-version>
+    <spring-version>6.1.11</spring-version>
     <spring-version-range>[6,7)</spring-version-range>
     <taglibs-version>1.2.5</taglibs-version>
     <velocity-version>2.3</velocity-version>

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
     <shiro-version>1.13.0</shiro-version>
     <slf4j-version>2.0.12</slf4j-version>
     <snappy-version>1.1.2</snappy-version>
-    <spring-version>6.1.5</spring-version>
+    <spring-version>6.1.10</spring-version>
     <spring-version-range>[6,7)</spring-version-range>
     <taglibs-version>1.2.5</taglibs-version>
     <velocity-version>2.3</velocity-version>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <httpclient-version>4.5.14</httpclient-version>
     <httpcore-version>4.4.16</httpcore-version>
     <insight-version>1.2.0.Beta4</insight-version>
-    <jackson-version>2.16.2</jackson-version>
+    <jackson-version>2.17.2</jackson-version>
     <jakarta-jms-api-version>3.1.0</jakarta-jms-api-version>
     <jasypt-version>1.9.3</jasypt-version>
     <jaxb-version>4.0.2</jaxb-version>

--- a/pom.xml
+++ b/pom.xml
@@ -25,14 +25,14 @@
 
   <groupId>org.apache.activemq</groupId>
   <artifactId>activemq-parent</artifactId>
-  <version>6.1.3-SNAPSHOT</version>
+  <version>6.1.3</version>
   <packaging>pom</packaging>
   <name>ActiveMQ</name>
   <inceptionYear>2005</inceptionYear>
 
   <properties>
     <!-- for reproducible builds -->	
-    <project.build.outputTimestamp>2024-04-11T17:41:28Z</project.build.outputTimestamp>
+    <project.build.outputTimestamp>2024-07-31T15:29:04Z</project.build.outputTimestamp>
 
     <siteId>activemq-${project.version}</siteId>
     <projectName>Apache ActiveMQ</projectName>
@@ -244,7 +244,7 @@
     <connection>scm:git:http://gitbox.apache.org/repos/asf/activemq.git</connection>
     <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/activemq.git</developerConnection>
     <url>https://github.com/apache/activemq</url>
-    <tag>main</tag>
+    <tag>activemq-6.1.3</tag>
   </scm>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <commons-dbcp2-version>2.12.0</commons-dbcp2-version>
     <commons-io-version>2.15.1</commons-io-version>
     <commons-lang-version>3.14.0</commons-lang-version>
-    <commons-logging-version>1.3.0</commons-logging-version>
+    <commons-logging-version>1.3.3</commons-logging-version>
     <commons-pool2-version>2.12.0</commons-pool2-version>
     <commons-primitives-version>1.0</commons-primitives-version>
     <directory-version>2.0.0.AM25</directory-version>

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
     <velocity-version>2.3</velocity-version>
     <xpp3-version>1.1.4c</xpp3-version>
     <xstream-version>1.4.20</xstream-version>
-    <xbean-version>4.24</xbean-version>
+    <xbean-version>4.25</xbean-version>
     <xerces-version>2.12.2</xerces-version>
     <jaxb-tools-version>4.0.8</jaxb-tools-version>
     <stompjms-version>3.1.0</stompjms-version>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <ant-version>1.10.14</ant-version>
     <aries-version>1.1.0</aries-version>
     <axion-version>1.0-M3-dev</axion-version>
-    <camel-version>4.4.1</camel-version>
+    <camel-version>4.4.3</camel-version>
     <commons-beanutils-version>1.9.4</commons-beanutils-version>
     <commons-collections-version>3.2.2</commons-collections-version>
     <commons-daemon-version>1.3.4</commons-daemon-version>

--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
     <maven-dependency-plugin-version>3.6.1</maven-dependency-plugin-version>
     <maven-project-info-reports-plugin-version>3.5.0</maven-project-info-reports-plugin-version>
     <maven-graph-plugin-version>1.45</maven-graph-plugin-version>
-    <maven-plugin-plugin-version>3.11.0</maven-plugin-plugin-version>
+    <maven-plugin-plugin-version>3.13.1</maven-plugin-plugin-version>
     <maven-core-version>3.8.6</maven-core-version>
     <!-- OSGi bundles properties -->
     <activemq.osgi.import.pkg>*</activemq.osgi.import.pkg>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
     <tomcat-api-version>9.0.65</tomcat-api-version>
     <jettison-version>1.5.4</jettison-version>
     <jmock-version>2.12.0</jmock-version>
-    <jolokia-version>2.0.0-M4</jolokia-version>
+    <jolokia-version>2.0.3</jolokia-version>
     <josql-version>1.5_5</josql-version>
     <!-- for json-simple use same version as jolokia uses -->
     <json-simple-version>1.1.1</json-simple-version>

--- a/pom.xml
+++ b/pom.xml
@@ -138,6 +138,7 @@
     <maven-shade-plugin-version>3.5.1</maven-shade-plugin-version>
     <exec-maven-plugin-version>3.1.0</exec-maven-plugin-version>
     <findbugs-maven-plugin-version>3.0.5</findbugs-maven-plugin-version>
+    <flatten-maven-plugin-version>1.6.0</flatten-maven-plugin-version>
     <javacc-maven-plugin-version>3.0.1</javacc-maven-plugin-version>
     <cobertura-maven-plugin-version>2.7</cobertura-maven-plugin-version>
     <taglist-maven-plugin-version>3.0.0</taglist-maven-plugin-version>
@@ -203,6 +204,7 @@
   </distributionManagement>
 
   <modules>
+    <module>bom</module>
     <module>activemq-openwire-generator</module>
     <module>activemq-client</module>
     <module>activemq-openwire-legacy</module>
@@ -1081,6 +1083,11 @@
           <groupId>org.apache.geronimo.genesis.plugins</groupId>
           <artifactId>tools-maven-plugin</artifactId>
           <version>${tools-maven-plugin-version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>flatten-maven-plugin</artifactId>
+          <version>${flatten-maven-plugin-version}</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
     <jackson-version>2.17.2</jackson-version>
     <jakarta-jms-api-version>3.1.0</jakarta-jms-api-version>
     <jasypt-version>1.9.3</jasypt-version>
-    <jaxb-version>4.0.2</jaxb-version>
+    <jaxb-version>4.0.5</jaxb-version>
     <jaxb-bundle-version>2.3.2_1</jaxb-bundle-version>
     <jetty-version>11.0.22</jetty-version>
     <jetty-version-range>[11,13)</jetty-version-range>
@@ -105,7 +105,7 @@
     <xstream-version>1.4.20</xstream-version>
     <xbean-version>4.24</xbean-version>
     <xerces-version>2.12.2</xerces-version>
-    <jaxb-tools-version>4.0.0</jaxb-tools-version>
+    <jaxb-tools-version>4.0.8</jaxb-tools-version>
     <stompjms-version>3.1.0</stompjms-version>
 
     <pax-logging-version>2.1.3</pax-logging-version>

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
     <regexp-version>1.4</regexp-version>
     <rome-version>2.1.0</rome-version>
     <shiro-version>1.13.0</shiro-version>
-    <slf4j-version>2.0.12</slf4j-version>
+    <slf4j-version>2.0.13</slf4j-version>
     <snappy-version>1.1.2</snappy-version>
     <spring-version>6.1.10</spring-version>
     <spring-version-range>[6,7)</spring-version-range>

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,8 @@
     <jasypt-version>1.9.3</jasypt-version>
     <jaxb-version>4.0.2</jaxb-version>
     <jaxb-bundle-version>2.3.2_1</jaxb-bundle-version>
-    <jetty-version>11.0.20</jetty-version>
+    <jetty-version>11.0.22</jetty-version>
+    <jetty-version-range>[11,13)</jetty-version-range>
     <jmdns-version>3.5.9</jmdns-version>
     <tomcat-api-version>9.0.65</tomcat-api-version>
     <jettison-version>1.5.4</jettison-version>


### PR DESCRIPTION
What problems does this PR solve?
Fixes a bug where BeanCreationException is thrown for not finding jetty-realm-5.x.properties when running jetty demo in 6.1.3

Why is it beneficial to merge into ActiveMQ?
It fixes a bug

How do you make sure this PR is well tested?
The demo can run without an exception after adding the file.