### PR TITLE
AMQ-6596 - Validate size of buffers during unmarshalling

### DIFF
--- a/activemq-client/pom.xml
+++ b/activemq-client/pom.xml
@@ -79,6 +79,11 @@
       <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.javassist</groupId>
+      <artifactId>javassist</artifactId>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 

--- a/activemq-client/src/main/java/org/apache/activemq/openwire/OpenWireUtil.java
+++ b/activemq-client/src/main/java/org/apache/activemq/openwire/OpenWireUtil.java
@@ -16,10 +16,13 @@
  */
 package org.apache.activemq.openwire;
 
+import java.io.IOException;
+import org.apache.activemq.util.IOExceptionSupport;
+
 public class OpenWireUtil {
 
-    private static final String jmsPackageToReplace = "javax.jms";
-    private static final String jmsPackageToUse = "jakarta.jms";
+    static final String jmsPackageToReplace = "javax.jms";
+    static final String jmsPackageToUse = "jakarta.jms";
 
     /**
      * Verify that the provided class extends {@link Throwable} and throw an
@@ -30,6 +33,50 @@ public class OpenWireUtil {
     public static void validateIsThrowable(Class<?> clazz) {
         if (!Throwable.class.isAssignableFrom(clazz)) {
             throw new IllegalArgumentException("Class " + clazz + " is not assignable to Throwable");
+        }
+    }
+
+    /**
+     * Verify that the buffer size that will be allocated will not push the total allocated
+     * size of this frame above the expected frame size. This is an estimate as the current
+     * size is only tracked when calls to this method are made and is primarily intended
+     * to prevent large arrays from being created due to an invalid size.
+     *
+     * Also verify the size against configured max frame size.
+     * This check is a sanity check in case of corrupt packets contain invalid size values.
+     *
+     * @param wireFormat configured OpenWireFormat
+     * @param size buffer size to verify
+     * @throws IOException If size is larger than currentFrameSize or maxFrameSize
+     */
+    public static void validateBufferSize(OpenWireFormat wireFormat, int size) throws IOException {
+        validateLessThanFrameSize(wireFormat, size);
+
+        // if currentFrameSize is set and was checked above then this check should not be needed,
+        // but it doesn't hurt to verify again in case the max frame size check was missed
+        // somehow
+        if (wireFormat.isMaxFrameSizeEnabled() && size > wireFormat.getMaxFrameSize()) {
+            throw IOExceptionSupport.createFrameSizeException(size,  wireFormat.getMaxFrameSize());
+        }
+    }
+
+    // Verify total tracked sizes will not exceed the overall size of the frame
+    private static void validateLessThanFrameSize(OpenWireFormat wireFormat, int size)
+        throws IOException {
+        final var context = wireFormat.getMarshallingContext();
+        // No information on current frame size so just return
+        if (context == null || context.getFrameSize() < 0) {
+            return;
+        }
+
+        // Increment existing estimated buffer size with new size
+        context.increment(size);
+
+        // We should never be trying to allocate a buffer that is going to push the total
+        // size greater than the entire frame itself
+        if (context.getEstimatedAllocated() > context.getFrameSize()) {
+            throw IOExceptionSupport.createFrameSizeBufferException(
+                context.getEstimatedAllocated(), context.getFrameSize());
         }
     }
 

--- a/activemq-client/src/main/java/org/apache/activemq/openwire/v1/BaseDataStreamMarshaller.java
+++ b/activemq-client/src/main/java/org/apache/activemq/openwire/v1/BaseDataStreamMarshaller.java
@@ -411,10 +411,11 @@ public abstract class BaseDataStreamMarshaller implements DataStreamMarshaller {
         }
     }
 
