### PR TITLE
[AMQ-9637] Add web socket connection limit.

### DIFF
--- a/activemq-amqp/src/test/java/org/apache/activemq/transport/amqp/client/AmqpClientTestSupport.java
+++ b/activemq-amqp/src/test/java/org/apache/activemq/transport/amqp/client/AmqpClientTestSupport.java
@@ -55,7 +55,7 @@ public class AmqpClientTestSupport extends AmqpTestSupport {
     }
 
     public String getConnectorScheme() {
-        return connectorScheme;
+        return connectorScheme.contains("ws") ? connectorScheme.replace("amqp+", "") : connectorScheme;
     }
 
     public boolean isUseSSL() {

--- a/activemq-amqp/src/test/java/org/apache/activemq/transport/amqp/interop/AmqpConfiguredMaxConnectionsTest.java
+++ b/activemq-amqp/src/test/java/org/apache/activemq/transport/amqp/interop/AmqpConfiguredMaxConnectionsTest.java
@@ -45,7 +45,9 @@ public class AmqpConfiguredMaxConnectionsTest extends AmqpClientTestSupport {
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][] {
                 {"amqp", false},
+                {"amqp+ws", false},
                 {"amqp+nio", false},
+                {"amqp+wss", true}
             });
     }
 

--- a/activemq-http/src/main/java/org/apache/activemq/transport/ws/AbstractMQTTSocket.java
+++ b/activemq-http/src/main/java/org/apache/activemq/transport/ws/AbstractMQTTSocket.java
@@ -35,7 +35,7 @@ import org.apache.activemq.util.IOExceptionSupport;
 import org.apache.activemq.util.ServiceStopper;
 import org.fusesource.mqtt.codec.MQTTFrame;
 
