### PR TITLE
[AMQ-9683] java.io.IOException on idle HTTP/XA connection

### DIFF
--- a/activemq-http/src/main/java/org/apache/activemq/transport/http/HttpTunnelServlet.java
+++ b/activemq-http/src/main/java/org/apache/activemq/transport/http/HttpTunnelServlet.java
@@ -104,11 +104,6 @@ public class HttpTunnelServlet extends HttpServlet {
 
             packet = (Command)transportChannel.getQueue().poll(requestTimeout, TimeUnit.MILLISECONDS);
 
-            // If the packet is ShutDownInfo then we are shutting down so return.
-            if (packet instanceof ShutdownInfo) {
-                return;
-            }
-
             DataOutputStream stream = new DataOutputStream(response.getOutputStream());
             wireFormat.marshal(packet, stream);
             count++;


### PR DESCRIPTION
As described in https://issues.apache.org/jira/browse/AMQ-9683 an EMPTY payload was received in response to a GET, as an intermediate POST sent a shutdown.

This PR implements solution 2, where we simply do not send an empty payload.

Solution 1 is in https://github.com/apache/activemq/pull/1414. We only need one or the other...