-    protected byte[] tightUnmarshalByteArray(DataInput dataIn, BooleanStream bs) throws IOException {
+    protected byte[] tightUnmarshalByteArray(OpenWireFormat wireFormat, DataInput dataIn, BooleanStream bs) throws IOException {
         byte rc[] = null;
         if (bs.readBoolean()) {
             int size = dataIn.readInt();
+            OpenWireUtil.validateBufferSize(wireFormat, size);
             rc = new byte[size];
             dataIn.readFully(rc);
         }
@@ -438,10 +439,11 @@ public abstract class BaseDataStreamMarshaller implements DataStreamMarshaller {
         }
     }
 
-    protected ByteSequence tightUnmarshalByteSequence(DataInput dataIn, BooleanStream bs) throws IOException {
+    protected ByteSequence tightUnmarshalByteSequence(OpenWireFormat wireFormat, DataInput dataIn, BooleanStream bs) throws IOException {
         ByteSequence rc = null;
         if (bs.readBoolean()) {
             int size = dataIn.readInt();
+            OpenWireUtil.validateBufferSize(wireFormat, size);
             byte[] t = new byte[size];
             dataIn.readFully(t);
             return new ByteSequence(t, 0, size);
@@ -618,10 +620,11 @@ public abstract class BaseDataStreamMarshaller implements DataStreamMarshaller {
         }
     }
 
-    protected byte[] looseUnmarshalByteArray(DataInput dataIn) throws IOException {
+    protected byte[] looseUnmarshalByteArray(OpenWireFormat wireFormat, DataInput dataIn) throws IOException {
         byte rc[] = null;
         if (dataIn.readBoolean()) {
             int size = dataIn.readInt();
+            OpenWireUtil.validateBufferSize(wireFormat, size);
             rc = new byte[size];
             dataIn.readFully(rc);
         }
@@ -637,10 +640,11 @@ public abstract class BaseDataStreamMarshaller implements DataStreamMarshaller {
         }
     }
 
-    protected ByteSequence looseUnmarshalByteSequence(DataInput dataIn) throws IOException {
+    protected ByteSequence looseUnmarshalByteSequence(OpenWireFormat wireFormat, DataInput dataIn) throws IOException {
         ByteSequence rc = null;
         if (dataIn.readBoolean()) {
             int size = dataIn.readInt();
+            OpenWireUtil.validateBufferSize(wireFormat, size);
             byte[] t = new byte[size];
             dataIn.readFully(t);
             rc = new ByteSequence(t, 0, size);

--- a/activemq-client/src/main/java/org/apache/activemq/openwire/v1/MessageMarshaller.java
+++ b/activemq-client/src/main/java/org/apache/activemq/openwire/v1/MessageMarshaller.java
@@ -65,8 +65,8 @@ public abstract class MessageMarshaller extends BaseCommandMarshaller {
         info.setReplyTo((org.apache.activemq.command.ActiveMQDestination)tightUnmarsalNestedObject(wireFormat, dataIn, bs));
         info.setTimestamp(tightUnmarshalLong(wireFormat, dataIn, bs));
         info.setType(tightUnmarshalString(dataIn, bs));
-        info.setContent(tightUnmarshalByteSequence(dataIn, bs));
-        info.setMarshalledProperties(tightUnmarshalByteSequence(dataIn, bs));
+        info.setContent(tightUnmarshalByteSequence(wireFormat, dataIn, bs));
+        info.setMarshalledProperties(tightUnmarshalByteSequence(wireFormat, dataIn, bs));
         info.setDataStructure((org.apache.activemq.command.DataStructure)tightUnmarsalNestedObject(wireFormat, dataIn, bs));
         info.setTargetConsumerId((org.apache.activemq.command.ConsumerId)tightUnmarsalCachedObject(wireFormat, dataIn, bs));
         info.setCompressed(bs.readBoolean());
@@ -196,8 +196,8 @@ public abstract class MessageMarshaller extends BaseCommandMarshaller {
         info.setReplyTo((org.apache.activemq.command.ActiveMQDestination)looseUnmarsalNestedObject(wireFormat, dataIn));
         info.setTimestamp(looseUnmarshalLong(wireFormat, dataIn));
         info.setType(looseUnmarshalString(dataIn));
-        info.setContent(looseUnmarshalByteSequence(dataIn));
-        info.setMarshalledProperties(looseUnmarshalByteSequence(dataIn));
+        info.setContent(looseUnmarshalByteSequence(wireFormat, dataIn));
+        info.setMarshalledProperties(looseUnmarshalByteSequence(wireFormat, dataIn));
         info.setDataStructure((org.apache.activemq.command.DataStructure)looseUnmarsalNestedObject(wireFormat, dataIn));
         info.setTargetConsumerId((org.apache.activemq.command.ConsumerId)looseUnmarsalCachedObject(wireFormat, dataIn));
         info.setCompressed(dataIn.readBoolean());

--- a/activemq-client/src/main/java/org/apache/activemq/openwire/v1/PartialCommandMarshaller.java
+++ b/activemq-client/src/main/java/org/apache/activemq/openwire/v1/PartialCommandMarshaller.java
@@ -68,7 +68,7 @@ public class PartialCommandMarshaller extends BaseDataStreamMarshaller {
 
         PartialCommand info = (PartialCommand)o;
         info.setCommandId(dataIn.readInt());
-        info.setData(tightUnmarshalByteArray(dataIn, bs));
+        info.setData(tightUnmarshalByteArray(wireFormat, dataIn, bs));
 
     }
 
@@ -114,7 +114,7 @@ public class PartialCommandMarshaller extends BaseDataStreamMarshaller {
 
         PartialCommand info = (PartialCommand)o;
         info.setCommandId(dataIn.readInt());
-        info.setData(looseUnmarshalByteArray(dataIn));
+        info.setData(looseUnmarshalByteArray(wireFormat, dataIn));
 
     }
 

--- a/activemq-client/src/main/java/org/apache/activemq/openwire/v1/WireFormatInfoMarshaller.java
+++ b/activemq-client/src/main/java/org/apache/activemq/openwire/v1/WireFormatInfoMarshaller.java
@@ -72,7 +72,7 @@ public class WireFormatInfoMarshaller extends BaseDataStreamMarshaller {
         
         info.setMagic(tightUnmarshalConstByteArray(dataIn, bs, 8));
         info.setVersion(dataIn.readInt());
-        info.setMarshalledProperties(tightUnmarshalByteSequence(dataIn, bs));
+        info.setMarshalledProperties(tightUnmarshalByteSequence(wireFormat, dataIn, bs));
 
         info.afterUnmarshall(wireFormat);
 
@@ -130,7 +130,7 @@ public class WireFormatInfoMarshaller extends BaseDataStreamMarshaller {
         
         info.setMagic(looseUnmarshalConstByteArray(dataIn, 8));
         info.setVersion(dataIn.readInt());
-        info.setMarshalledProperties(looseUnmarshalByteSequence(dataIn));
+        info.setMarshalledProperties(looseUnmarshalByteSequence(wireFormat, dataIn));
 
         info.afterUnmarshall(wireFormat);
 

--- a/activemq-client/src/main/java/org/apache/activemq/openwire/v1/XATransactionIdMarshaller.java
+++ b/activemq-client/src/main/java/org/apache/activemq/openwire/v1/XATransactionIdMarshaller.java
@@ -68,8 +68,8 @@ public class XATransactionIdMarshaller extends TransactionIdMarshaller {
 
         XATransactionId info = (XATransactionId)o;
         info.setFormatId(dataIn.readInt());
-        info.setGlobalTransactionId(tightUnmarshalByteArray(dataIn, bs));
-        info.setBranchQualifier(tightUnmarshalByteArray(dataIn, bs));
+        info.setGlobalTransactionId(tightUnmarshalByteArray(wireFormat, dataIn, bs));
+        info.setBranchQualifier(tightUnmarshalByteArray(wireFormat, dataIn, bs));
 
     }
 
@@ -117,8 +117,8 @@ public class XATransactionIdMarshaller extends TransactionIdMarshaller {
 
         XATransactionId info = (XATransactionId)o;
         info.setFormatId(dataIn.readInt());
-        info.setGlobalTransactionId(looseUnmarshalByteArray(dataIn));
-        info.setBranchQualifier(looseUnmarshalByteArray(dataIn));
+        info.setGlobalTransactionId(looseUnmarshalByteArray(wireFormat, dataIn));
+        info.setBranchQualifier(looseUnmarshalByteArray(wireFormat, dataIn));
 
     }
 

--- a/activemq-client/src/main/java/org/apache/activemq/openwire/v10/BaseDataStreamMarshaller.java
+++ b/activemq-client/src/main/java/org/apache/activemq/openwire/v10/BaseDataStreamMarshaller.java
@@ -410,10 +410,11 @@ public abstract class BaseDataStreamMarshaller implements DataStreamMarshaller {
         }
     }
 
-    protected byte[] tightUnmarshalByteArray(DataInput dataIn, BooleanStream bs) throws IOException {
+    protected byte[] tightUnmarshalByteArray(OpenWireFormat wireFormat, DataInput dataIn, BooleanStream bs) throws IOException {
         byte rc[] = null;
         if (bs.readBoolean()) {
             int size = dataIn.readInt();
+            OpenWireUtil.validateBufferSize(wireFormat, size);
             rc = new byte[size];
             dataIn.readFully(rc);
         }
@@ -437,10 +438,11 @@ public abstract class BaseDataStreamMarshaller implements DataStreamMarshaller {
         }
     }
 
-    protected ByteSequence tightUnmarshalByteSequence(DataInput dataIn, BooleanStream bs) throws IOException {
+    protected ByteSequence tightUnmarshalByteSequence(OpenWireFormat wireFormat, DataInput dataIn, BooleanStream bs) throws IOException {
         ByteSequence rc = null;
         if (bs.readBoolean()) {
             int size = dataIn.readInt();
+            OpenWireUtil.validateBufferSize(wireFormat, size);
             byte[] t = new byte[size];
             dataIn.readFully(t);
             return new ByteSequence(t, 0, size);
@@ -617,10 +619,11 @@ public abstract class BaseDataStreamMarshaller implements DataStreamMarshaller {
         }
     }
 
-    protected byte[] looseUnmarshalByteArray(DataInput dataIn) throws IOException {
+    protected byte[] looseUnmarshalByteArray(OpenWireFormat wireFormat, DataInput dataIn) throws IOException {
         byte rc[] = null;
         if (dataIn.readBoolean()) {
             int size = dataIn.readInt();
+            OpenWireUtil.validateBufferSize(wireFormat, size);
             rc = new byte[size];
             dataIn.readFully(rc);
         }
@@ -636,10 +639,11 @@ public abstract class BaseDataStreamMarshaller implements DataStreamMarshaller {
         }
     }
 
-    protected ByteSequence looseUnmarshalByteSequence(DataInput dataIn) throws IOException {
+    protected ByteSequence looseUnmarshalByteSequence(OpenWireFormat wireFormat, DataInput dataIn) throws IOException {
         ByteSequence rc = null;
         if (dataIn.readBoolean()) {
             int size = dataIn.readInt();
+            OpenWireUtil.validateBufferSize(wireFormat, size);
             byte[] t = new byte[size];
             dataIn.readFully(t);
             rc = new ByteSequence(t, 0, size);

--- a/activemq-client/src/main/java/org/apache/activemq/openwire/v10/ConnectionControlMarshaller.java
+++ b/activemq-client/src/main/java/org/apache/activemq/openwire/v10/ConnectionControlMarshaller.java
@@ -74,7 +74,7 @@ public class ConnectionControlMarshaller extends BaseCommandMarshaller {
         info.setConnectedBrokers(tightUnmarshalString(dataIn, bs));
         info.setReconnectTo(tightUnmarshalString(dataIn, bs));
         info.setRebalanceConnection(bs.readBoolean());
-        info.setToken(tightUnmarshalByteArray(dataIn, bs));
+        info.setToken(tightUnmarshalByteArray(wireFormat, dataIn, bs));
 
     }
 
@@ -142,7 +142,7 @@ public class ConnectionControlMarshaller extends BaseCommandMarshaller {
         info.setConnectedBrokers(looseUnmarshalString(dataIn));
         info.setReconnectTo(looseUnmarshalString(dataIn));
         info.setRebalanceConnection(dataIn.readBoolean());
-        info.setToken(looseUnmarshalByteArray(dataIn));
+        info.setToken(looseUnmarshalByteArray(wireFormat, dataIn));
 
     }
 

--- a/activemq-client/src/main/java/org/apache/activemq/openwire/v10/MessageMarshaller.java
+++ b/activemq-client/src/main/java/org/apache/activemq/openwire/v10/MessageMarshaller.java
@@ -69,8 +69,8 @@ public abstract class MessageMarshaller extends BaseCommandMarshaller {
         info.setReplyTo((org.apache.activemq.command.ActiveMQDestination) tightUnmarsalNestedObject(wireFormat, dataIn, bs));
         info.setTimestamp(tightUnmarshalLong(wireFormat, dataIn, bs));
         info.setType(tightUnmarshalString(dataIn, bs));
-        info.setContent(tightUnmarshalByteSequence(dataIn, bs));
-        info.setMarshalledProperties(tightUnmarshalByteSequence(dataIn, bs));
+        info.setContent(tightUnmarshalByteSequence(wireFormat, dataIn, bs));
+        info.setMarshalledProperties(tightUnmarshalByteSequence(wireFormat, dataIn, bs));
         info.setDataStructure((org.apache.activemq.command.DataStructure) tightUnmarsalNestedObject(wireFormat, dataIn, bs));
         info.setTargetConsumerId((org.apache.activemq.command.ConsumerId) tightUnmarsalCachedObject(wireFormat, dataIn, bs));
         info.setCompressed(bs.readBoolean());
@@ -228,8 +228,8 @@ public abstract class MessageMarshaller extends BaseCommandMarshaller {
         info.setReplyTo((org.apache.activemq.command.ActiveMQDestination) looseUnmarsalNestedObject(wireFormat, dataIn));
         info.setTimestamp(looseUnmarshalLong(wireFormat, dataIn));
         info.setType(looseUnmarshalString(dataIn));
-        info.setContent(looseUnmarshalByteSequence(dataIn));
-        info.setMarshalledProperties(looseUnmarshalByteSequence(dataIn));
+        info.setContent(looseUnmarshalByteSequence(wireFormat, dataIn));
+        info.setMarshalledProperties(looseUnmarshalByteSequence(wireFormat, dataIn));
         info.setDataStructure((org.apache.activemq.command.DataStructure) looseUnmarsalNestedObject(wireFormat, dataIn));
         info.setTargetConsumerId((org.apache.activemq.command.ConsumerId) looseUnmarsalCachedObject(wireFormat, dataIn));
         info.setCompressed(dataIn.readBoolean());

--- a/activemq-client/src/main/java/org/apache/activemq/openwire/v10/PartialCommandMarshaller.java
+++ b/activemq-client/src/main/java/org/apache/activemq/openwire/v10/PartialCommandMarshaller.java
@@ -67,7 +67,7 @@ public class PartialCommandMarshaller extends BaseDataStreamMarshaller {
 
         PartialCommand info = (PartialCommand)o;
         info.setCommandId(dataIn.readInt());
-        info.setData(tightUnmarshalByteArray(dataIn, bs));
+        info.setData(tightUnmarshalByteArray(wireFormat, dataIn, bs));
 
     }
 
@@ -113,7 +113,7 @@ public class PartialCommandMarshaller extends BaseDataStreamMarshaller {
 
         PartialCommand info = (PartialCommand)o;
         info.setCommandId(dataIn.readInt());
-        info.setData(looseUnmarshalByteArray(dataIn));
+        info.setData(looseUnmarshalByteArray(wireFormat, dataIn));
 
     }
 

--- a/activemq-client/src/main/java/org/apache/activemq/openwire/v10/WireFormatInfoMarshaller.java
+++ b/activemq-client/src/main/java/org/apache/activemq/openwire/v10/WireFormatInfoMarshaller.java
@@ -71,7 +71,7 @@ public class WireFormatInfoMarshaller extends BaseDataStreamMarshaller {
         
         info.setMagic(tightUnmarshalConstByteArray(dataIn, bs, 8));
         info.setVersion(dataIn.readInt());
-        info.setMarshalledProperties(tightUnmarshalByteSequence(dataIn, bs));
+        info.setMarshalledProperties(tightUnmarshalByteSequence(wireFormat, dataIn, bs));
 
         info.afterUnmarshall(wireFormat);
 
@@ -129,7 +129,7 @@ public class WireFormatInfoMarshaller extends BaseDataStreamMarshaller {
         
         info.setMagic(looseUnmarshalConstByteArray(dataIn, 8));
         info.setVersion(dataIn.readInt());
-        info.setMarshalledProperties(looseUnmarshalByteSequence(dataIn));
+        info.setMarshalledProperties(looseUnmarshalByteSequence(wireFormat, dataIn));
 
         info.afterUnmarshall(wireFormat);
 

--- a/activemq-client/src/main/java/org/apache/activemq/openwire/v10/XATransactionIdMarshaller.java
+++ b/activemq-client/src/main/java/org/apache/activemq/openwire/v10/XATransactionIdMarshaller.java
@@ -67,8 +67,8 @@ public class XATransactionIdMarshaller extends TransactionIdMarshaller {
 
         XATransactionId info = (XATransactionId)o;
         info.setFormatId(dataIn.readInt());
-        info.setGlobalTransactionId(tightUnmarshalByteArray(dataIn, bs));
-        info.setBranchQualifier(tightUnmarshalByteArray(dataIn, bs));
+        info.setGlobalTransactionId(tightUnmarshalByteArray(wireFormat, dataIn, bs));
+        info.setBranchQualifier(tightUnmarshalByteArray(wireFormat, dataIn, bs));
 
     }
 
@@ -116,8 +116,8 @@ public class XATransactionIdMarshaller extends TransactionIdMarshaller {
 
         XATransactionId info = (XATransactionId)o;
         info.setFormatId(dataIn.readInt());
-        info.setGlobalTransactionId(looseUnmarshalByteArray(dataIn));
-        info.setBranchQualifier(looseUnmarshalByteArray(dataIn));
+        info.setGlobalTransactionId(looseUnmarshalByteArray(wireFormat, dataIn));
+        info.setBranchQualifier(looseUnmarshalByteArray(wireFormat, dataIn));
 
     }
 

--- a/activemq-client/src/main/java/org/apache/activemq/openwire/v11/BaseDataStreamMarshaller.java
+++ b/activemq-client/src/main/java/org/apache/activemq/openwire/v11/BaseDataStreamMarshaller.java
@@ -409,10 +409,11 @@ public abstract class BaseDataStreamMarshaller implements DataStreamMarshaller {
         }
     }
 
-    protected byte[] tightUnmarshalByteArray(DataInput dataIn, BooleanStream bs) throws IOException {
+    protected byte[] tightUnmarshalByteArray(OpenWireFormat wireFormat, DataInput dataIn, BooleanStream bs) throws IOException {
         byte rc[] = null;
         if (bs.readBoolean()) {
             int size = dataIn.readInt();
+            OpenWireUtil.validateBufferSize(wireFormat, size);
             rc = new byte[size];
             dataIn.readFully(rc);
         }
@@ -436,10 +437,11 @@ public abstract class BaseDataStreamMarshaller implements DataStreamMarshaller {
         }
     }
 
-    protected ByteSequence tightUnmarshalByteSequence(DataInput dataIn, BooleanStream bs) throws IOException {
+    protected ByteSequence tightUnmarshalByteSequence(OpenWireFormat wireFormat, DataInput dataIn, BooleanStream bs) throws IOException {
         ByteSequence rc = null;
         if (bs.readBoolean()) {
             int size = dataIn.readInt();
+            OpenWireUtil.validateBufferSize(wireFormat, size);
             byte[] t = new byte[size];
             dataIn.readFully(t);
             return new ByteSequence(t, 0, size);
@@ -616,10 +618,11 @@ public abstract class BaseDataStreamMarshaller implements DataStreamMarshaller {
         }
     }
 
-    protected byte[] looseUnmarshalByteArray(DataInput dataIn) throws IOException {
+    protected byte[] looseUnmarshalByteArray(OpenWireFormat wireFormat, DataInput dataIn) throws IOException {
         byte rc[] = null;
         if (dataIn.readBoolean()) {
             int size = dataIn.readInt();
+            OpenWireUtil.validateBufferSize(wireFormat, size);
             rc = new byte[size];
             dataIn.readFully(rc);
         }
@@ -635,10 +638,11 @@ public abstract class BaseDataStreamMarshaller implements DataStreamMarshaller {
         }
     }
 
-    protected ByteSequence looseUnmarshalByteSequence(DataInput dataIn) throws IOException {
+    protected ByteSequence looseUnmarshalByteSequence(OpenWireFormat wireFormat, DataInput dataIn) throws IOException {
         ByteSequence rc = null;
         if (dataIn.readBoolean()) {
             int size = dataIn.readInt();
+            OpenWireUtil.validateBufferSize(wireFormat, size);
             byte[] t = new byte[size];
             dataIn.readFully(t);
             rc = new ByteSequence(t, 0, size);

--- a/activemq-client/src/main/java/org/apache/activemq/openwire/v11/ConnectionControlMarshaller.java
+++ b/activemq-client/src/main/java/org/apache/activemq/openwire/v11/ConnectionControlMarshaller.java
@@ -74,7 +74,7 @@ public class ConnectionControlMarshaller extends BaseCommandMarshaller {
         info.setConnectedBrokers(tightUnmarshalString(dataIn, bs));
         info.setReconnectTo(tightUnmarshalString(dataIn, bs));
         info.setRebalanceConnection(bs.readBoolean());
-        info.setToken(tightUnmarshalByteArray(dataIn, bs));
+        info.setToken(tightUnmarshalByteArray(wireFormat, dataIn, bs));
 
     }
 
@@ -142,7 +142,7 @@ public class ConnectionControlMarshaller extends BaseCommandMarshaller {
         info.setConnectedBrokers(looseUnmarshalString(dataIn));
         info.setReconnectTo(looseUnmarshalString(dataIn));
         info.setRebalanceConnection(dataIn.readBoolean());
-        info.setToken(looseUnmarshalByteArray(dataIn));
+        info.setToken(looseUnmarshalByteArray(wireFormat, dataIn));
 
     }
 

--- a/activemq-client/src/main/java/org/apache/activemq/openwire/v11/MessageMarshaller.java
+++ b/activemq-client/src/main/java/org/apache/activemq/openwire/v11/MessageMarshaller.java
@@ -69,8 +69,8 @@ public abstract class MessageMarshaller extends BaseCommandMarshaller {
         info.setReplyTo((org.apache.activemq.command.ActiveMQDestination) tightUnmarsalNestedObject(wireFormat, dataIn, bs));
         info.setTimestamp(tightUnmarshalLong(wireFormat, dataIn, bs));
         info.setType(tightUnmarshalString(dataIn, bs));
-        info.setContent(tightUnmarshalByteSequence(dataIn, bs));
-        info.setMarshalledProperties(tightUnmarshalByteSequence(dataIn, bs));
+        info.setContent(tightUnmarshalByteSequence(wireFormat, dataIn, bs));
+        info.setMarshalledProperties(tightUnmarshalByteSequence(wireFormat, dataIn, bs));
         info.setDataStructure((org.apache.activemq.command.DataStructure) tightUnmarsalNestedObject(wireFormat, dataIn, bs));
         info.setTargetConsumerId((org.apache.activemq.command.ConsumerId) tightUnmarsalCachedObject(wireFormat, dataIn, bs));
         info.setCompressed(bs.readBoolean());
@@ -228,8 +228,8 @@ public abstract class MessageMarshaller extends BaseCommandMarshaller {
         info.setReplyTo((org.apache.activemq.command.ActiveMQDestination) looseUnmarsalNestedObject(wireFormat, dataIn));
         info.setTimestamp(looseUnmarshalLong(wireFormat, dataIn));
         info.setType(looseUnmarshalString(dataIn));
-        info.setContent(looseUnmarshalByteSequence(dataIn));
-        info.setMarshalledProperties(looseUnmarshalByteSequence(dataIn));
+        info.setContent(looseUnmarshalByteSequence(wireFormat, dataIn));
+        info.setMarshalledProperties(looseUnmarshalByteSequence(wireFormat, dataIn));
         info.setDataStructure((org.apache.activemq.command.DataStructure) looseUnmarsalNestedObject(wireFormat, dataIn));
         info.setTargetConsumerId((org.apache.activemq.command.ConsumerId) looseUnmarsalCachedObject(wireFormat, dataIn));
         info.setCompressed(dataIn.readBoolean());

--- a/activemq-client/src/main/java/org/apache/activemq/openwire/v11/PartialCommandMarshaller.java
+++ b/activemq-client/src/main/java/org/apache/activemq/openwire/v11/PartialCommandMarshaller.java
@@ -67,7 +67,7 @@ public class PartialCommandMarshaller extends BaseDataStreamMarshaller {
 
         PartialCommand info = (PartialCommand)o;
         info.setCommandId(dataIn.readInt());
-        info.setData(tightUnmarshalByteArray(dataIn, bs));
+        info.setData(tightUnmarshalByteArray(wireFormat, dataIn, bs));
 
     }
 
@@ -113,7 +113,7 @@ public class PartialCommandMarshaller extends BaseDataStreamMarshaller {
 
         PartialCommand info = (PartialCommand)o;
         info.setCommandId(dataIn.readInt());
-        info.setData(looseUnmarshalByteArray(dataIn));
+        info.setData(looseUnmarshalByteArray(wireFormat, dataIn));
 
     }
 

--- a/activemq-client/src/main/java/org/apache/activemq/openwire/v11/WireFormatInfoMarshaller.java
+++ b/activemq-client/src/main/java/org/apache/activemq/openwire/v11/WireFormatInfoMarshaller.java
@@ -71,7 +71,7 @@ public class WireFormatInfoMarshaller extends BaseDataStreamMarshaller {
         
         info.setMagic(tightUnmarshalConstByteArray(dataIn, bs, 8));
         info.setVersion(dataIn.readInt());
-        info.setMarshalledProperties(tightUnmarshalByteSequence(dataIn, bs));
+        info.setMarshalledProperties(tightUnmarshalByteSequence(wireFormat, dataIn, bs));
 
         info.afterUnmarshall(wireFormat);
 
@@ -129,7 +129,7 @@ public class WireFormatInfoMarshaller extends BaseDataStreamMarshaller {
         
         info.setMagic(looseUnmarshalConstByteArray(dataIn, 8));
         info.setVersion(dataIn.readInt());
-        info.setMarshalledProperties(looseUnmarshalByteSequence(dataIn));
+        info.setMarshalledProperties(looseUnmarshalByteSequence(wireFormat, dataIn));
 
         info.afterUnmarshall(wireFormat);
 

--- a/activemq-client/src/main/java/org/apache/activemq/openwire/v11/XATransactionIdMarshaller.java
+++ b/activemq-client/src/main/java/org/apache/activemq/openwire/v11/XATransactionIdMarshaller.java
@@ -67,8 +67,8 @@ public class XATransactionIdMarshaller extends TransactionIdMarshaller {
 
         XATransactionId info = (XATransactionId)o;
         info.setFormatId(dataIn.readInt());
-        info.setGlobalTransactionId(tightUnmarshalByteArray(dataIn, bs));
-        info.setBranchQualifier(tightUnmarshalByteArray(dataIn, bs));
+        info.setGlobalTransactionId(tightUnmarshalByteArray(wireFormat, dataIn, bs));
+        info.setBranchQualifier(tightUnmarshalByteArray(wireFormat, dataIn, bs));
 
     }
 
@@ -116,8 +116,8 @@ public class XATransactionIdMarshaller extends TransactionIdMarshaller {
 
         XATransactionId info = (XATransactionId)o;
         info.setFormatId(dataIn.readInt());
-        info.setGlobalTransactionId(looseUnmarshalByteArray(dataIn));
-        info.setBranchQualifier(looseUnmarshalByteArray(dataIn));
+        info.setGlobalTransactionId(looseUnmarshalByteArray(wireFormat, dataIn));
+        info.setBranchQualifier(looseUnmarshalByteArray(wireFormat, dataIn));
 
     }
 

--- a/activemq-client/src/main/java/org/apache/activemq/openwire/v12/BaseDataStreamMarshaller.java
+++ b/activemq-client/src/main/java/org/apache/activemq/openwire/v12/BaseDataStreamMarshaller.java
@@ -412,10 +412,11 @@ public abstract class BaseDataStreamMarshaller implements DataStreamMarshaller {
         }
     }
 
-    protected byte[] tightUnmarshalByteArray(DataInput dataIn, BooleanStream bs) throws IOException {
+    protected byte[] tightUnmarshalByteArray(OpenWireFormat wireFormat, DataInput dataIn, BooleanStream bs) throws IOException {
         byte rc[] = null;
         if (bs.readBoolean()) {
             int size = dataIn.readInt();
+            OpenWireUtil.validateBufferSize(wireFormat, size);
             rc = new byte[size];
             dataIn.readFully(rc);
         }
@@ -439,10 +440,11 @@ public abstract class BaseDataStreamMarshaller implements DataStreamMarshaller {
         }
     }
 
-    protected ByteSequence tightUnmarshalByteSequence(DataInput dataIn, BooleanStream bs) throws IOException {
+    protected ByteSequence tightUnmarshalByteSequence(OpenWireFormat wireFormat, DataInput dataIn, BooleanStream bs) throws IOException {
         ByteSequence rc = null;
         if (bs.readBoolean()) {
             int size = dataIn.readInt();
+            OpenWireUtil.validateBufferSize(wireFormat, size);
             byte[] t = new byte[size];
             dataIn.readFully(t);
             return new ByteSequence(t, 0, size);
@@ -619,10 +621,11 @@ public abstract class BaseDataStreamMarshaller implements DataStreamMarshaller {
         }
     }
 
-    protected byte[] looseUnmarshalByteArray(DataInput dataIn) throws IOException {
+    protected byte[] looseUnmarshalByteArray(OpenWireFormat wireFormat, DataInput dataIn) throws IOException {
         byte rc[] = null;
         if (dataIn.readBoolean()) {
             int size = dataIn.readInt();
+            OpenWireUtil.validateBufferSize(wireFormat, size);
             rc = new byte[size];
             dataIn.readFully(rc);
         }
@@ -638,10 +641,11 @@ public abstract class BaseDataStreamMarshaller implements DataStreamMarshaller {
         }
     }
 
-    protected ByteSequence looseUnmarshalByteSequence(DataInput dataIn) throws IOException {
+    protected ByteSequence looseUnmarshalByteSequence(OpenWireFormat wireFormat, DataInput dataIn) throws IOException {
         ByteSequence rc = null;
         if (dataIn.readBoolean()) {
             int size = dataIn.readInt();
+            OpenWireUtil.validateBufferSize(wireFormat, size);
             byte[] t = new byte[size];
             dataIn.readFully(t);
             rc = new ByteSequence(t, 0, size);

--- a/activemq-client/src/main/java/org/apache/activemq/openwire/v12/ConnectionControlMarshaller.java
+++ b/activemq-client/src/main/java/org/apache/activemq/openwire/v12/ConnectionControlMarshaller.java
@@ -74,7 +74,7 @@ public class ConnectionControlMarshaller extends BaseCommandMarshaller {
         info.setConnectedBrokers(tightUnmarshalString(dataIn, bs));
         info.setReconnectTo(tightUnmarshalString(dataIn, bs));
         info.setRebalanceConnection(bs.readBoolean());
-        info.setToken(tightUnmarshalByteArray(dataIn, bs));
+        info.setToken(tightUnmarshalByteArray(wireFormat, dataIn, bs));
 
     }
 
@@ -142,7 +142,7 @@ public class ConnectionControlMarshaller extends BaseCommandMarshaller {
         info.setConnectedBrokers(looseUnmarshalString(dataIn));
         info.setReconnectTo(looseUnmarshalString(dataIn));
         info.setRebalanceConnection(dataIn.readBoolean());
-        info.setToken(looseUnmarshalByteArray(dataIn));
+        info.setToken(looseUnmarshalByteArray(wireFormat, dataIn));
 
     }
 

--- a/activemq-client/src/main/java/org/apache/activemq/openwire/v12/MessageMarshaller.java
+++ b/activemq-client/src/main/java/org/apache/activemq/openwire/v12/MessageMarshaller.java
@@ -69,8 +69,8 @@ public abstract class MessageMarshaller extends BaseCommandMarshaller {
         info.setReplyTo((org.apache.activemq.command.ActiveMQDestination) tightUnmarsalNestedObject(wireFormat, dataIn, bs));
         info.setTimestamp(tightUnmarshalLong(wireFormat, dataIn, bs));
         info.setType(tightUnmarshalString(dataIn, bs));
-        info.setContent(tightUnmarshalByteSequence(dataIn, bs));
-        info.setMarshalledProperties(tightUnmarshalByteSequence(dataIn, bs));
+        info.setContent(tightUnmarshalByteSequence(wireFormat, dataIn, bs));
+        info.setMarshalledProperties(tightUnmarshalByteSequence(wireFormat, dataIn, bs));
         info.setDataStructure((org.apache.activemq.command.DataStructure) tightUnmarsalNestedObject(wireFormat, dataIn, bs));
         info.setTargetConsumerId((org.apache.activemq.command.ConsumerId) tightUnmarsalCachedObject(wireFormat, dataIn, bs));
         info.setCompressed(bs.readBoolean());
@@ -228,8 +228,8 @@ public abstract class MessageMarshaller extends BaseCommandMarshaller {
         info.setReplyTo((org.apache.activemq.command.ActiveMQDestination) looseUnmarsalNestedObject(wireFormat, dataIn));
         info.setTimestamp(looseUnmarshalLong(wireFormat, dataIn));
         info.setType(looseUnmarshalString(dataIn));
-        info.setContent(looseUnmarshalByteSequence(dataIn));
-        info.setMarshalledProperties(looseUnmarshalByteSequence(dataIn));
+        info.setContent(looseUnmarshalByteSequence(wireFormat, dataIn));
+        info.setMarshalledProperties(looseUnmarshalByteSequence(wireFormat, dataIn));
         info.setDataStructure((org.apache.activemq.command.DataStructure) looseUnmarsalNestedObject(wireFormat, dataIn));
         info.setTargetConsumerId((org.apache.activemq.command.ConsumerId) looseUnmarsalCachedObject(wireFormat, dataIn));
         info.setCompressed(dataIn.readBoolean());

--- a/activemq-client/src/main/java/org/apache/activemq/openwire/v12/PartialCommandMarshaller.java
+++ b/activemq-client/src/main/java/org/apache/activemq/openwire/v12/PartialCommandMarshaller.java
@@ -67,7 +67,7 @@ public class PartialCommandMarshaller extends BaseDataStreamMarshaller {
 
         PartialCommand info = (PartialCommand)o;
         info.setCommandId(dataIn.readInt());
-        info.setData(tightUnmarshalByteArray(dataIn, bs));
+        info.setData(tightUnmarshalByteArray(wireFormat, dataIn, bs));
 
     }
 
@@ -113,7 +113,7 @@ public class PartialCommandMarshaller extends BaseDataStreamMarshaller {
 
         PartialCommand info = (PartialCommand)o;
         info.setCommandId(dataIn.readInt());
-        info.setData(looseUnmarshalByteArray(dataIn));
+        info.setData(looseUnmarshalByteArray(wireFormat, dataIn));
 
     }
 

--- a/activemq-client/src/main/java/org/apache/activemq/openwire/v12/WireFormatInfoMarshaller.java
+++ b/activemq-client/src/main/java/org/apache/activemq/openwire/v12/WireFormatInfoMarshaller.java
@@ -71,7 +71,7 @@ public class WireFormatInfoMarshaller extends BaseDataStreamMarshaller {
         
         info.setMagic(tightUnmarshalConstByteArray(dataIn, bs, 8));
         info.setVersion(dataIn.readInt());
-        info.setMarshalledProperties(tightUnmarshalByteSequence(dataIn, bs));
+        info.setMarshalledProperties(tightUnmarshalByteSequence(wireFormat, dataIn, bs));
 
         info.afterUnmarshall(wireFormat);
 
@@ -129,7 +129,7 @@ public class WireFormatInfoMarshaller extends BaseDataStreamMarshaller {
         
         info.setMagic(looseUnmarshalConstByteArray(dataIn, 8));
         info.setVersion(dataIn.readInt());
-        info.setMarshalledProperties(looseUnmarshalByteSequence(dataIn));
+        info.setMarshalledProperties(looseUnmarshalByteSequence(wireFormat, dataIn));
 
         info.afterUnmarshall(wireFormat);
 

--- a/activemq-client/src/main/java/org/apache/activemq/openwire/v12/XATransactionIdMarshaller.java
+++ b/activemq-client/src/main/java/org/apache/activemq/openwire/v12/XATransactionIdMarshaller.java
@@ -67,8 +67,8 @@ public class XATransactionIdMarshaller extends TransactionIdMarshaller {
 
         XATransactionId info = (XATransactionId)o;
         info.setFormatId(dataIn.readInt());
-        info.setGlobalTransactionId(tightUnmarshalByteArray(dataIn, bs));
-        info.setBranchQualifier(tightUnmarshalByteArray(dataIn, bs));
+        info.setGlobalTransactionId(tightUnmarshalByteArray(wireFormat, dataIn, bs));
+        info.setBranchQualifier(tightUnmarshalByteArray(wireFormat, dataIn, bs));
 
     }
 
@@ -116,8 +116,8 @@ public class XATransactionIdMarshaller extends TransactionIdMarshaller {
 
         XATransactionId info = (XATransactionId)o;
         info.setFormatId(dataIn.readInt());
-        info.setGlobalTransactionId(looseUnmarshalByteArray(dataIn));
-        info.setBranchQualifier(looseUnmarshalByteArray(dataIn));
+        info.setGlobalTransactionId(looseUnmarshalByteArray(wireFormat, dataIn));
+        info.setBranchQualifier(looseUnmarshalByteArray(wireFormat, dataIn));
 
     }
 

--- a/activemq-client/src/main/java/org/apache/activemq/openwire/v9/BaseDataStreamMarshaller.java
+++ b/activemq-client/src/main/java/org/apache/activemq/openwire/v9/BaseDataStreamMarshaller.java
@@ -409,10 +409,11 @@ public abstract class BaseDataStreamMarshaller implements DataStreamMarshaller {
         }
     }
 
-    protected byte[] tightUnmarshalByteArray(DataInput dataIn, BooleanStream bs) throws IOException {
+    protected byte[] tightUnmarshalByteArray(OpenWireFormat wireFormat, DataInput dataIn, BooleanStream bs) throws IOException {
         byte rc[] = null;
         if (bs.readBoolean()) {
             int size = dataIn.readInt();
+            OpenWireUtil.validateBufferSize(wireFormat, size);
             rc = new byte[size];
             dataIn.readFully(rc);
         }
@@ -436,10 +437,11 @@ public abstract class BaseDataStreamMarshaller implements DataStreamMarshaller {
         }
     }
 
-    protected ByteSequence tightUnmarshalByteSequence(DataInput dataIn, BooleanStream bs) throws IOException {
+    protected ByteSequence tightUnmarshalByteSequence(OpenWireFormat wireFormat, DataInput dataIn, BooleanStream bs) throws IOException {
         ByteSequence rc = null;
         if (bs.readBoolean()) {
             int size = dataIn.readInt();
+            OpenWireUtil.validateBufferSize(wireFormat, size);
             byte[] t = new byte[size];
             dataIn.readFully(t);
             return new ByteSequence(t, 0, size);
@@ -616,10 +618,11 @@ public abstract class BaseDataStreamMarshaller implements DataStreamMarshaller {
         }
     }
 
-    protected byte[] looseUnmarshalByteArray(DataInput dataIn) throws IOException {
+    protected byte[] looseUnmarshalByteArray(OpenWireFormat wireFormat, DataInput dataIn) throws IOException {
         byte rc[] = null;
         if (dataIn.readBoolean()) {
             int size = dataIn.readInt();
+            OpenWireUtil.validateBufferSize(wireFormat, size);
             rc = new byte[size];
             dataIn.readFully(rc);
         }
@@ -635,10 +638,11 @@ public abstract class BaseDataStreamMarshaller implements DataStreamMarshaller {
         }
     }
 
-    protected ByteSequence looseUnmarshalByteSequence(DataInput dataIn) throws IOException {
+    protected ByteSequence looseUnmarshalByteSequence(OpenWireFormat wireFormat, DataInput dataIn) throws IOException {
         ByteSequence rc = null;
         if (dataIn.readBoolean()) {
             int size = dataIn.readInt();
+            OpenWireUtil.validateBufferSize(wireFormat, size);
             byte[] t = new byte[size];
             dataIn.readFully(t);
             rc = new ByteSequence(t, 0, size);

--- a/activemq-client/src/main/java/org/apache/activemq/openwire/v9/ConnectionControlMarshaller.java
+++ b/activemq-client/src/main/java/org/apache/activemq/openwire/v9/ConnectionControlMarshaller.java
@@ -74,7 +74,7 @@ public class ConnectionControlMarshaller extends BaseCommandMarshaller {
         info.setConnectedBrokers(tightUnmarshalString(dataIn, bs));
         info.setReconnectTo(tightUnmarshalString(dataIn, bs));
         info.setRebalanceConnection(bs.readBoolean());
-        info.setToken(tightUnmarshalByteArray(dataIn, bs));
+        info.setToken(tightUnmarshalByteArray(wireFormat, dataIn, bs));
 
     }
 
@@ -142,7 +142,7 @@ public class ConnectionControlMarshaller extends BaseCommandMarshaller {
         info.setConnectedBrokers(looseUnmarshalString(dataIn));
         info.setReconnectTo(looseUnmarshalString(dataIn));
         info.setRebalanceConnection(dataIn.readBoolean());
-        info.setToken(looseUnmarshalByteArray(dataIn));
+        info.setToken(looseUnmarshalByteArray(wireFormat, dataIn));
 
     }
 

--- a/activemq-client/src/main/java/org/apache/activemq/openwire/v9/MessageMarshaller.java
+++ b/activemq-client/src/main/java/org/apache/activemq/openwire/v9/MessageMarshaller.java
@@ -69,8 +69,8 @@ public abstract class MessageMarshaller extends BaseCommandMarshaller {
         info.setReplyTo((org.apache.activemq.command.ActiveMQDestination) tightUnmarsalNestedObject(wireFormat, dataIn, bs));
         info.setTimestamp(tightUnmarshalLong(wireFormat, dataIn, bs));
         info.setType(tightUnmarshalString(dataIn, bs));
-        info.setContent(tightUnmarshalByteSequence(dataIn, bs));
-        info.setMarshalledProperties(tightUnmarshalByteSequence(dataIn, bs));
+        info.setContent(tightUnmarshalByteSequence(wireFormat, dataIn, bs));
+        info.setMarshalledProperties(tightUnmarshalByteSequence(wireFormat, dataIn, bs));
         info.setDataStructure((org.apache.activemq.command.DataStructure) tightUnmarsalNestedObject(wireFormat, dataIn, bs));
         info.setTargetConsumerId((org.apache.activemq.command.ConsumerId) tightUnmarsalCachedObject(wireFormat, dataIn, bs));
         info.setCompressed(bs.readBoolean());
@@ -225,8 +225,8 @@ public abstract class MessageMarshaller extends BaseCommandMarshaller {
         info.setReplyTo((org.apache.activemq.command.ActiveMQDestination) looseUnmarsalNestedObject(wireFormat, dataIn));
         info.setTimestamp(looseUnmarshalLong(wireFormat, dataIn));
         info.setType(looseUnmarshalString(dataIn));
-        info.setContent(looseUnmarshalByteSequence(dataIn));
-        info.setMarshalledProperties(looseUnmarshalByteSequence(dataIn));
+        info.setContent(looseUnmarshalByteSequence(wireFormat, dataIn));
+        info.setMarshalledProperties(looseUnmarshalByteSequence(wireFormat, dataIn));
         info.setDataStructure((org.apache.activemq.command.DataStructure) looseUnmarsalNestedObject(wireFormat, dataIn));
         info.setTargetConsumerId((org.apache.activemq.command.ConsumerId) looseUnmarsalCachedObject(wireFormat, dataIn));
         info.setCompressed(dataIn.readBoolean());

--- a/activemq-client/src/main/java/org/apache/activemq/openwire/v9/PartialCommandMarshaller.java
+++ b/activemq-client/src/main/java/org/apache/activemq/openwire/v9/PartialCommandMarshaller.java
@@ -67,7 +67,7 @@ public class PartialCommandMarshaller extends BaseDataStreamMarshaller {
 
         PartialCommand info = (PartialCommand)o;
         info.setCommandId(dataIn.readInt());
-        info.setData(tightUnmarshalByteArray(dataIn, bs));
+        info.setData(tightUnmarshalByteArray(wireFormat, dataIn, bs));
 
     }
 
@@ -113,7 +113,7 @@ public class PartialCommandMarshaller extends BaseDataStreamMarshaller {
 
         PartialCommand info = (PartialCommand)o;
         info.setCommandId(dataIn.readInt());
-        info.setData(looseUnmarshalByteArray(dataIn));
+        info.setData(looseUnmarshalByteArray(wireFormat, dataIn));
 
     }
 

--- a/activemq-client/src/main/java/org/apache/activemq/openwire/v9/WireFormatInfoMarshaller.java
+++ b/activemq-client/src/main/java/org/apache/activemq/openwire/v9/WireFormatInfoMarshaller.java
@@ -71,7 +71,7 @@ public class WireFormatInfoMarshaller extends BaseDataStreamMarshaller {
         
         info.setMagic(tightUnmarshalConstByteArray(dataIn, bs, 8));
         info.setVersion(dataIn.readInt());
-        info.setMarshalledProperties(tightUnmarshalByteSequence(dataIn, bs));
+        info.setMarshalledProperties(tightUnmarshalByteSequence(wireFormat, dataIn, bs));
 
         info.afterUnmarshall(wireFormat);
 
@@ -129,7 +129,7 @@ public class WireFormatInfoMarshaller extends BaseDataStreamMarshaller {
         
         info.setMagic(looseUnmarshalConstByteArray(dataIn, 8));
         info.setVersion(dataIn.readInt());
-        info.setMarshalledProperties(looseUnmarshalByteSequence(dataIn));
+        info.setMarshalledProperties(looseUnmarshalByteSequence(wireFormat, dataIn));
 
         info.afterUnmarshall(wireFormat);
 

--- a/activemq-client/src/main/java/org/apache/activemq/openwire/v9/XATransactionIdMarshaller.java
+++ b/activemq-client/src/main/java/org/apache/activemq/openwire/v9/XATransactionIdMarshaller.java
@@ -67,8 +67,8 @@ public class XATransactionIdMarshaller extends TransactionIdMarshaller {
 
         XATransactionId info = (XATransactionId)o;
         info.setFormatId(dataIn.readInt());
-        info.setGlobalTransactionId(tightUnmarshalByteArray(dataIn, bs));
-        info.setBranchQualifier(tightUnmarshalByteArray(dataIn, bs));
+        info.setGlobalTransactionId(tightUnmarshalByteArray(wireFormat, dataIn, bs));
+        info.setBranchQualifier(tightUnmarshalByteArray(wireFormat, dataIn, bs));
 
     }
 
@@ -116,8 +116,8 @@ public class XATransactionIdMarshaller extends TransactionIdMarshaller {
 
         XATransactionId info = (XATransactionId)o;
         info.setFormatId(dataIn.readInt());
-        info.setGlobalTransactionId(looseUnmarshalByteArray(dataIn));
-        info.setBranchQualifier(looseUnmarshalByteArray(dataIn));
+        info.setGlobalTransactionId(looseUnmarshalByteArray(wireFormat, dataIn));
+        info.setBranchQualifier(looseUnmarshalByteArray(wireFormat, dataIn));
 
     }
 

--- a/activemq-client/src/main/java/org/apache/activemq/util/IOExceptionSupport.java
+++ b/activemq-client/src/main/java/org/apache/activemq/util/IOExceptionSupport.java
@@ -52,7 +52,13 @@ public final class IOExceptionSupport {
 
     public static IOException createFrameSizeException(int size, long maxSize) {
         return new MaxFrameSizeExceededException("Frame size of " + toHumanReadableSizeString(size) +
-            " larger than max allowed " + toHumanReadableSizeString(maxSize));
+            " is larger than max allowed " + toHumanReadableSizeString(maxSize));
+    }
+
+    public static IOException createFrameSizeBufferException(int bufferSize, long frameSize) {
+        return new IOException("Estimated allocated buffer size of "
+          + toHumanReadableSizeString(bufferSize) + " is larger than frame size of "
+          + toHumanReadableSizeString(frameSize));
     }
 
     private static String toHumanReadableSizeString(final int size) {

--- a/activemq-client/src/test/java/org/apache/activemq/openwire/OpenWireUtilTest.java
+++ b/activemq-client/src/test/java/org/apache/activemq/openwire/OpenWireUtilTest.java
@@ -1,0 +1,103 @@
+package org.apache.activemq.openwire;
+
+
+import jakarta.jms.InvalidClientIDException;
+import jakarta.jms.JMSException;
+import org.apache.activemq.ActiveMQConnection;
+import org.apache.activemq.MaxFrameSizeExceededException;
+import org.apache.activemq.command.WireFormatInfo;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class OpenWireUtilTest {
+
+    @Test
+    public void testValidateIsThrowable() {
+        OpenWireUtil.validateIsThrowable(Exception.class);
+        OpenWireUtil.validateIsThrowable(Throwable.class);
+        OpenWireUtil.validateIsThrowable(JMSException.class);
+        OpenWireUtil.validateIsThrowable(InvalidClientIDException.class);
+
+        try {
+            OpenWireUtil.validateIsThrowable(String.class);
+            fail("Not a valid Throwable");
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
+
+        try {
+            OpenWireUtil.validateIsThrowable(ActiveMQConnection.class);
+            fail("Not a valid Throwable");
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
+    }
+
+    @Test
+    public void testConvertJmsPackage() {
+        // should not change
+        assertEquals(InvalidClientIDException.class.getName(),
+            OpenWireUtil.convertJmsPackage(InvalidClientIDException.class.getName()));
+
+        // should convert to correct exception type
+        assertEquals(InvalidClientIDException.class.getName(),
+            OpenWireUtil.convertJmsPackage(OpenWireUtil.jmsPackageToReplace + ".InvalidClientIDException"));
+    }
+
+    @Test
+    public void testValidateBufferSize() throws IOException {
+        OpenWireFormatFactory factory = new OpenWireFormatFactory();
+
+        var wireFormat = (OpenWireFormat) factory.createWireFormat();
+
+        // Nothing set, no validation
+        OpenWireUtil.validateBufferSize(wireFormat, 2048);
+
+        // verify max frame check works
+        try {
+            wireFormat.setMaxFrameSize(1024);
+            OpenWireUtil.validateBufferSize(wireFormat, 2048);
+            fail("should have failed");
+        } catch (MaxFrameSizeExceededException e) {
+            // expected
+        }
+
+        // rest max frame size back so we can test validating current size
+        // is less than expected buffer size
+        wireFormat.setMaxFrameSize(OpenWireFormat.DEFAULT_MAX_FRAME_SIZE);
+        WireFormatInfo wfi = new WireFormatInfo();
+        wfi.setProperty("test", "test");
+
+        // should be no error for the first 2 calls, last call should
+        // go over frame size and error
+        initContext(wireFormat, 2048);
+        OpenWireUtil.validateBufferSize(wireFormat, 1024);
+        OpenWireUtil.validateBufferSize(wireFormat, 1024);
+        try {
+            OpenWireUtil.validateBufferSize(wireFormat, 1);
+            fail("should have failed");
+        } catch (IOException e) {
+            // expected
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void initContext(OpenWireFormat format, int frameSize) throws IOException {
+        try {
+            Field mcThreadLocalField = OpenWireFormat.class.getDeclaredField("marshallingContext");
+            mcThreadLocalField.setAccessible(true);
+            var mcThreadLocal = (ThreadLocal<OpenWireFormat.MarshallingContext>) mcThreadLocalField.get(format);
+            var context = new OpenWireFormat.MarshallingContext();
+            context.setFrameSize(frameSize);
+            mcThreadLocal.set(context);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/activemq-client/src/test/java/org/apache/activemq/openwire/OpenWireValidationTest.java
+++ b/activemq-client/src/test/java/org/apache/activemq/openwire/OpenWireValidationTest.java
@@ -16,19 +16,24 @@
  */
 package org.apache.activemq.openwire;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
+import java.io.DataInputStream;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
-import org.apache.activemq.command.CommandTypes;
-import org.apache.activemq.command.ExceptionResponse;
+
+import javassist.util.proxy.MethodHandler;
+import javassist.util.proxy.ProxyFactory;
+import javassist.util.proxy.ProxyObject;
+import org.apache.activemq.command.*;
+import org.apache.activemq.openwire.v1.BaseDataStreamMarshaller;
+import org.apache.activemq.transport.nio.NIOInputStream;
 import org.apache.activemq.util.ByteSequence;
 import org.junit.Before;
 import org.junit.Test;
@@ -36,9 +41,10 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
+import static org.junit.Assert.*;
+
 /**
- * Test that Openwire marshalling will validate Throwable types during
- * unmarshalling commands that contain a Throwable
+ * Test that Openwire marshalling will validate commands correctly
  */
 @RunWith(Parameterized.class)
 public class OpenWireValidationTest {
@@ -63,7 +69,7 @@ public class OpenWireValidationTest {
         // This will make sure that we don't forget to update this test to include
         // any future versions that are generated
         assertTrue("List of Openwire versions does not include latest version",
-            versions.contains((int)CommandTypes.PROTOCOL_VERSION));
+            versions.contains((int) CommandTypes.PROTOCOL_VERSION));
 
         return versionObjs;
     }
@@ -73,20 +79,97 @@ public class OpenWireValidationTest {
     }
 
     @Test
+    public void testLooseUnmarshalByteSequenceValidation() throws Exception {
+        testUnmarshalByteSequenceValidation(false);
+    }
+
+    @Test
+    public void testTightUnmarshalByteSequenceValidation() throws Exception {
+        testUnmarshalByteSequenceValidation(true);
+    }
+
+    @Test
+    public void testLooseUnmarshalByteArray() throws Exception {
+        testUnmarshalByteArray(false);
+    }
+
+    @Test
+    public void testTightUnmarshalByteArray() throws Exception {
+        testUnmarshalByteArray(true);
+    }
+
+    // WireFormatInfo eventually delegates to BaseDataStreamMarshaller#tightUnmarshalByteSequence() and
+    // BaseDataStreamMarshaller#looseUnmarshalByteSequence()
+    private void testUnmarshalByteSequenceValidation(boolean tightEncoding) throws Exception {
+        WireFormatInfo wfi = new WireFormatInfo();
+        wfi.setProperty("prop1", "val1");
+        testUnmarshal(wfi, tightEncoding);
+    }
+
+    // PartialCommand eventually delegates to BaseDataStreamMarshaller#tightUnmarshalByteArray()
+    // and BaseDataStreamMarshaller#looseUnmarshalByteArray()
+    private void testUnmarshalByteArray(boolean tightEncoding) throws Exception {
+        PartialCommand pc = new PartialCommand();
+        pc.setData("bytes".getBytes(StandardCharsets.UTF_8));
+        testUnmarshal(pc, tightEncoding);
+    }
+
+    private void testUnmarshal(Command command, boolean tightEncoding) throws Exception {
+        var format = setupWireFormat(tightEncoding);
+        ByteSequence bss = format.marshal(command);
+        try {
+            // We should get an exception from an invalid size value that is too large
+            // Test OpenWireFormat#unmarshal(ByteSequence) method
+            format.unmarshal(bss);
+            fail("Should have received an IOException");
+        } catch (IOException io) {
+            assertTrue(io.getMessage().contains("Estimated allocated buffer size"));
+            assertTrue(io.getMessage().contains("is larger than frame size"));
+        }
+        // Verify thread local is cleared even after exception
+        assertNull(format.getMarshallingContext());
+
+        try {
+            // We should get an exception from an invalid size value that is too large
+            // Test OpenWireFormat#unmarshal(DataInput) method
+            format.unmarshal(new DataInputStream(new NIOInputStream(
+                ByteBuffer.wrap(bss.toArray()))));
+            fail("Should have received an IOException");
+        } catch (IOException io) {
+            assertTrue(io.getMessage().contains("Estimated allocated buffer size"));
+            assertTrue(io.getMessage().contains("is larger than frame size"));
+        }
+        // Verify thread local is cleared even after exception
+        assertNull(format.getMarshallingContext());
+    }
+
+    // Verify MarshallingContext thread local is cleared where there is
+    // successful unmarshalling and no error. The other tests that check
+    // validation works if invalid size will validate the context is cleared
+    // when there is an error
+    @Test
+    public void testUnmarshalNoErrorClearContext() throws Exception {
+        var format = new OpenWireFormat();
+        ByteSequence bss = format.marshal(new ConnectionInfo());
+
+        // make sure context cleared after calling
+        // OpenWireFormat#unmarshal(ByteSequence) method
+        format.unmarshal(bss);
+        assertNull(format.getMarshallingContext());
+
+        // Make sure context cleared after calling
+        // OpenWireFormat#unmarshal(DataInput) method
+        format.unmarshal(new DataInputStream(new NIOInputStream(
+            ByteBuffer.wrap(bss.toArray()))));
+        assertNull(format.getMarshallingContext());
+    }
+
+    @Test
     public void testOpenwireThrowableValidation() throws Exception {
         // Create a format which will use loose encoding by default
         // The code for handling exception creation is shared between both
         // tight/loose encoding so only need to test 1
-        OpenWireFormat format = new OpenWireFormat();
-
-        // Override the marshaller map with a custom impl to purposely marshal a class type that is
-        // not a Throwable for testing the unmarshaller
-        Class<?> marshallerFactory = getMarshallerFactory();
-        Method createMarshallerMap = marshallerFactory.getMethod("createMarshallerMap", OpenWireFormat.class);
-        DataStreamMarshaller[] map = (DataStreamMarshaller[]) createMarshallerMap.invoke(marshallerFactory, format);
-        map[ExceptionResponse.DATA_STRUCTURE_TYPE] = getExceptionMarshaller();
-        // This will trigger updating the marshaller from the marshaller map with the right version
-        format.setVersion(version);
+        var format = setupWireFormat(false);
 
         // Build the response and try to unmarshal which should give an IllegalArgumentExeption on unmarshall
         // as the test marshaller should have encoded a class type that is not a Throwable
@@ -100,6 +183,23 @@ public class OpenWireValidationTest {
 
         // assert the class was never initialized
         assertFalse(initialized.get());
+    }
+
+    private OpenWireFormat setupWireFormat(boolean tightEncoding) throws Exception {
+        // Create a format
+        OpenWireFormat format = new OpenWireFormat();
+        format.setTightEncodingEnabled(tightEncoding);
+
+        // Override the marshaller map with a custom impl to purposely marshal a bad size value
+        Class<?> marshallerFactory = getMarshallerFactory();
+        Method createMarshallerMap = marshallerFactory.getMethod("createMarshallerMap", OpenWireFormat.class);
+        DataStreamMarshaller[] map = (DataStreamMarshaller[]) createMarshallerMap.invoke(marshallerFactory, format);
+        map[ExceptionResponse.DATA_STRUCTURE_TYPE] = getExceptionMarshaller();
+        map[WireFormatInfo.DATA_STRUCTURE_TYPE] = getWireFormatInfoMarshaller();
+        map[PartialCommand.DATA_STRUCTURE_TYPE] = getPartialCommandMarshaller();
+        // This will trigger updating the marshaller from the marshaller map with the right version
+        format.setVersion(version);
+        return format;
     }
 
     static class NotAThrowable {
@@ -181,4 +281,127 @@ public class OpenWireValidationTest {
         }
     }
 
+    // Create test marshallers for all non-legacy versions
+    // WireFormatInfo will test the bytesequence marshallers
+    protected DataStreamMarshaller getWireFormatInfoMarshaller() {
+        switch (version) {
+            case 12:
+                return proxyBadBufferCommand(new org.apache.activemq.openwire.v12.WireFormatInfoMarshaller());
+            case 11:
+                return proxyBadBufferCommand(new org.apache.activemq.openwire.v11.WireFormatInfoMarshaller());
+            case 10:
+                return proxyBadBufferCommand(new org.apache.activemq.openwire.v10.WireFormatInfoMarshaller());
+            case 9:
+                return proxyBadBufferCommand(new org.apache.activemq.openwire.v9.WireFormatInfoMarshaller());
+            case 1:
+                return proxyBadBufferCommand(new org.apache.activemq.openwire.v1.WireFormatInfoMarshaller());
+            default:
+                throw new IllegalArgumentException("Unknown OpenWire version of " + version);
+        }
+    }
+
+    // PartialCommand will test the byte array marshallers
+    protected DataStreamMarshaller getPartialCommandMarshaller() {
+        switch (version) {
+            case 12:
+                return proxyBadBufferCommand(new org.apache.activemq.openwire.v12.PartialCommandMarshaller());
+            case 11:
+                return proxyBadBufferCommand(new org.apache.activemq.openwire.v11.PartialCommandMarshaller());
+            case 10:
+                return proxyBadBufferCommand(new org.apache.activemq.openwire.v10.PartialCommandMarshaller());
+            case 9:
+                return proxyBadBufferCommand(new org.apache.activemq.openwire.v9.PartialCommandMarshaller());
+            case 1:
+                return proxyBadBufferCommand(new org.apache.activemq.openwire.v1.PartialCommandMarshaller());
+            default:
+                throw new IllegalArgumentException("Unknown OpenWire version of " + version);
+        }
+    }
+
+    protected static void badTightMarshalByteSequence(ByteSequence data, DataOutput dataOut,
+                                               BooleanStream bs) throws IOException {
+        if (bs.readBoolean()) {
+            // Write an invalid length that is much larger than it should be
+            dataOut.writeInt(data.getLength() * 10);
+            dataOut.write(data.getData(), data.getOffset(), data.getLength());
+        }
+    }
+
+    protected static void badLooseMarshalByteSequence(ByteSequence data, DataOutput dataOut)
+        throws IOException {
+        dataOut.writeBoolean(data != null);
+        if (data != null) {
+            // Write an invalid length that is much larger than it should be
+            dataOut.writeInt(data.getLength() * 10);
+            dataOut.write(data.getData(), data.getOffset(), data.getLength());
+        }
+    }
+
+    protected static void badLooseMarshalByteArray(byte[] data,
+                                            DataOutput dataOut) throws IOException {
+        dataOut.writeBoolean(data != null);
+        if (data != null) {
+            // Write an invalid length that is much larger than it should be
+            dataOut.writeInt(data.length * 10);
+            dataOut.write(data);
+        }
+    }
+
+    protected static void badTightMarshalByteArray(byte[] data, DataOutput dataOut,
+                                            BooleanStream bs) throws IOException {
+        if (bs.readBoolean()) {
+            // Write an invalid length that is much larger than it should be
+            dataOut.writeInt(data.length * 10);
+            dataOut.write(data);
+        }
+    }
+
+    // This will create a proxy object to wrap the marhallers so that we can intercept
+    // both the byte and bytesequence methods to write bad sizes for testing
+    protected DataStreamMarshaller proxyBadBufferCommand(DataStreamMarshaller marshaller) {
+        ProxyFactory factory = new ProxyFactory();
+        factory.setSuperclass(marshaller.getClass());
+        Class<?> clazz = factory.createClass();
+
+        try {
+            DataStreamMarshaller instance = (DataStreamMarshaller) clazz.getConstructor().newInstance();
+            ((ProxyObject) instance).setHandler(new BadBufferProxy());
+            return instance;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    protected static class BadBufferProxy implements MethodHandler {
+
+        @Override
+        public Object invoke(Object self, Method thisMethod, Method proceed, Object[] args) throws Throwable {
+            Object result = null;
+
+            try {
+                // This handles writing a bad size for all 4 types of methods that should validate
+                switch (thisMethod.getName()) {
+                    case "looseMarshalByteArray":
+                        badLooseMarshalByteArray((byte[]) args[1], (DataOutput) args[2]);
+                        break;
+                    case "tightMarshalByteArray2":
+                        badTightMarshalByteArray((byte[]) args[0], (DataOutput) args[1], (BooleanStream) args[2]);
+                        break;
+                    case "looseMarshalByteSequence":
+                        badLooseMarshalByteSequence((ByteSequence) args[1], (DataOutput) args[2]);
+                        break;
+                    case "tightMarshalByteSequence2":
+                        badTightMarshalByteSequence((ByteSequence) args[0], (DataOutput) args[1], (BooleanStream) args[2]);
+                        break;
+                    default:
+                        result = proceed.invoke(self, args);
+                        break;
+                }
+            } catch (InvocationTargetException e) {
+                throw e.getCause();
+            }
+
+            return result;
+        }
+    }
 }

--- a/activemq-openwire-legacy/pom.xml
+++ b/activemq-openwire-legacy/pom.xml
@@ -47,6 +47,11 @@
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.javassist</groupId>
+      <artifactId>javassist</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v2/BaseDataStreamMarshaller.java
+++ b/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v2/BaseDataStreamMarshaller.java
@@ -410,10 +410,11 @@ public abstract class BaseDataStreamMarshaller implements DataStreamMarshaller {
         }
     }
 
-    protected byte[] tightUnmarshalByteArray(DataInput dataIn, BooleanStream bs) throws IOException {
+    protected byte[] tightUnmarshalByteArray(OpenWireFormat wireFormat, DataInput dataIn, BooleanStream bs) throws IOException {
         byte rc[] = null;
         if (bs.readBoolean()) {
             int size = dataIn.readInt();
+            OpenWireUtil.validateBufferSize(wireFormat, size);
             rc = new byte[size];
             dataIn.readFully(rc);
         }
@@ -437,10 +438,11 @@ public abstract class BaseDataStreamMarshaller implements DataStreamMarshaller {
         }
     }
 
-    protected ByteSequence tightUnmarshalByteSequence(DataInput dataIn, BooleanStream bs) throws IOException {
+    protected ByteSequence tightUnmarshalByteSequence(OpenWireFormat wireFormat, DataInput dataIn, BooleanStream bs) throws IOException {
         ByteSequence rc = null;
         if (bs.readBoolean()) {
             int size = dataIn.readInt();
+            OpenWireUtil.validateBufferSize(wireFormat, size);
             byte[] t = new byte[size];
             dataIn.readFully(t);
             return new ByteSequence(t, 0, size);
@@ -617,10 +619,11 @@ public abstract class BaseDataStreamMarshaller implements DataStreamMarshaller {
         }
     }
 
-    protected byte[] looseUnmarshalByteArray(DataInput dataIn) throws IOException {
+    protected byte[] looseUnmarshalByteArray(OpenWireFormat wireFormat, DataInput dataIn) throws IOException {
         byte rc[] = null;
         if (dataIn.readBoolean()) {
             int size = dataIn.readInt();
+            OpenWireUtil.validateBufferSize(wireFormat, size);
             rc = new byte[size];
             dataIn.readFully(rc);
         }
@@ -636,10 +639,11 @@ public abstract class BaseDataStreamMarshaller implements DataStreamMarshaller {
         }
     }
 
-    protected ByteSequence looseUnmarshalByteSequence(DataInput dataIn) throws IOException {
+    protected ByteSequence looseUnmarshalByteSequence(OpenWireFormat wireFormat, DataInput dataIn) throws IOException {
         ByteSequence rc = null;
         if (dataIn.readBoolean()) {
             int size = dataIn.readInt();
+            OpenWireUtil.validateBufferSize(wireFormat, size);
             byte[] t = new byte[size];
             dataIn.readFully(t);
             rc = new ByteSequence(t, 0, size);

--- a/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v2/MessageMarshaller.java
+++ b/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v2/MessageMarshaller.java
@@ -65,8 +65,8 @@ public abstract class MessageMarshaller extends BaseCommandMarshaller {
         info.setReplyTo((org.apache.activemq.command.ActiveMQDestination)tightUnmarsalNestedObject(wireFormat, dataIn, bs));
         info.setTimestamp(tightUnmarshalLong(wireFormat, dataIn, bs));
         info.setType(tightUnmarshalString(dataIn, bs));
-        info.setContent(tightUnmarshalByteSequence(dataIn, bs));
-        info.setMarshalledProperties(tightUnmarshalByteSequence(dataIn, bs));
+        info.setContent(tightUnmarshalByteSequence(wireFormat, dataIn, bs));
+        info.setMarshalledProperties(tightUnmarshalByteSequence(wireFormat, dataIn, bs));
         info.setDataStructure((org.apache.activemq.command.DataStructure)tightUnmarsalNestedObject(wireFormat, dataIn, bs));
         info.setTargetConsumerId((org.apache.activemq.command.ConsumerId)tightUnmarsalCachedObject(wireFormat, dataIn, bs));
         info.setCompressed(bs.readBoolean());
@@ -199,8 +199,8 @@ public abstract class MessageMarshaller extends BaseCommandMarshaller {
         info.setReplyTo((org.apache.activemq.command.ActiveMQDestination)looseUnmarsalNestedObject(wireFormat, dataIn));
         info.setTimestamp(looseUnmarshalLong(wireFormat, dataIn));
         info.setType(looseUnmarshalString(dataIn));
-        info.setContent(looseUnmarshalByteSequence(dataIn));
-        info.setMarshalledProperties(looseUnmarshalByteSequence(dataIn));
+        info.setContent(looseUnmarshalByteSequence(wireFormat, dataIn));
+        info.setMarshalledProperties(looseUnmarshalByteSequence(wireFormat, dataIn));
         info.setDataStructure((org.apache.activemq.command.DataStructure)looseUnmarsalNestedObject(wireFormat, dataIn));
         info.setTargetConsumerId((org.apache.activemq.command.ConsumerId)looseUnmarsalCachedObject(wireFormat, dataIn));
         info.setCompressed(dataIn.readBoolean());

--- a/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v2/PartialCommandMarshaller.java
+++ b/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v2/PartialCommandMarshaller.java
@@ -68,7 +68,7 @@ public class PartialCommandMarshaller extends BaseDataStreamMarshaller {
 
         PartialCommand info = (PartialCommand)o;
         info.setCommandId(dataIn.readInt());
-        info.setData(tightUnmarshalByteArray(dataIn, bs));
+        info.setData(tightUnmarshalByteArray(wireFormat, dataIn, bs));
 
     }
 
@@ -114,7 +114,7 @@ public class PartialCommandMarshaller extends BaseDataStreamMarshaller {
 
         PartialCommand info = (PartialCommand)o;
         info.setCommandId(dataIn.readInt());
-        info.setData(looseUnmarshalByteArray(dataIn));
+        info.setData(looseUnmarshalByteArray(wireFormat, dataIn));
 
     }
 

--- a/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v2/WireFormatInfoMarshaller.java
+++ b/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v2/WireFormatInfoMarshaller.java
@@ -72,7 +72,7 @@ public class WireFormatInfoMarshaller extends BaseDataStreamMarshaller {
         
         info.setMagic(tightUnmarshalConstByteArray(dataIn, bs, 8));
         info.setVersion(dataIn.readInt());
-        info.setMarshalledProperties(tightUnmarshalByteSequence(dataIn, bs));
+        info.setMarshalledProperties(tightUnmarshalByteSequence(wireFormat, dataIn, bs));
 
         info.afterUnmarshall(wireFormat);
 
@@ -130,7 +130,7 @@ public class WireFormatInfoMarshaller extends BaseDataStreamMarshaller {
         
         info.setMagic(looseUnmarshalConstByteArray(dataIn, 8));
         info.setVersion(dataIn.readInt());
-        info.setMarshalledProperties(looseUnmarshalByteSequence(dataIn));
+        info.setMarshalledProperties(looseUnmarshalByteSequence(wireFormat, dataIn));
 
         info.afterUnmarshall(wireFormat);
 

--- a/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v2/XATransactionIdMarshaller.java
+++ b/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v2/XATransactionIdMarshaller.java
@@ -68,8 +68,8 @@ public class XATransactionIdMarshaller extends TransactionIdMarshaller {
 
         XATransactionId info = (XATransactionId)o;
         info.setFormatId(dataIn.readInt());
-        info.setGlobalTransactionId(tightUnmarshalByteArray(dataIn, bs));
-        info.setBranchQualifier(tightUnmarshalByteArray(dataIn, bs));
+        info.setGlobalTransactionId(tightUnmarshalByteArray(wireFormat, dataIn, bs));
+        info.setBranchQualifier(tightUnmarshalByteArray(wireFormat, dataIn, bs));
 
     }
 
@@ -117,8 +117,8 @@ public class XATransactionIdMarshaller extends TransactionIdMarshaller {
 
         XATransactionId info = (XATransactionId)o;
         info.setFormatId(dataIn.readInt());
-        info.setGlobalTransactionId(looseUnmarshalByteArray(dataIn));
-        info.setBranchQualifier(looseUnmarshalByteArray(dataIn));
+        info.setGlobalTransactionId(looseUnmarshalByteArray(wireFormat, dataIn));
+        info.setBranchQualifier(looseUnmarshalByteArray(wireFormat, dataIn));
 
     }
 

--- a/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v3/BaseDataStreamMarshaller.java
+++ b/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v3/BaseDataStreamMarshaller.java
@@ -410,10 +410,11 @@ public abstract class BaseDataStreamMarshaller implements DataStreamMarshaller {
         }
     }
 
-    protected byte[] tightUnmarshalByteArray(DataInput dataIn, BooleanStream bs) throws IOException {
+    protected byte[] tightUnmarshalByteArray(OpenWireFormat wireFormat, DataInput dataIn, BooleanStream bs) throws IOException {
         byte rc[] = null;
         if (bs.readBoolean()) {
             int size = dataIn.readInt();
+            OpenWireUtil.validateBufferSize(wireFormat, size);
             rc = new byte[size];
             dataIn.readFully(rc);
         }
@@ -437,10 +438,11 @@ public abstract class BaseDataStreamMarshaller implements DataStreamMarshaller {
         }
     }
 
-    protected ByteSequence tightUnmarshalByteSequence(DataInput dataIn, BooleanStream bs) throws IOException {
+    protected ByteSequence tightUnmarshalByteSequence(OpenWireFormat wireFormat, DataInput dataIn, BooleanStream bs) throws IOException {
         ByteSequence rc = null;
         if (bs.readBoolean()) {
             int size = dataIn.readInt();
+            OpenWireUtil.validateBufferSize(wireFormat, size);
             byte[] t = new byte[size];
             dataIn.readFully(t);
             return new ByteSequence(t, 0, size);
@@ -617,10 +619,11 @@ public abstract class BaseDataStreamMarshaller implements DataStreamMarshaller {
         }
     }
 
-    protected byte[] looseUnmarshalByteArray(DataInput dataIn) throws IOException {
+    protected byte[] looseUnmarshalByteArray(OpenWireFormat wireFormat, DataInput dataIn) throws IOException {
         byte rc[] = null;
         if (dataIn.readBoolean()) {
             int size = dataIn.readInt();
+            OpenWireUtil.validateBufferSize(wireFormat, size);
             rc = new byte[size];
             dataIn.readFully(rc);
         }
@@ -636,10 +639,11 @@ public abstract class BaseDataStreamMarshaller implements DataStreamMarshaller {
         }
     }
 
-    protected ByteSequence looseUnmarshalByteSequence(DataInput dataIn) throws IOException {
+    protected ByteSequence looseUnmarshalByteSequence(OpenWireFormat wireFormat, DataInput dataIn) throws IOException {
         ByteSequence rc = null;
         if (dataIn.readBoolean()) {
             int size = dataIn.readInt();
+            OpenWireUtil.validateBufferSize(wireFormat, size);
             byte[] t = new byte[size];
             dataIn.readFully(t);
             rc = new ByteSequence(t, 0, size);

--- a/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v3/MessageMarshaller.java
+++ b/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v3/MessageMarshaller.java
@@ -65,8 +65,8 @@ public abstract class MessageMarshaller extends BaseCommandMarshaller {
         info.setReplyTo((org.apache.activemq.command.ActiveMQDestination)tightUnmarsalNestedObject(wireFormat, dataIn, bs));
         info.setTimestamp(tightUnmarshalLong(wireFormat, dataIn, bs));
         info.setType(tightUnmarshalString(dataIn, bs));
-        info.setContent(tightUnmarshalByteSequence(dataIn, bs));
-        info.setMarshalledProperties(tightUnmarshalByteSequence(dataIn, bs));
+        info.setContent(tightUnmarshalByteSequence(wireFormat, dataIn, bs));
+        info.setMarshalledProperties(tightUnmarshalByteSequence(wireFormat, dataIn, bs));
         info.setDataStructure((org.apache.activemq.command.DataStructure)tightUnmarsalNestedObject(wireFormat, dataIn, bs));
         info.setTargetConsumerId((org.apache.activemq.command.ConsumerId)tightUnmarsalCachedObject(wireFormat, dataIn, bs));
         info.setCompressed(bs.readBoolean());
@@ -218,8 +218,8 @@ public abstract class MessageMarshaller extends BaseCommandMarshaller {
         info.setReplyTo((org.apache.activemq.command.ActiveMQDestination)looseUnmarsalNestedObject(wireFormat, dataIn));
         info.setTimestamp(looseUnmarshalLong(wireFormat, dataIn));
         info.setType(looseUnmarshalString(dataIn));
-        info.setContent(looseUnmarshalByteSequence(dataIn));
-        info.setMarshalledProperties(looseUnmarshalByteSequence(dataIn));
+        info.setContent(looseUnmarshalByteSequence(wireFormat, dataIn));
+        info.setMarshalledProperties(looseUnmarshalByteSequence(wireFormat, dataIn));
         info.setDataStructure((org.apache.activemq.command.DataStructure)looseUnmarsalNestedObject(wireFormat, dataIn));
         info.setTargetConsumerId((org.apache.activemq.command.ConsumerId)looseUnmarsalCachedObject(wireFormat, dataIn));
         info.setCompressed(dataIn.readBoolean());

--- a/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v3/PartialCommandMarshaller.java
+++ b/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v3/PartialCommandMarshaller.java
@@ -68,7 +68,7 @@ public class PartialCommandMarshaller extends BaseDataStreamMarshaller {
 
         PartialCommand info = (PartialCommand)o;
         info.setCommandId(dataIn.readInt());
-        info.setData(tightUnmarshalByteArray(dataIn, bs));
+        info.setData(tightUnmarshalByteArray(wireFormat, dataIn, bs));
 
     }
 
@@ -114,7 +114,7 @@ public class PartialCommandMarshaller extends BaseDataStreamMarshaller {
 
         PartialCommand info = (PartialCommand)o;
         info.setCommandId(dataIn.readInt());
-        info.setData(looseUnmarshalByteArray(dataIn));
+        info.setData(looseUnmarshalByteArray(wireFormat, dataIn));
 
     }
 

--- a/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v3/WireFormatInfoMarshaller.java
+++ b/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v3/WireFormatInfoMarshaller.java
@@ -72,7 +72,7 @@ public class WireFormatInfoMarshaller extends BaseDataStreamMarshaller {
         
         info.setMagic(tightUnmarshalConstByteArray(dataIn, bs, 8));
         info.setVersion(dataIn.readInt());
-        info.setMarshalledProperties(tightUnmarshalByteSequence(dataIn, bs));
+        info.setMarshalledProperties(tightUnmarshalByteSequence(wireFormat, dataIn, bs));
 
         info.afterUnmarshall(wireFormat);
 
@@ -130,7 +130,7 @@ public class WireFormatInfoMarshaller extends BaseDataStreamMarshaller {
         
         info.setMagic(looseUnmarshalConstByteArray(dataIn, 8));
         info.setVersion(dataIn.readInt());
-        info.setMarshalledProperties(looseUnmarshalByteSequence(dataIn));
+        info.setMarshalledProperties(looseUnmarshalByteSequence(wireFormat, dataIn));
 
         info.afterUnmarshall(wireFormat);
 

--- a/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v3/XATransactionIdMarshaller.java
+++ b/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v3/XATransactionIdMarshaller.java
@@ -68,8 +68,8 @@ public class XATransactionIdMarshaller extends TransactionIdMarshaller {
 
         XATransactionId info = (XATransactionId)o;
         info.setFormatId(dataIn.readInt());
-        info.setGlobalTransactionId(tightUnmarshalByteArray(dataIn, bs));
-        info.setBranchQualifier(tightUnmarshalByteArray(dataIn, bs));
+        info.setGlobalTransactionId(tightUnmarshalByteArray(wireFormat, dataIn, bs));
+        info.setBranchQualifier(tightUnmarshalByteArray(wireFormat, dataIn, bs));
 
     }
 
@@ -117,8 +117,8 @@ public class XATransactionIdMarshaller extends TransactionIdMarshaller {
 
         XATransactionId info = (XATransactionId)o;
         info.setFormatId(dataIn.readInt());
-        info.setGlobalTransactionId(looseUnmarshalByteArray(dataIn));
-        info.setBranchQualifier(looseUnmarshalByteArray(dataIn));
+        info.setGlobalTransactionId(looseUnmarshalByteArray(wireFormat, dataIn));
+        info.setBranchQualifier(looseUnmarshalByteArray(wireFormat, dataIn));
 
     }
 

--- a/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v4/BaseDataStreamMarshaller.java
+++ b/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v4/BaseDataStreamMarshaller.java
@@ -410,10 +410,11 @@ public abstract class BaseDataStreamMarshaller implements DataStreamMarshaller {
         }
     }
 
-    protected byte[] tightUnmarshalByteArray(DataInput dataIn, BooleanStream bs) throws IOException {
+    protected byte[] tightUnmarshalByteArray(OpenWireFormat wireFormat, DataInput dataIn, BooleanStream bs) throws IOException {
         byte rc[] = null;
         if (bs.readBoolean()) {
             int size = dataIn.readInt();
+            OpenWireUtil.validateBufferSize(wireFormat, size);
             rc = new byte[size];
             dataIn.readFully(rc);
         }
@@ -437,10 +438,11 @@ public abstract class BaseDataStreamMarshaller implements DataStreamMarshaller {
         }
     }
 
-    protected ByteSequence tightUnmarshalByteSequence(DataInput dataIn, BooleanStream bs) throws IOException {
+    protected ByteSequence tightUnmarshalByteSequence(OpenWireFormat wireFormat, DataInput dataIn, BooleanStream bs) throws IOException {
         ByteSequence rc = null;
         if (bs.readBoolean()) {
             int size = dataIn.readInt();
+            OpenWireUtil.validateBufferSize(wireFormat, size);
             byte[] t = new byte[size];
             dataIn.readFully(t);
             return new ByteSequence(t, 0, size);
@@ -617,10 +619,11 @@ public abstract class BaseDataStreamMarshaller implements DataStreamMarshaller {
         }
     }
 
-    protected byte[] looseUnmarshalByteArray(DataInput dataIn) throws IOException {
+    protected byte[] looseUnmarshalByteArray(OpenWireFormat wireFormat, DataInput dataIn) throws IOException {
         byte rc[] = null;
         if (dataIn.readBoolean()) {
             int size = dataIn.readInt();
+            OpenWireUtil.validateBufferSize(wireFormat, size);
             rc = new byte[size];
             dataIn.readFully(rc);
         }
@@ -636,10 +639,11 @@ public abstract class BaseDataStreamMarshaller implements DataStreamMarshaller {
         }
     }
 
-    protected ByteSequence looseUnmarshalByteSequence(DataInput dataIn) throws IOException {
+    protected ByteSequence looseUnmarshalByteSequence(OpenWireFormat wireFormat, DataInput dataIn) throws IOException {
         ByteSequence rc = null;
         if (dataIn.readBoolean()) {
             int size = dataIn.readInt();
+            OpenWireUtil.validateBufferSize(wireFormat, size);
             byte[] t = new byte[size];
             dataIn.readFully(t);
             rc = new ByteSequence(t, 0, size);

--- a/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v4/MessageMarshaller.java
+++ b/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v4/MessageMarshaller.java
@@ -69,8 +69,8 @@ public abstract class MessageMarshaller extends BaseCommandMarshaller {
         info.setReplyTo((org.apache.activemq.command.ActiveMQDestination) tightUnmarsalNestedObject(wireFormat, dataIn, bs));
         info.setTimestamp(tightUnmarshalLong(wireFormat, dataIn, bs));
         info.setType(tightUnmarshalString(dataIn, bs));
-        info.setContent(tightUnmarshalByteSequence(dataIn, bs));
-        info.setMarshalledProperties(tightUnmarshalByteSequence(dataIn, bs));
+        info.setContent(tightUnmarshalByteSequence(wireFormat, dataIn, bs));
+        info.setMarshalledProperties(tightUnmarshalByteSequence(wireFormat, dataIn, bs));
         info.setDataStructure((org.apache.activemq.command.DataStructure) tightUnmarsalNestedObject(wireFormat, dataIn, bs));
         info.setTargetConsumerId((org.apache.activemq.command.ConsumerId) tightUnmarsalCachedObject(wireFormat, dataIn, bs));
         info.setCompressed(bs.readBoolean());
@@ -225,8 +225,8 @@ public abstract class MessageMarshaller extends BaseCommandMarshaller {
         info.setReplyTo((org.apache.activemq.command.ActiveMQDestination) looseUnmarsalNestedObject(wireFormat, dataIn));
         info.setTimestamp(looseUnmarshalLong(wireFormat, dataIn));
         info.setType(looseUnmarshalString(dataIn));
-        info.setContent(looseUnmarshalByteSequence(dataIn));
-        info.setMarshalledProperties(looseUnmarshalByteSequence(dataIn));
+        info.setContent(looseUnmarshalByteSequence(wireFormat, dataIn));
+        info.setMarshalledProperties(looseUnmarshalByteSequence(wireFormat, dataIn));
         info.setDataStructure((org.apache.activemq.command.DataStructure) looseUnmarsalNestedObject(wireFormat, dataIn));
         info.setTargetConsumerId((org.apache.activemq.command.ConsumerId) looseUnmarsalCachedObject(wireFormat, dataIn));
         info.setCompressed(dataIn.readBoolean());

--- a/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v4/PartialCommandMarshaller.java
+++ b/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v4/PartialCommandMarshaller.java
@@ -67,7 +67,7 @@ public class PartialCommandMarshaller extends BaseDataStreamMarshaller {
 
         PartialCommand info = (PartialCommand)o;
         info.setCommandId(dataIn.readInt());
-        info.setData(tightUnmarshalByteArray(dataIn, bs));
+        info.setData(tightUnmarshalByteArray(wireFormat, dataIn, bs));
 
     }
 
@@ -113,7 +113,7 @@ public class PartialCommandMarshaller extends BaseDataStreamMarshaller {
 
         PartialCommand info = (PartialCommand)o;
         info.setCommandId(dataIn.readInt());
-        info.setData(looseUnmarshalByteArray(dataIn));
+        info.setData(looseUnmarshalByteArray(wireFormat, dataIn));
 
     }
 

--- a/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v4/WireFormatInfoMarshaller.java
+++ b/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v4/WireFormatInfoMarshaller.java
@@ -71,7 +71,7 @@ public class WireFormatInfoMarshaller extends BaseDataStreamMarshaller {
         
         info.setMagic(tightUnmarshalConstByteArray(dataIn, bs, 8));
         info.setVersion(dataIn.readInt());
-        info.setMarshalledProperties(tightUnmarshalByteSequence(dataIn, bs));
+        info.setMarshalledProperties(tightUnmarshalByteSequence(wireFormat, dataIn, bs));
 
         info.afterUnmarshall(wireFormat);
 
@@ -129,7 +129,7 @@ public class WireFormatInfoMarshaller extends BaseDataStreamMarshaller {
         
         info.setMagic(looseUnmarshalConstByteArray(dataIn, 8));
         info.setVersion(dataIn.readInt());
-        info.setMarshalledProperties(looseUnmarshalByteSequence(dataIn));
+        info.setMarshalledProperties(looseUnmarshalByteSequence(wireFormat, dataIn));
 
         info.afterUnmarshall(wireFormat);
 

--- a/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v4/XATransactionIdMarshaller.java
+++ b/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v4/XATransactionIdMarshaller.java
@@ -67,8 +67,8 @@ public class XATransactionIdMarshaller extends TransactionIdMarshaller {
 
         XATransactionId info = (XATransactionId)o;
         info.setFormatId(dataIn.readInt());
-        info.setGlobalTransactionId(tightUnmarshalByteArray(dataIn, bs));
-        info.setBranchQualifier(tightUnmarshalByteArray(dataIn, bs));
+        info.setGlobalTransactionId(tightUnmarshalByteArray(wireFormat, dataIn, bs));
+        info.setBranchQualifier(tightUnmarshalByteArray(wireFormat, dataIn, bs));
 
     }
 
@@ -116,8 +116,8 @@ public class XATransactionIdMarshaller extends TransactionIdMarshaller {
 
         XATransactionId info = (XATransactionId)o;
         info.setFormatId(dataIn.readInt());
-        info.setGlobalTransactionId(looseUnmarshalByteArray(dataIn));
-        info.setBranchQualifier(looseUnmarshalByteArray(dataIn));
+        info.setGlobalTransactionId(looseUnmarshalByteArray(wireFormat, dataIn));
+        info.setBranchQualifier(looseUnmarshalByteArray(wireFormat, dataIn));
 
     }
 

--- a/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v5/BaseDataStreamMarshaller.java
+++ b/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v5/BaseDataStreamMarshaller.java
@@ -410,10 +410,11 @@ public abstract class BaseDataStreamMarshaller implements DataStreamMarshaller {
         }
     }
 
-    protected byte[] tightUnmarshalByteArray(DataInput dataIn, BooleanStream bs) throws IOException {
+    protected byte[] tightUnmarshalByteArray(OpenWireFormat wireFormat, DataInput dataIn, BooleanStream bs) throws IOException {
         byte rc[] = null;
         if (bs.readBoolean()) {
             int size = dataIn.readInt();
+            OpenWireUtil.validateBufferSize(wireFormat, size);
             rc = new byte[size];
             dataIn.readFully(rc);
         }
@@ -437,10 +438,11 @@ public abstract class BaseDataStreamMarshaller implements DataStreamMarshaller {
         }
     }
 
-    protected ByteSequence tightUnmarshalByteSequence(DataInput dataIn, BooleanStream bs) throws IOException {
+    protected ByteSequence tightUnmarshalByteSequence(OpenWireFormat wireFormat, DataInput dataIn, BooleanStream bs) throws IOException {
         ByteSequence rc = null;
         if (bs.readBoolean()) {
             int size = dataIn.readInt();
+            OpenWireUtil.validateBufferSize(wireFormat, size);
             byte[] t = new byte[size];
             dataIn.readFully(t);
             return new ByteSequence(t, 0, size);
@@ -617,10 +619,11 @@ public abstract class BaseDataStreamMarshaller implements DataStreamMarshaller {
         }
     }
 
-    protected byte[] looseUnmarshalByteArray(DataInput dataIn) throws IOException {
+    protected byte[] looseUnmarshalByteArray(OpenWireFormat wireFormat, DataInput dataIn) throws IOException {
         byte rc[] = null;
         if (dataIn.readBoolean()) {
             int size = dataIn.readInt();
+            OpenWireUtil.validateBufferSize(wireFormat, size);
             rc = new byte[size];
             dataIn.readFully(rc);
         }
@@ -636,10 +639,11 @@ public abstract class BaseDataStreamMarshaller implements DataStreamMarshaller {
         }
     }
 
-    protected ByteSequence looseUnmarshalByteSequence(DataInput dataIn) throws IOException {
+    protected ByteSequence looseUnmarshalByteSequence(OpenWireFormat wireFormat, DataInput dataIn) throws IOException {
         ByteSequence rc = null;
         if (dataIn.readBoolean()) {
             int size = dataIn.readInt();
+            OpenWireUtil.validateBufferSize(wireFormat, size);
             byte[] t = new byte[size];
             dataIn.readFully(t);
             rc = new ByteSequence(t, 0, size);

--- a/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v5/MessageMarshaller.java
+++ b/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v5/MessageMarshaller.java
@@ -69,8 +69,8 @@ public abstract class MessageMarshaller extends BaseCommandMarshaller {
         info.setReplyTo((org.apache.activemq.command.ActiveMQDestination) tightUnmarsalNestedObject(wireFormat, dataIn, bs));
         info.setTimestamp(tightUnmarshalLong(wireFormat, dataIn, bs));
         info.setType(tightUnmarshalString(dataIn, bs));
-        info.setContent(tightUnmarshalByteSequence(dataIn, bs));
-        info.setMarshalledProperties(tightUnmarshalByteSequence(dataIn, bs));
+        info.setContent(tightUnmarshalByteSequence(wireFormat, dataIn, bs));
+        info.setMarshalledProperties(tightUnmarshalByteSequence(wireFormat, dataIn, bs));
         info.setDataStructure((org.apache.activemq.command.DataStructure) tightUnmarsalNestedObject(wireFormat, dataIn, bs));
         info.setTargetConsumerId((org.apache.activemq.command.ConsumerId) tightUnmarsalCachedObject(wireFormat, dataIn, bs));
         info.setCompressed(bs.readBoolean());
@@ -225,8 +225,8 @@ public abstract class MessageMarshaller extends BaseCommandMarshaller {
         info.setReplyTo((org.apache.activemq.command.ActiveMQDestination) looseUnmarsalNestedObject(wireFormat, dataIn));
         info.setTimestamp(looseUnmarshalLong(wireFormat, dataIn));
         info.setType(looseUnmarshalString(dataIn));
-        info.setContent(looseUnmarshalByteSequence(dataIn));
-        info.setMarshalledProperties(looseUnmarshalByteSequence(dataIn));
+        info.setContent(looseUnmarshalByteSequence(wireFormat, dataIn));
+        info.setMarshalledProperties(looseUnmarshalByteSequence(wireFormat, dataIn));
         info.setDataStructure((org.apache.activemq.command.DataStructure) looseUnmarsalNestedObject(wireFormat, dataIn));
         info.setTargetConsumerId((org.apache.activemq.command.ConsumerId) looseUnmarsalCachedObject(wireFormat, dataIn));
         info.setCompressed(dataIn.readBoolean());

--- a/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v5/PartialCommandMarshaller.java
+++ b/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v5/PartialCommandMarshaller.java
@@ -67,7 +67,7 @@ public class PartialCommandMarshaller extends BaseDataStreamMarshaller {
 
         PartialCommand info = (PartialCommand)o;
         info.setCommandId(dataIn.readInt());
-        info.setData(tightUnmarshalByteArray(dataIn, bs));
+        info.setData(tightUnmarshalByteArray(wireFormat, dataIn, bs));
 
     }
 
@@ -113,7 +113,7 @@ public class PartialCommandMarshaller extends BaseDataStreamMarshaller {
 
         PartialCommand info = (PartialCommand)o;
         info.setCommandId(dataIn.readInt());
-        info.setData(looseUnmarshalByteArray(dataIn));
+        info.setData(looseUnmarshalByteArray(wireFormat, dataIn));
 
     }
 

--- a/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v5/WireFormatInfoMarshaller.java
+++ b/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v5/WireFormatInfoMarshaller.java
@@ -71,7 +71,7 @@ public class WireFormatInfoMarshaller extends BaseDataStreamMarshaller {
         
         info.setMagic(tightUnmarshalConstByteArray(dataIn, bs, 8));
         info.setVersion(dataIn.readInt());
-        info.setMarshalledProperties(tightUnmarshalByteSequence(dataIn, bs));
+        info.setMarshalledProperties(tightUnmarshalByteSequence(wireFormat, dataIn, bs));
 
         info.afterUnmarshall(wireFormat);
 
@@ -129,7 +129,7 @@ public class WireFormatInfoMarshaller extends BaseDataStreamMarshaller {
         
         info.setMagic(looseUnmarshalConstByteArray(dataIn, 8));
         info.setVersion(dataIn.readInt());
-        info.setMarshalledProperties(looseUnmarshalByteSequence(dataIn));
+        info.setMarshalledProperties(looseUnmarshalByteSequence(wireFormat, dataIn));
 
         info.afterUnmarshall(wireFormat);
 

--- a/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v5/XATransactionIdMarshaller.java
+++ b/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v5/XATransactionIdMarshaller.java
@@ -67,8 +67,8 @@ public class XATransactionIdMarshaller extends TransactionIdMarshaller {
 
         XATransactionId info = (XATransactionId)o;
         info.setFormatId(dataIn.readInt());
-        info.setGlobalTransactionId(tightUnmarshalByteArray(dataIn, bs));
-        info.setBranchQualifier(tightUnmarshalByteArray(dataIn, bs));
+        info.setGlobalTransactionId(tightUnmarshalByteArray(wireFormat, dataIn, bs));
+        info.setBranchQualifier(tightUnmarshalByteArray(wireFormat, dataIn, bs));
 
     }
 
@@ -116,8 +116,8 @@ public class XATransactionIdMarshaller extends TransactionIdMarshaller {
 
         XATransactionId info = (XATransactionId)o;
         info.setFormatId(dataIn.readInt());
-        info.setGlobalTransactionId(looseUnmarshalByteArray(dataIn));
-        info.setBranchQualifier(looseUnmarshalByteArray(dataIn));
+        info.setGlobalTransactionId(looseUnmarshalByteArray(wireFormat, dataIn));
+        info.setBranchQualifier(looseUnmarshalByteArray(wireFormat, dataIn));
 
     }
 

--- a/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v6/BaseDataStreamMarshaller.java
+++ b/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v6/BaseDataStreamMarshaller.java
@@ -410,10 +410,11 @@ public abstract class BaseDataStreamMarshaller implements DataStreamMarshaller {
         }
     }
 
-    protected byte[] tightUnmarshalByteArray(DataInput dataIn, BooleanStream bs) throws IOException {
+    protected byte[] tightUnmarshalByteArray(OpenWireFormat wireFormat, DataInput dataIn, BooleanStream bs) throws IOException {
         byte rc[] = null;
         if (bs.readBoolean()) {
             int size = dataIn.readInt();
+            OpenWireUtil.validateBufferSize(wireFormat, size);
             rc = new byte[size];
             dataIn.readFully(rc);
         }
@@ -437,10 +438,11 @@ public abstract class BaseDataStreamMarshaller implements DataStreamMarshaller {
         }
     }
 
-    protected ByteSequence tightUnmarshalByteSequence(DataInput dataIn, BooleanStream bs) throws IOException {
+    protected ByteSequence tightUnmarshalByteSequence(OpenWireFormat wireFormat, DataInput dataIn, BooleanStream bs) throws IOException {
         ByteSequence rc = null;
         if (bs.readBoolean()) {
             int size = dataIn.readInt();
+            OpenWireUtil.validateBufferSize(wireFormat, size);
             byte[] t = new byte[size];
             dataIn.readFully(t);
             return new ByteSequence(t, 0, size);
@@ -617,10 +619,11 @@ public abstract class BaseDataStreamMarshaller implements DataStreamMarshaller {
         }
     }
 
-    protected byte[] looseUnmarshalByteArray(DataInput dataIn) throws IOException {
+    protected byte[] looseUnmarshalByteArray(OpenWireFormat wireFormat, DataInput dataIn) throws IOException {
         byte rc[] = null;
         if (dataIn.readBoolean()) {
             int size = dataIn.readInt();
+            OpenWireUtil.validateBufferSize(wireFormat, size);
             rc = new byte[size];
             dataIn.readFully(rc);
         }
@@ -636,10 +639,11 @@ public abstract class BaseDataStreamMarshaller implements DataStreamMarshaller {
         }
     }
 
-    protected ByteSequence looseUnmarshalByteSequence(DataInput dataIn) throws IOException {
+    protected ByteSequence looseUnmarshalByteSequence(OpenWireFormat wireFormat, DataInput dataIn) throws IOException {
         ByteSequence rc = null;
         if (dataIn.readBoolean()) {
             int size = dataIn.readInt();
+            OpenWireUtil.validateBufferSize(wireFormat, size);
             byte[] t = new byte[size];
             dataIn.readFully(t);
             rc = new ByteSequence(t, 0, size);

--- a/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v6/MessageMarshaller.java
+++ b/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v6/MessageMarshaller.java
@@ -69,8 +69,8 @@ public abstract class MessageMarshaller extends BaseCommandMarshaller {
         info.setReplyTo((org.apache.activemq.command.ActiveMQDestination) tightUnmarsalNestedObject(wireFormat, dataIn, bs));
         info.setTimestamp(tightUnmarshalLong(wireFormat, dataIn, bs));
         info.setType(tightUnmarshalString(dataIn, bs));
-        info.setContent(tightUnmarshalByteSequence(dataIn, bs));
-        info.setMarshalledProperties(tightUnmarshalByteSequence(dataIn, bs));
+        info.setContent(tightUnmarshalByteSequence(wireFormat, dataIn, bs));
+        info.setMarshalledProperties(tightUnmarshalByteSequence(wireFormat, dataIn, bs));
         info.setDataStructure((org.apache.activemq.command.DataStructure) tightUnmarsalNestedObject(wireFormat, dataIn, bs));
         info.setTargetConsumerId((org.apache.activemq.command.ConsumerId) tightUnmarsalCachedObject(wireFormat, dataIn, bs));
         info.setCompressed(bs.readBoolean());
@@ -225,8 +225,8 @@ public abstract class MessageMarshaller extends BaseCommandMarshaller {
         info.setReplyTo((org.apache.activemq.command.ActiveMQDestination) looseUnmarsalNestedObject(wireFormat, dataIn));
         info.setTimestamp(looseUnmarshalLong(wireFormat, dataIn));
         info.setType(looseUnmarshalString(dataIn));
-        info.setContent(looseUnmarshalByteSequence(dataIn));
-        info.setMarshalledProperties(looseUnmarshalByteSequence(dataIn));
+        info.setContent(looseUnmarshalByteSequence(wireFormat, dataIn));
+        info.setMarshalledProperties(looseUnmarshalByteSequence(wireFormat, dataIn));
         info.setDataStructure((org.apache.activemq.command.DataStructure) looseUnmarsalNestedObject(wireFormat, dataIn));
         info.setTargetConsumerId((org.apache.activemq.command.ConsumerId) looseUnmarsalCachedObject(wireFormat, dataIn));
         info.setCompressed(dataIn.readBoolean());

--- a/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v6/PartialCommandMarshaller.java
+++ b/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v6/PartialCommandMarshaller.java
@@ -67,7 +67,7 @@ public class PartialCommandMarshaller extends BaseDataStreamMarshaller {
 
         PartialCommand info = (PartialCommand)o;
         info.setCommandId(dataIn.readInt());
-        info.setData(tightUnmarshalByteArray(dataIn, bs));
+        info.setData(tightUnmarshalByteArray(wireFormat, dataIn, bs));
 
     }
 
@@ -113,7 +113,7 @@ public class PartialCommandMarshaller extends BaseDataStreamMarshaller {
 
         PartialCommand info = (PartialCommand)o;
         info.setCommandId(dataIn.readInt());
-        info.setData(looseUnmarshalByteArray(dataIn));
+        info.setData(looseUnmarshalByteArray(wireFormat, dataIn));
 
     }
 

--- a/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v6/WireFormatInfoMarshaller.java
+++ b/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v6/WireFormatInfoMarshaller.java
@@ -71,7 +71,7 @@ public class WireFormatInfoMarshaller extends BaseDataStreamMarshaller {
         
         info.setMagic(tightUnmarshalConstByteArray(dataIn, bs, 8));
         info.setVersion(dataIn.readInt());
-        info.setMarshalledProperties(tightUnmarshalByteSequence(dataIn, bs));
+        info.setMarshalledProperties(tightUnmarshalByteSequence(wireFormat, dataIn, bs));
 
         info.afterUnmarshall(wireFormat);
 
@@ -129,7 +129,7 @@ public class WireFormatInfoMarshaller extends BaseDataStreamMarshaller {
         
         info.setMagic(looseUnmarshalConstByteArray(dataIn, 8));
         info.setVersion(dataIn.readInt());
-        info.setMarshalledProperties(looseUnmarshalByteSequence(dataIn));
+        info.setMarshalledProperties(looseUnmarshalByteSequence(wireFormat, dataIn));
 
         info.afterUnmarshall(wireFormat);
 

--- a/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v6/XATransactionIdMarshaller.java
+++ b/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v6/XATransactionIdMarshaller.java
@@ -67,8 +67,8 @@ public class XATransactionIdMarshaller extends TransactionIdMarshaller {
 
         XATransactionId info = (XATransactionId)o;
         info.setFormatId(dataIn.readInt());
-        info.setGlobalTransactionId(tightUnmarshalByteArray(dataIn, bs));
-        info.setBranchQualifier(tightUnmarshalByteArray(dataIn, bs));
+        info.setGlobalTransactionId(tightUnmarshalByteArray(wireFormat, dataIn, bs));
+        info.setBranchQualifier(tightUnmarshalByteArray(wireFormat, dataIn, bs));
 
     }
 
@@ -116,8 +116,8 @@ public class XATransactionIdMarshaller extends TransactionIdMarshaller {
 
         XATransactionId info = (XATransactionId)o;
         info.setFormatId(dataIn.readInt());
-        info.setGlobalTransactionId(looseUnmarshalByteArray(dataIn));
-        info.setBranchQualifier(looseUnmarshalByteArray(dataIn));
+        info.setGlobalTransactionId(looseUnmarshalByteArray(wireFormat, dataIn));
+        info.setBranchQualifier(looseUnmarshalByteArray(wireFormat, dataIn));
 
     }
 

--- a/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v7/BaseDataStreamMarshaller.java
+++ b/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v7/BaseDataStreamMarshaller.java
@@ -409,10 +409,11 @@ public abstract class BaseDataStreamMarshaller implements DataStreamMarshaller {
         }
     }
 
-    protected byte[] tightUnmarshalByteArray(DataInput dataIn, BooleanStream bs) throws IOException {
+    protected byte[] tightUnmarshalByteArray(OpenWireFormat wireFormat, DataInput dataIn, BooleanStream bs) throws IOException {
         byte rc[] = null;
         if (bs.readBoolean()) {
             int size = dataIn.readInt();
+            OpenWireUtil.validateBufferSize(wireFormat, size);
             rc = new byte[size];
             dataIn.readFully(rc);
         }
@@ -436,10 +437,11 @@ public abstract class BaseDataStreamMarshaller implements DataStreamMarshaller {
         }
     }
 
-    protected ByteSequence tightUnmarshalByteSequence(DataInput dataIn, BooleanStream bs) throws IOException {
+    protected ByteSequence tightUnmarshalByteSequence(OpenWireFormat wireFormat, DataInput dataIn, BooleanStream bs) throws IOException {
         ByteSequence rc = null;
         if (bs.readBoolean()) {
             int size = dataIn.readInt();
+            OpenWireUtil.validateBufferSize(wireFormat, size);
             byte[] t = new byte[size];
             dataIn.readFully(t);
             return new ByteSequence(t, 0, size);
@@ -616,10 +618,11 @@ public abstract class BaseDataStreamMarshaller implements DataStreamMarshaller {
         }
     }
 
-    protected byte[] looseUnmarshalByteArray(DataInput dataIn) throws IOException {
+    protected byte[] looseUnmarshalByteArray(OpenWireFormat wireFormat, DataInput dataIn) throws IOException {
         byte rc[] = null;
         if (dataIn.readBoolean()) {
             int size = dataIn.readInt();
+            OpenWireUtil.validateBufferSize(wireFormat, size);
             rc = new byte[size];
             dataIn.readFully(rc);
         }
@@ -635,10 +638,11 @@ public abstract class BaseDataStreamMarshaller implements DataStreamMarshaller {
         }
     }
 
-    protected ByteSequence looseUnmarshalByteSequence(DataInput dataIn) throws IOException {
+    protected ByteSequence looseUnmarshalByteSequence(OpenWireFormat wireFormat, DataInput dataIn) throws IOException {
         ByteSequence rc = null;
         if (dataIn.readBoolean()) {
             int size = dataIn.readInt();
+            OpenWireUtil.validateBufferSize(wireFormat, size);
             byte[] t = new byte[size];
             dataIn.readFully(t);
             rc = new ByteSequence(t, 0, size);

--- a/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v7/MessageMarshaller.java
+++ b/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v7/MessageMarshaller.java
@@ -69,8 +69,8 @@ public abstract class MessageMarshaller extends BaseCommandMarshaller {
         info.setReplyTo((org.apache.activemq.command.ActiveMQDestination) tightUnmarsalNestedObject(wireFormat, dataIn, bs));
         info.setTimestamp(tightUnmarshalLong(wireFormat, dataIn, bs));
         info.setType(tightUnmarshalString(dataIn, bs));
-        info.setContent(tightUnmarshalByteSequence(dataIn, bs));
-        info.setMarshalledProperties(tightUnmarshalByteSequence(dataIn, bs));
+        info.setContent(tightUnmarshalByteSequence(wireFormat, dataIn, bs));
+        info.setMarshalledProperties(tightUnmarshalByteSequence(wireFormat, dataIn, bs));
         info.setDataStructure((org.apache.activemq.command.DataStructure) tightUnmarsalNestedObject(wireFormat, dataIn, bs));
         info.setTargetConsumerId((org.apache.activemq.command.ConsumerId) tightUnmarsalCachedObject(wireFormat, dataIn, bs));
         info.setCompressed(bs.readBoolean());
@@ -225,8 +225,8 @@ public abstract class MessageMarshaller extends BaseCommandMarshaller {
         info.setReplyTo((org.apache.activemq.command.ActiveMQDestination) looseUnmarsalNestedObject(wireFormat, dataIn));
         info.setTimestamp(looseUnmarshalLong(wireFormat, dataIn));
         info.setType(looseUnmarshalString(dataIn));
-        info.setContent(looseUnmarshalByteSequence(dataIn));
-        info.setMarshalledProperties(looseUnmarshalByteSequence(dataIn));
+        info.setContent(looseUnmarshalByteSequence(wireFormat, dataIn));
+        info.setMarshalledProperties(looseUnmarshalByteSequence(wireFormat, dataIn));
         info.setDataStructure((org.apache.activemq.command.DataStructure) looseUnmarsalNestedObject(wireFormat, dataIn));
         info.setTargetConsumerId((org.apache.activemq.command.ConsumerId) looseUnmarsalCachedObject(wireFormat, dataIn));
         info.setCompressed(dataIn.readBoolean());

--- a/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v7/PartialCommandMarshaller.java
+++ b/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v7/PartialCommandMarshaller.java
@@ -67,7 +67,7 @@ public class PartialCommandMarshaller extends BaseDataStreamMarshaller {
 
         PartialCommand info = (PartialCommand)o;
         info.setCommandId(dataIn.readInt());
-        info.setData(tightUnmarshalByteArray(dataIn, bs));
+        info.setData(tightUnmarshalByteArray(wireFormat, dataIn, bs));
 
     }
 
@@ -113,7 +113,7 @@ public class PartialCommandMarshaller extends BaseDataStreamMarshaller {
 
         PartialCommand info = (PartialCommand)o;
         info.setCommandId(dataIn.readInt());
-        info.setData(looseUnmarshalByteArray(dataIn));
+        info.setData(looseUnmarshalByteArray(wireFormat, dataIn));
 
     }
 

--- a/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v7/WireFormatInfoMarshaller.java
+++ b/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v7/WireFormatInfoMarshaller.java
@@ -71,7 +71,7 @@ public class WireFormatInfoMarshaller extends BaseDataStreamMarshaller {
         
         info.setMagic(tightUnmarshalConstByteArray(dataIn, bs, 8));
         info.setVersion(dataIn.readInt());
-        info.setMarshalledProperties(tightUnmarshalByteSequence(dataIn, bs));
+        info.setMarshalledProperties(tightUnmarshalByteSequence(wireFormat, dataIn, bs));
 
         info.afterUnmarshall(wireFormat);
 
@@ -129,7 +129,7 @@ public class WireFormatInfoMarshaller extends BaseDataStreamMarshaller {
         
         info.setMagic(looseUnmarshalConstByteArray(dataIn, 8));
         info.setVersion(dataIn.readInt());
-        info.setMarshalledProperties(looseUnmarshalByteSequence(dataIn));
+        info.setMarshalledProperties(looseUnmarshalByteSequence(wireFormat, dataIn));
 
         info.afterUnmarshall(wireFormat);
 

--- a/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v7/XATransactionIdMarshaller.java
+++ b/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v7/XATransactionIdMarshaller.java
@@ -67,8 +67,8 @@ public class XATransactionIdMarshaller extends TransactionIdMarshaller {
 
         XATransactionId info = (XATransactionId)o;
         info.setFormatId(dataIn.readInt());
-        info.setGlobalTransactionId(tightUnmarshalByteArray(dataIn, bs));
-        info.setBranchQualifier(tightUnmarshalByteArray(dataIn, bs));
+        info.setGlobalTransactionId(tightUnmarshalByteArray(wireFormat, dataIn, bs));
+        info.setBranchQualifier(tightUnmarshalByteArray(wireFormat, dataIn, bs));
 
     }
 
@@ -116,8 +116,8 @@ public class XATransactionIdMarshaller extends TransactionIdMarshaller {
 
         XATransactionId info = (XATransactionId)o;
         info.setFormatId(dataIn.readInt());
-        info.setGlobalTransactionId(looseUnmarshalByteArray(dataIn));
-        info.setBranchQualifier(looseUnmarshalByteArray(dataIn));
+        info.setGlobalTransactionId(looseUnmarshalByteArray(wireFormat, dataIn));
+        info.setBranchQualifier(looseUnmarshalByteArray(wireFormat, dataIn));
 
     }
 

--- a/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v8/BaseDataStreamMarshaller.java
+++ b/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v8/BaseDataStreamMarshaller.java
@@ -409,10 +409,11 @@ public abstract class BaseDataStreamMarshaller implements DataStreamMarshaller {
         }
     }
 
-    protected byte[] tightUnmarshalByteArray(DataInput dataIn, BooleanStream bs) throws IOException {
+    protected byte[] tightUnmarshalByteArray(OpenWireFormat wireFormat, DataInput dataIn, BooleanStream bs) throws IOException {
         byte rc[] = null;
         if (bs.readBoolean()) {
             int size = dataIn.readInt();
+            OpenWireUtil.validateBufferSize(wireFormat, size);
             rc = new byte[size];
             dataIn.readFully(rc);
         }
@@ -436,10 +437,11 @@ public abstract class BaseDataStreamMarshaller implements DataStreamMarshaller {
         }
     }
 
-    protected ByteSequence tightUnmarshalByteSequence(DataInput dataIn, BooleanStream bs) throws IOException {
+    protected ByteSequence tightUnmarshalByteSequence(OpenWireFormat wireFormat, DataInput dataIn, BooleanStream bs) throws IOException {
         ByteSequence rc = null;
         if (bs.readBoolean()) {
             int size = dataIn.readInt();
+            OpenWireUtil.validateBufferSize(wireFormat, size);
             byte[] t = new byte[size];
             dataIn.readFully(t);
             return new ByteSequence(t, 0, size);
@@ -616,10 +618,11 @@ public abstract class BaseDataStreamMarshaller implements DataStreamMarshaller {
         }
     }
 
-    protected byte[] looseUnmarshalByteArray(DataInput dataIn) throws IOException {
+    protected byte[] looseUnmarshalByteArray(OpenWireFormat wireFormat, DataInput dataIn) throws IOException {
         byte rc[] = null;
         if (dataIn.readBoolean()) {
             int size = dataIn.readInt();
+            OpenWireUtil.validateBufferSize(wireFormat, size);
             rc = new byte[size];
             dataIn.readFully(rc);
         }
@@ -635,10 +638,11 @@ public abstract class BaseDataStreamMarshaller implements DataStreamMarshaller {
         }
     }
 
-    protected ByteSequence looseUnmarshalByteSequence(DataInput dataIn) throws IOException {
+    protected ByteSequence looseUnmarshalByteSequence(OpenWireFormat wireFormat, DataInput dataIn) throws IOException {
         ByteSequence rc = null;
         if (dataIn.readBoolean()) {
             int size = dataIn.readInt();
+            OpenWireUtil.validateBufferSize(wireFormat, size);
             byte[] t = new byte[size];
             dataIn.readFully(t);
             rc = new ByteSequence(t, 0, size);

--- a/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v8/ConnectionControlMarshaller.java
+++ b/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v8/ConnectionControlMarshaller.java
@@ -74,7 +74,7 @@ public class ConnectionControlMarshaller extends BaseCommandMarshaller {
         info.setConnectedBrokers(tightUnmarshalString(dataIn, bs));
         info.setReconnectTo(tightUnmarshalString(dataIn, bs));
         info.setRebalanceConnection(bs.readBoolean());
-        info.setToken(tightUnmarshalByteArray(dataIn, bs));
+        info.setToken(tightUnmarshalByteArray(wireFormat, dataIn, bs));
 
     }
 
@@ -142,7 +142,7 @@ public class ConnectionControlMarshaller extends BaseCommandMarshaller {
         info.setConnectedBrokers(looseUnmarshalString(dataIn));
         info.setReconnectTo(looseUnmarshalString(dataIn));
         info.setRebalanceConnection(dataIn.readBoolean());
-        info.setToken(looseUnmarshalByteArray(dataIn));
+        info.setToken(looseUnmarshalByteArray(wireFormat, dataIn));
 
     }
 

--- a/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v8/MessageMarshaller.java
+++ b/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v8/MessageMarshaller.java
@@ -69,8 +69,8 @@ public abstract class MessageMarshaller extends BaseCommandMarshaller {
         info.setReplyTo((org.apache.activemq.command.ActiveMQDestination) tightUnmarsalNestedObject(wireFormat, dataIn, bs));
         info.setTimestamp(tightUnmarshalLong(wireFormat, dataIn, bs));
         info.setType(tightUnmarshalString(dataIn, bs));
-        info.setContent(tightUnmarshalByteSequence(dataIn, bs));
-        info.setMarshalledProperties(tightUnmarshalByteSequence(dataIn, bs));
+        info.setContent(tightUnmarshalByteSequence(wireFormat, dataIn, bs));
+        info.setMarshalledProperties(tightUnmarshalByteSequence(wireFormat, dataIn, bs));
         info.setDataStructure((org.apache.activemq.command.DataStructure) tightUnmarsalNestedObject(wireFormat, dataIn, bs));
         info.setTargetConsumerId((org.apache.activemq.command.ConsumerId) tightUnmarsalCachedObject(wireFormat, dataIn, bs));
         info.setCompressed(bs.readBoolean());
@@ -225,8 +225,8 @@ public abstract class MessageMarshaller extends BaseCommandMarshaller {
         info.setReplyTo((org.apache.activemq.command.ActiveMQDestination) looseUnmarsalNestedObject(wireFormat, dataIn));
         info.setTimestamp(looseUnmarshalLong(wireFormat, dataIn));
         info.setType(looseUnmarshalString(dataIn));
-        info.setContent(looseUnmarshalByteSequence(dataIn));
-        info.setMarshalledProperties(looseUnmarshalByteSequence(dataIn));
+        info.setContent(looseUnmarshalByteSequence(wireFormat, dataIn));
+        info.setMarshalledProperties(looseUnmarshalByteSequence(wireFormat, dataIn));
         info.setDataStructure((org.apache.activemq.command.DataStructure) looseUnmarsalNestedObject(wireFormat, dataIn));
         info.setTargetConsumerId((org.apache.activemq.command.ConsumerId) looseUnmarsalCachedObject(wireFormat, dataIn));
         info.setCompressed(dataIn.readBoolean());

--- a/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v8/PartialCommandMarshaller.java
+++ b/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v8/PartialCommandMarshaller.java
@@ -67,7 +67,7 @@ public class PartialCommandMarshaller extends BaseDataStreamMarshaller {
 
         PartialCommand info = (PartialCommand)o;
         info.setCommandId(dataIn.readInt());
-        info.setData(tightUnmarshalByteArray(dataIn, bs));
+        info.setData(tightUnmarshalByteArray(wireFormat, dataIn, bs));
 
     }
 
@@ -113,7 +113,7 @@ public class PartialCommandMarshaller extends BaseDataStreamMarshaller {
 
         PartialCommand info = (PartialCommand)o;
         info.setCommandId(dataIn.readInt());
-        info.setData(looseUnmarshalByteArray(dataIn));
+        info.setData(looseUnmarshalByteArray(wireFormat, dataIn));
 
     }
 

--- a/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v8/WireFormatInfoMarshaller.java
+++ b/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v8/WireFormatInfoMarshaller.java
@@ -71,7 +71,7 @@ public class WireFormatInfoMarshaller extends BaseDataStreamMarshaller {
         
         info.setMagic(tightUnmarshalConstByteArray(dataIn, bs, 8));
         info.setVersion(dataIn.readInt());
-        info.setMarshalledProperties(tightUnmarshalByteSequence(dataIn, bs));
+        info.setMarshalledProperties(tightUnmarshalByteSequence(wireFormat, dataIn, bs));
 
         info.afterUnmarshall(wireFormat);
 
@@ -129,7 +129,7 @@ public class WireFormatInfoMarshaller extends BaseDataStreamMarshaller {
         
         info.setMagic(looseUnmarshalConstByteArray(dataIn, 8));
         info.setVersion(dataIn.readInt());
-        info.setMarshalledProperties(looseUnmarshalByteSequence(dataIn));
+        info.setMarshalledProperties(looseUnmarshalByteSequence(wireFormat, dataIn));
 
         info.afterUnmarshall(wireFormat);
 

--- a/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v8/XATransactionIdMarshaller.java
+++ b/activemq-openwire-legacy/src/main/java/org/apache/activemq/openwire/v8/XATransactionIdMarshaller.java
@@ -67,8 +67,8 @@ public class XATransactionIdMarshaller extends TransactionIdMarshaller {
 
         XATransactionId info = (XATransactionId)o;
         info.setFormatId(dataIn.readInt());
-        info.setGlobalTransactionId(tightUnmarshalByteArray(dataIn, bs));
-        info.setBranchQualifier(tightUnmarshalByteArray(dataIn, bs));
+        info.setGlobalTransactionId(tightUnmarshalByteArray(wireFormat, dataIn, bs));
+        info.setBranchQualifier(tightUnmarshalByteArray(wireFormat, dataIn, bs));
 
     }
 
@@ -116,8 +116,8 @@ public class XATransactionIdMarshaller extends TransactionIdMarshaller {
 
         XATransactionId info = (XATransactionId)o;
         info.setFormatId(dataIn.readInt());
-        info.setGlobalTransactionId(looseUnmarshalByteArray(dataIn));
-        info.setBranchQualifier(looseUnmarshalByteArray(dataIn));
+        info.setGlobalTransactionId(looseUnmarshalByteArray(wireFormat, dataIn));
+        info.setBranchQualifier(looseUnmarshalByteArray(wireFormat, dataIn));
 
     }
 

--- a/activemq-openwire-legacy/src/test/java/org/apache/activemq/openwire/OpenWireLegacyValidationTest.java
+++ b/activemq-openwire-legacy/src/test/java/org/apache/activemq/openwire/OpenWireLegacyValidationTest.java
@@ -21,13 +21,13 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import org.apache.activemq.util.ByteSequence;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
 /**
- * Test that Openwire marshalling for legacy versions will validate Throwable types during
- * unmarshalling commands that contain a Throwable
+ * Test that Openwire marshalling for legacy versions will validate certain commands correctly
  */
 @RunWith(Parameterized.class)
 public class OpenWireLegacyValidationTest extends OpenWireValidationTest {
@@ -123,6 +123,48 @@ public class OpenWireLegacyValidationTest extends OpenWireValidationTest {
                 };
             default:
                 throw new IllegalArgumentException("Unknown openwire version of " + version);
+        }
+    }
+
+    protected DataStreamMarshaller getWireFormatInfoMarshaller() {
+        switch (version) {
+            case 2:
+                return proxyBadBufferCommand(new org.apache.activemq.openwire.v2.WireFormatInfoMarshaller());
+            case 3:
+                return proxyBadBufferCommand(new org.apache.activemq.openwire.v3.WireFormatInfoMarshaller());
+            case 4:
+                return proxyBadBufferCommand(new org.apache.activemq.openwire.v4.WireFormatInfoMarshaller());
+            case 5:
+                return proxyBadBufferCommand(new org.apache.activemq.openwire.v5.WireFormatInfoMarshaller());
+            case 6:
+                return proxyBadBufferCommand(new org.apache.activemq.openwire.v6.WireFormatInfoMarshaller());
+            case 7:
+                return proxyBadBufferCommand(new org.apache.activemq.openwire.v7.WireFormatInfoMarshaller());
+            case 8:
+                return proxyBadBufferCommand(new org.apache.activemq.openwire.v8.WireFormatInfoMarshaller());
+            default:
+                throw new IllegalArgumentException("Unknown OpenWire version of " + version);
+        }
+    }
+
+    protected DataStreamMarshaller getPartialCommandMarshaller() {
+        switch (version) {
+            case 2:
+                return proxyBadBufferCommand(new org.apache.activemq.openwire.v2.PartialCommandMarshaller());
+            case 3:
+                return proxyBadBufferCommand(new org.apache.activemq.openwire.v3.PartialCommandMarshaller());
+            case 4:
+                return proxyBadBufferCommand(new org.apache.activemq.openwire.v4.PartialCommandMarshaller());
+            case 5:
+                return proxyBadBufferCommand(new org.apache.activemq.openwire.v5.PartialCommandMarshaller());
+            case 6:
+                return proxyBadBufferCommand(new org.apache.activemq.openwire.v6.PartialCommandMarshaller());
+            case 7:
+                return proxyBadBufferCommand(new org.apache.activemq.openwire.v7.PartialCommandMarshaller());
+            case 8:
+                return proxyBadBufferCommand(new org.apache.activemq.openwire.v8.PartialCommandMarshaller());
+            default:
+                throw new IllegalArgumentException("Unknown OpenWire version of " + version);
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
     <jetty-version-range>[11,13)</jetty-version-range>
     <jmdns-version>3.6.0</jmdns-version>
     <tomcat-api-version>9.0.65</tomcat-api-version>
+    <javassist-version>3.30.2-GA</javassist-version>
     <jettison-version>1.5.4</jettison-version>
     <jmock-version>2.13.1</jmock-version>
     <jolokia-version>2.1.2</jolokia-version>
@@ -924,6 +925,11 @@
         <artifactId>jettison</artifactId>
         <version>${jettison-version}</version>
     </dependency>
+      <dependency>
+        <groupId>org.javassist</groupId>
+        <artifactId>javassist</artifactId>
+        <version>${javassist-version}</version>
+      </dependency>
 
       <dependency>
         <groupId>annogen</groupId>


### PR DESCRIPTION
Verify that size buffers for arrays and bytesequences will not exceed the overall frame size