-public abstract class AbstractMQTTSocket extends TransportSupport implements MQTTTransport, BrokerServiceAware {
+public abstract class AbstractMQTTSocket extends AbstractWsSocket implements MQTTTransport, BrokerServiceAware {
 
     protected ReentrantLock protocolLock = new ReentrantLock();
     protected volatile MQTTProtocolConverter protocolConverter = null;

--- a/activemq-http/src/main/java/org/apache/activemq/transport/ws/AbstractStompSocket.java
+++ b/activemq-http/src/main/java/org/apache/activemq/transport/ws/AbstractStompSocket.java
@@ -38,7 +38,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Base implementation of a STOMP based WebSocket handler.
  */
-public abstract class AbstractStompSocket extends TransportSupport implements StompTransport {
+public abstract class AbstractStompSocket extends AbstractWsSocket implements StompTransport {
 
     private static final Logger LOG = LoggerFactory.getLogger(AbstractStompSocket.class);
 

--- a/activemq-http/src/main/java/org/apache/activemq/transport/ws/AbstractWsSocket.java
+++ b/activemq-http/src/main/java/org/apache/activemq/transport/ws/AbstractWsSocket.java
@@ -1,0 +1,43 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.transport.ws;
+
+import org.apache.activemq.transport.TransportSupport;
+import org.eclipse.jetty.websocket.api.WebSocketListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class AbstractWsSocket extends TransportSupport implements WebSocketListener {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractWsSocket.class);
+
+    @Override
+    public void onWebSocketClose(int statusCode, String reason) {
+        WebSocketListener.super.onWebSocketClose(statusCode, reason);
+
+        try {
+            stop();
+            LOG.debug("Stopped socket: {}", getRemoteAddress());
+        } catch (Exception e) {
+            LOG.debug("Could not stop socket to {}. This exception is ignored.", getRemoteAddress(), e);
+        }
+
+        doWebSocketClose(statusCode, reason);
+    }
+
+    public abstract void doWebSocketClose(int statusCode, String reason);
+}

--- a/activemq-http/src/main/java/org/apache/activemq/transport/ws/WSTransportProxy.java
+++ b/activemq-http/src/main/java/org/apache/activemq/transport/ws/WSTransportProxy.java
@@ -43,7 +43,7 @@ import org.slf4j.LoggerFactory;
  * A proxy class that manages sending WebSocket events to the wrapped protocol level
  * WebSocket Transport.
  */
-public final class WSTransportProxy extends TransportSupport implements Transport, WebSocketListener, BrokerServiceAware, WSTransportSink {
+public final class WSTransportProxy extends AbstractWsSocket implements Transport, WebSocketListener, BrokerServiceAware, WSTransportSink {
 
     private static final Logger LOG = LoggerFactory.getLogger(WSTransportProxy.class);
 
@@ -201,7 +201,7 @@ public final class WSTransportProxy extends TransportSupport implements Transpor
     }
 
     @Override
-    public void onWebSocketClose(int statusCode, String reason) {
+    public void doWebSocketClose(int statusCode, String reason) {
         try {
             if (protocolLock.tryLock() || protocolLock.tryLock(ORDERLY_CLOSE_TIMEOUT, TimeUnit.SECONDS)) {
                 LOG.debug("WebSocket closed: code[{}] message[{}]", statusCode, reason);

--- a/activemq-http/src/main/java/org/apache/activemq/transport/ws/WSTransportServer.java
+++ b/activemq-http/src/main/java/org/apache/activemq/transport/ws/WSTransportServer.java
@@ -20,6 +20,7 @@ package org.apache.activemq.transport.ws;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import jakarta.servlet.Servlet;
 
@@ -52,6 +53,11 @@ public class WSTransportServer extends WebTransportServerSupport implements Brok
 
     private BrokerService brokerService;
     private WSServlet servlet;
+
+    /**
+     * The maximum number of sockets allowed for this server
+     */
+    protected int maximumConnections = Integer.MAX_VALUE;
 
     public WSTransportServer(URI location) {
         super(location);
@@ -122,6 +128,7 @@ public class WSTransportServer extends WebTransportServerSupport implements Brok
         servlet = new WSServlet();
         servlet.setTransportOptions(transportOptions);
         servlet.setBrokerService(brokerService);
+        servlet.setMaximumConnections(maximumConnections);
 
         return servlet;
     }
@@ -176,12 +183,35 @@ public class WSTransportServer extends WebTransportServerSupport implements Brok
 
     @Override
     public long getMaxConnectionExceededCount() {
-        // Max Connection Count not supported for ws
-        return -1l;
+        if (servlet != null) {
+            return servlet.getMaxConnectionExceededCount();
+        }
+        return 0;
     }
 
     @Override
     public void resetStatistics() {
-        // Statistics not implemented for ws
+        if(servlet != null) {
+            servlet.resetStatistics();
+        }
     }
+
+    public int getMaximumConnections() {
+        return maximumConnections;
+    }
+
+    public void setMaximumConnections(int maximumConnections) {
+        this.maximumConnections = maximumConnections;
+        if (servlet != null) {
+            servlet.setMaximumConnections(maximumConnections);
+        }
+    }
+
+    public AtomicInteger getCurrentTransportCount() {
+        if (servlet != null) {
+            return servlet.getCurrentTransportCount();
+        }
+        return new AtomicInteger(0);
+    }
+
 }

--- a/activemq-http/src/main/java/org/apache/activemq/transport/ws/jetty11/MQTTSocket.java
+++ b/activemq-http/src/main/java/org/apache/activemq/transport/ws/jetty11/MQTTSocket.java
@@ -95,7 +95,7 @@ public class MQTTSocket extends AbstractMQTTSocket implements MQTTCodec.MQTTFram
     }
 
     @Override
-    public void onWebSocketClose(int arg0, String arg1) {
+    public void doWebSocketClose(int arg0, String arg1) {
         try {
             if (protocolLock.tryLock() || protocolLock.tryLock(ORDERLY_CLOSE_TIMEOUT, TimeUnit.SECONDS)) {
                 LOG.debug("MQTT WebSocket closed: code[{}] message[{}]", arg0, arg1);
@@ -120,14 +120,6 @@ public class MQTTSocket extends AbstractMQTTSocket implements MQTTCodec.MQTTFram
         this.session.setIdleTimeout(Duration.ZERO);
     }
 
-    @Override
-    public void onWebSocketError(Throwable arg0) {
-
-    }
-
-    @Override
-    public void onWebSocketText(String arg0) {
-    }
 
     private static int getDefaultSendTimeOut() {
         return Integer.getInteger("org.apache.activemq.transport.ws.MQTTSocket.sendTimeout", 30);

--- a/activemq-http/src/main/java/org/apache/activemq/transport/ws/jetty11/StompSocket.java
+++ b/activemq-http/src/main/java/org/apache/activemq/transport/ws/jetty11/StompSocket.java
@@ -69,7 +69,7 @@ public class StompSocket extends AbstractStompSocket implements WebSocketListene
     }
 
     @Override
-    public void onWebSocketClose(int arg0, String arg1) {
+    public void doWebSocketClose(int arg0, String arg1) {
         try {
             if (protocolLock.tryLock() || protocolLock.tryLock(ORDERLY_CLOSE_TIMEOUT, TimeUnit.SECONDS)) {
                 LOG.debug("Stomp WebSocket closed: code[{}] message[{}]", arg0, arg1);

--- a/activemq-http/src/test/java/org/apache/activemq/transport/ws/MQTTWSConfiguredMaxConnectionsTest.java
+++ b/activemq-http/src/test/java/org/apache/activemq/transport/ws/MQTTWSConfiguredMaxConnectionsTest.java
@@ -1,0 +1,123 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.transport.ws;
+
+import org.apache.activemq.util.Wait;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.dynamic.HttpClientTransportDynamic;
+import org.eclipse.jetty.io.ClientConnector;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
+import org.eclipse.jetty.websocket.client.WebSocketClient;
+import org.fusesource.hawtbuf.UTF8Buffer;
+import org.fusesource.mqtt.codec.CONNACK;
+import org.fusesource.mqtt.codec.CONNECT;
+import org.fusesource.mqtt.codec.MQTTFrame;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class MQTTWSConfiguredMaxConnectionsTest extends WSTransportTestSupport {
+
+    private static final String connectorScheme = "ws";
+
+    private static final int MAX_CONNECTIONS = 10;
+
+    @Test(timeout = 60000)
+    public void testMaxConnectionsSettingIsHonored() throws Exception {
+        List<MQTTWSConnection> connections = new ArrayList<>();
+
+        for (int i = 0; i < MAX_CONNECTIONS; i++) {
+            MQTTWSConnection connection = createConnection();
+            if (!connection.awaitConnection(30, TimeUnit.SECONDS)) {
+                throw new IOException("Could not connect to STOMP WS endpoint");
+            }
+
+            connections.add(connection);
+
+            CONNECT command = new CONNECT();
+
+            command.clientId(new UTF8Buffer(UUID.randomUUID().toString()));
+            command.cleanSession(false);
+            command.version(3);
+            command.keepAlive((short) 60);
+
+            connection.sendFrame(command.encode());
+
+            MQTTFrame received = connection.receive(15, TimeUnit.SECONDS);
+            if (received == null || received.messageType() != CONNACK.TYPE) {
+                fail("Client did not get expected CONNACK");
+            }
+        }
+
+        assertEquals(MAX_CONNECTIONS, getProxyToBroker().getCurrentConnectionsCount());
+        assertEquals(Long.valueOf(0L), Long.valueOf(getProxyToConnectionView(connectorScheme).getMaxConnectionExceededCount()));
+
+        {
+            MQTTWSConnection connection = createConnection();
+            if (!connection.awaitError(30, TimeUnit.SECONDS)) {
+                throw new IOException("WS endpoint has maximumConnections=" + MAX_CONNECTIONS);
+            }
+
+            connections.add(connection);
+        }
+
+        assertEquals(MAX_CONNECTIONS, getProxyToBroker().getCurrentConnectionsCount());
+        assertEquals(1, getProxyToConnectionView(connectorScheme).getMaxConnectionExceededCount());
+
+        for (MQTTWSConnection connection : connections) {
+            connection.close();
+        }
+        assertTrue("Connection should close", Wait.waitFor(() -> getProxyToBroker().getCurrentConnectionsCount() == 0));
+
+        // Confirm reset statistics
+        getProxyToConnectionView(connectorScheme).resetStatistics();
+        assertEquals(0, getProxyToConnectionView(connectorScheme).getMaxConnectionExceededCount());
+    }
+
+    @Override
+    protected String getWSConnectorURI() {
+        return super.getWSConnectorURI() + "&maximumConnections=" + MAX_CONNECTIONS;
+    }
+
+    private MQTTWSConnection createConnection() throws Exception {
+        MQTTWSConnection connection = new MQTTWSConnection();
+
+        ClientUpgradeRequest request = new ClientUpgradeRequest();
+        request.setSubProtocols("mqttv3.1");
+
+        SslContextFactory.Client sslContextFactory = new SslContextFactory.Client();
+        sslContextFactory.setTrustAll(true);
+        ClientConnector clientConnector = new ClientConnector();
+        clientConnector.setSslContextFactory(sslContextFactory);
+
+        WebSocketClient wsClient = new WebSocketClient(new HttpClient(new HttpClientTransportDynamic(clientConnector)));
+        wsClient.start();
+
+        wsClient.connect(connection, wsConnectUri, request);
+
+        return connection;
+    }
+}

--- a/activemq-http/src/test/java/org/apache/activemq/transport/ws/StompWSConfiguredMaxConnectionsTest.java
+++ b/activemq-http/src/test/java/org/apache/activemq/transport/ws/StompWSConfiguredMaxConnectionsTest.java
@@ -1,0 +1,117 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.transport.ws;
+
+import org.apache.activemq.transport.stomp.Stomp;
+import org.apache.activemq.util.Wait;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.dynamic.HttpClientTransportDynamic;
+import org.eclipse.jetty.io.ClientConnector;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.eclipse.jetty.websocket.client.ClientUpgradeRequest;
+import org.eclipse.jetty.websocket.client.WebSocketClient;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class StompWSConfiguredMaxConnectionsTest extends WSTransportTestSupport {
+
+    private static final String connectorScheme = "ws";
+
+    private static final int MAX_CONNECTIONS = 10;
+
+    @Test(timeout = 60000)
+    public void testMaxConnectionsSettingIsHonored() throws Exception {
+        List<StompWSConnection> connections = new ArrayList<>();
+
+        for (int i = 0; i < MAX_CONNECTIONS; i++) {
+            StompWSConnection connection = createConnection();
+            if (!connection.awaitConnection(30, TimeUnit.SECONDS)) {
+                throw new IOException("Could not connect to STOMP WS endpoint");
+            }
+
+            connections.add(connection);
+
+            String connectFrame = "STOMP\n" +
+                    "login:system\n" +
+                    "passcode:manager\n" +
+                    "accept-version:1.0,1.1\n" +
+                    "host:localhost\n" +
+                    "\n" + Stomp.NULL;
+            connection.sendRawFrame(connectFrame);
+
+            String incoming = connection.receive(30, TimeUnit.SECONDS);
+            assertNotNull(incoming);
+            assertTrue(incoming.startsWith("CONNECTED"));
+        }
+
+        assertEquals(MAX_CONNECTIONS, getProxyToBroker().getCurrentConnectionsCount());
+        assertEquals(Long.valueOf(0l), Long.valueOf(getProxyToConnectionView(connectorScheme).getMaxConnectionExceededCount()));
+
+        {
+            StompWSConnection connection = createConnection();
+            if (!connection.awaitError(30, TimeUnit.SECONDS)) {
+                throw new IOException("WS endpoint has maximumConnections=" + MAX_CONNECTIONS);
+            }
+
+            connections.add(connection);
+        }
+
+        assertEquals(MAX_CONNECTIONS, getProxyToBroker().getCurrentConnectionsCount());
+        assertEquals(1, getProxyToConnectionView(connectorScheme).getMaxConnectionExceededCount());
+
+        for (StompWSConnection connection : connections) {
+            connection.close();
+        }
+        assertTrue("Connection should close", Wait.waitFor(() -> getProxyToBroker().getCurrentConnectionsCount() == 0));
+
+        // Confirm reset statistics
+        getProxyToConnectionView(connectorScheme).resetStatistics();
+        assertEquals(0, getProxyToConnectionView(connectorScheme).getMaxConnectionExceededCount());
+    }
+
+    @Override
+    protected String getWSConnectorURI() {
+        return super.getWSConnectorURI() + "&maximumConnections=" + MAX_CONNECTIONS;
+    }
+
+    private StompWSConnection createConnection() throws Exception {
+        StompWSConnection connection = new StompWSConnection();
+
+        ClientUpgradeRequest request = new ClientUpgradeRequest();
+        request.setSubProtocols("v11.stomp");
+
+        SslContextFactory.Client sslContextFactory = new SslContextFactory.Client();
+        sslContextFactory.setTrustAll(true);
+        ClientConnector clientConnector = new ClientConnector();
+        clientConnector.setSslContextFactory(sslContextFactory);
+
+        WebSocketClient wsClient = new WebSocketClient(new HttpClient(new HttpClientTransportDynamic(clientConnector)));
+        wsClient.start();
+
+        wsClient.connect(connection, wsConnectUri, request);
+
+        return connection;
+    }
+}

--- a/activemq-http/src/test/java/org/apache/activemq/transport/ws/WSTransportTestSupport.java
+++ b/activemq-http/src/test/java/org/apache/activemq/transport/ws/WSTransportTestSupport.java
@@ -19,6 +19,7 @@ package org.apache.activemq.transport.ws;
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.net.URI;
+import java.util.Set;
 
 import jakarta.jms.JMSException;
 import javax.management.MalformedObjectNameException;
@@ -27,6 +28,7 @@ import javax.net.ServerSocketFactory;
 
 import org.apache.activemq.broker.BrokerService;
 import org.apache.activemq.broker.jmx.BrokerViewMBean;
+import org.apache.activemq.broker.jmx.ConnectorViewMBean;
 import org.apache.activemq.broker.jmx.QueueViewMBean;
 import org.apache.activemq.broker.jmx.TopicViewMBean;
 import org.apache.activemq.spring.SpringSslContext;
@@ -171,6 +173,22 @@ public class WSTransportTestSupport {
         ObjectName topicViewMBeanName = new ObjectName("org.apache.activemq:type=Broker,brokerName=localhost,destinationType=Topic,destinationName="+name);
         TopicViewMBean proxy = (TopicViewMBean) broker.getManagementContext()
                 .newProxyInstance(topicViewMBeanName, TopicViewMBean.class, true);
+        return proxy;
+    }
+
+
+    protected ConnectorViewMBean getProxyToConnectionView(String connectionType) throws Exception {
+        ObjectName connectorQuery = new ObjectName(
+                "org.apache.activemq:type=Broker,brokerName=localhost,connector=clientConnectors,connectorName="+connectionType+"_//*");
+
+        Set<ObjectName> results = broker.getManagementContext().queryNames(connectorQuery, null);
+
+        if (results == null || results.size() != 1) {
+            throw new Exception("Unable to find the exact Connector instance.");
+        }
+
+        ConnectorViewMBean proxy = (ConnectorViewMBean) broker.getManagementContext()
+                .newProxyInstance(results.iterator().next(), ConnectorViewMBean.class, true);
         return proxy;
     }
 }


### PR DESCRIPTION
**What problems does this PR solve?**
It adds `maximumConnections` support for WS transport.

**Why is it beneficial to merge into ActiveMQ?**
all other transports have this limit. being able to limit the number of connections for WS transport brings in in par with the rest of transports.

**How do you make sure this PR is well tested?**
I updated the existing amqp test to test amqp+ws and amqp+wss, added new tests for stomp+ws and mqtt+ws as well.
