### PR TITLE
[NO-JIRA] Remove no-op 'optimize' flag to maven-compiler-plugin 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1248,7 +1248,6 @@
         <configuration>
           <source>${source-version}</source>
           <target>${target-version}</target>
-          <optimize>true</optimize>
           <debug>true</debug>
           <showDeprecation>true</showDeprecation>
           <showWarnings>true</showWarnings>


### PR DESCRIPTION
deprecated since Java 9