### PR TITLE
[AMQ-9647]  2025-01 Maven Plugin version updates

### DIFF
--- a/activemq-client/src/test/java/org/apache/activemq/thread/TaskRunnerTest.java
+++ b/activemq-client/src/test/java/org/apache/activemq/thread/TaskRunnerTest.java
@@ -91,7 +91,6 @@ public class TaskRunnerTest {
                         for (int i = 0; i < enqueueCount / workerCount; i++) {
                             queue.incrementAndGet();
                             runner.wakeup();
-                            yield();
                         }
                     } catch (BrokenBarrierException e) {
                     } catch (InterruptedException e) {

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
-    <version>30</version>
+    <version>33</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -112,8 +112,10 @@
     <felix-framework-version>5.6.12</felix-framework-version>
 
     <site-repo-url>scpexe://people.apache.org/www/activemq.apache.org/maven/</site-repo-url>
-    <source-version>11</source-version>
-    <target-version>17</target-version>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
+    <source-version>${maven.compiler.source}</source-version>
+    <target-version>${maven.compiler.target}</target-version>
     <javase-javadoc-url>https://docs.oracle.com/en/java/javase/11/docs/api/</javase-javadoc-url>
     <javaee-javadoc-url>http://download.oracle.com/javaee/6/api/</javaee-javadoc-url>
 
@@ -131,8 +133,8 @@
     <maven-rar-plugin-version>3.0.0</maven-rar-plugin-version>
     <maven-jar-plugin-version>3.4.2</maven-jar-plugin-version>
     <maven-source-plugin-version>3.3.1</maven-source-plugin-version>
-    <maven-javadoc-plugin-version>3.11.1</maven-javadoc-plugin-version>
-    <maven-install-plugin-version>2.5.2</maven-install-plugin-version>
+    <maven-javadoc-plugin-version>3.11.2</maven-javadoc-plugin-version>
+    <maven-install-plugin-version>3.1.3</maven-install-plugin-version>
     <maven-shade-plugin-version>3.6.0</maven-shade-plugin-version>
     <exec-maven-plugin-version>3.1.0</exec-maven-plugin-version>
     <findbugs-maven-plugin-version>3.0.5</findbugs-maven-plugin-version>
@@ -146,7 +148,7 @@
     <apache-rat-plugin-version>0.16.1</apache-rat-plugin-version>
     <tools-maven-plugin-version>1.4</tools-maven-plugin-version>
     <depends-maven-plugin-version>1.5.0</depends-maven-plugin-version>
-    <maven-dependency-plugin-version>3.6.1</maven-dependency-plugin-version>
+    <maven-dependency-plugin-version>3.8.1</maven-dependency-plugin-version>
     <maven-project-info-reports-plugin-version>3.8.0</maven-project-info-reports-plugin-version>
     <maven-graph-plugin-version>1.45</maven-graph-plugin-version>
     <maven-plugin-plugin-version>3.15.1</maven-plugin-plugin-version>

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
     <javaee-javadoc-url>http://download.oracle.com/javaee/6/api/</javaee-javadoc-url>
 
     <!-- Maven Plugin Version for this Project -->
-    <maven-bundle-plugin-version>5.1.9</maven-bundle-plugin-version>
+    <maven-bundle-plugin-version>6.0.0</maven-bundle-plugin-version>
     <maven-surefire-plugin-version>3.5.2</maven-surefire-plugin-version>
     <maven-antrun-plugin-version>3.1.0</maven-antrun-plugin-version>
     <maven-assembly-plugin-version>3.7.1</maven-assembly-plugin-version>


### PR DESCRIPTION
apache parent pom 33
maven-javadoc-plugin-version 3.11.2
maven-install-plugin-version 3.1.3
maven-dependency-plugin-version 3.8.1
maven-bundle-plugin 6.0.0 (JDK 17 required, not back-ported)
