### PR TITLE
AMQ-9478 Add unit tests for tcp & ssl socket properties

### DIFF
--- a/activemq-unit-tests/src/test/java/org/apache/activemq/ActiveMQSslConnectionFactoryTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/ActiveMQSslConnectionFactoryTest.java
@@ -128,7 +128,6 @@ public class ActiveMQSslConnectionFactoryTest extends CombinationTestSupport {
         cf.setTrustStore("server.keystore");
         cf.setTrustStorePassword("password");
         connection = (ActiveMQConnection)cf.createConnection();
-        LOG.info("Created client connection");
         assertNotNull(connection);
         connection.start();
         connection.stop();

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/ActiveMQSslConnectionFactoryTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/ActiveMQSslConnectionFactoryTest.java
@@ -72,6 +72,20 @@ public class ActiveMQSslConnectionFactoryTest extends CombinationTestSupport {
         brokerStop();
     }
 
+    public void testCreateTcpConnectionWithSocketParameters() throws Exception {
+        // Control case: check that the factory can create an ordinary (non-ssl) connection.
+        String tcpUri = "tcp://localhost:61610?socket.OOBInline=true";
+        broker = createBroker(tcpUri);
+
+        // This should create the connection.
+        ActiveMQSslConnectionFactory cf = getFactory(tcpUri);
+        connection = (ActiveMQConnection)cf.createConnection();
+        assertNotNull(connection);
+        connection.start();
+        connection.stop();
+        brokerStop();
+    }
+
     public void testCreateFailoverTcpConnectionUsingKnownPort() throws Exception {
         // Control case: check that the factory can create an ordinary (non-ssl) connection.
         broker = createBroker("tcp://localhost:61610?wireFormat.tcpNoDelayEnabled=true");
@@ -88,6 +102,24 @@ public class ActiveMQSslConnectionFactoryTest extends CombinationTestSupport {
     public void testCreateSslConnection() throws Exception {
         // Create SSL/TLS connection with trusted cert from truststore.
         String sslUri = "ssl://localhost:61611";
+        broker = createSslBroker(sslUri);
+        assertNotNull(broker);
+
+        // This should create the connection.
+        ActiveMQSslConnectionFactory cf = getFactory(sslUri);
+        cf.setTrustStore("server.keystore");
+        cf.setTrustStorePassword("password");
+        connection = (ActiveMQConnection)cf.createConnection();
+        LOG.info("Created client connection");
+        assertNotNull(connection);
+        connection.start();
+        connection.stop();
+        brokerStop();
+    }
+
+    public void testCreateSslConnectionWithSocketParameters() throws Exception {
+        // Create SSL/TLS connection with trusted cert from truststore.
+        String sslUri = "ssl://localhost:61611?socket.enabledProtocols=TLSv1.3";
         broker = createSslBroker(sslUri);
         assertNotNull(broker);
 

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/ActiveMQSslConnectionFactoryTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/ActiveMQSslConnectionFactoryTest.java
@@ -74,7 +74,7 @@ public class ActiveMQSslConnectionFactoryTest extends CombinationTestSupport {
 
     public void testCreateTcpConnectionWithSocketParameters() throws Exception {
         // Control case: check that the factory can create an ordinary (non-ssl) connection.
-        String tcpUri = "tcp://localhost:61610?socket.OOBInline=true";
+        String tcpUri = "tcp://localhost:61610?socket.OOBInline=true&socket.keepAlive=true&tcpNoDelay=true";
         broker = createBroker(tcpUri);
 
         // This should create the connection.
@@ -119,7 +119,7 @@ public class ActiveMQSslConnectionFactoryTest extends CombinationTestSupport {
 
     public void testCreateSslConnectionWithSocketParameters() throws Exception {
         // Create SSL/TLS connection with trusted cert from truststore.
-        String sslUri = "ssl://localhost:61611?socket.enabledProtocols=TLSv1.3";
+        String sslUri = "ssl://localhost:61611?socket.enabledProtocols=TLSv1.3&socket.enableSessionCreation=true&socket.needClientAuth=true";
         broker = createSslBroker(sslUri);
         assertNotNull(broker);
 


### PR DESCRIPTION
**What problems does this PR solve?**
Add test coverage to ensure socket parameters can be set for tcp and ssl connections. 

**Why is it beneficial to merge into ActiveMQ?**
The tests provide confidence and prevent future issues like [AMQ-9473](https://issues.apache.org/jira/browse/AMQ-9473). 

**How do you make sure this PR is well tested?**
_Test A_
Ran the two new units tests and verified success.

_Test B_
Edited the `IntrospectionSupport` class to comment out the following:
```
//            if (target instanceof SSLServerSocket) {
//                // overcome illegal access issues with internal implementation class
//                clazz = SSLServerSocket.class;
//            } else if (target instanceof javax.net.ssl.SSLSocket) {
//                // overcome illegal access issues with internal implementation class
//                clazz = javax.net.ssl.SSLSocket.class;
//            }
```
Ran the two new units tests and verified failure due to `java.lang.IllegalArgumentException: Invalid socket parameters`.

