### PR TITLE
[AMQ-9683] java.io.IOException on idle HTTP/XA connection

### DIFF
--- a/activemq-http/src/main/java/org/apache/activemq/transport/http/HttpClientTransport.java
+++ b/activemq-http/src/main/java/org/apache/activemq/transport/http/HttpClientTransport.java
@@ -206,7 +206,11 @@ public class HttpClientTransport extends HttpTransportSupport {
                     stream.close();
                 }
             } catch (Exception e) { // handle RuntimeException from unmarshal
-                onException(IOExceptionSupport.create("Failed to perform GET on: " + remoteUrl + " Reason: " + e.getMessage(), e));
+                if (isStopped() || isStopping()) {
+                    LOG.debug("While stopping/stopped failed to perform GET on: " + remoteUrl);
+                } else {
+                    onException(IOExceptionSupport.create("Failed to perform GET on: " + remoteUrl + " Reason: " + e.getMessage(), e));
+                }
                 break;
             } finally {
                 if (answer != null) {


### PR DESCRIPTION
As described in https://issues.apache.org/jira/browse/AMQ-9683 an EMPTY payload was received in response to a GET, as an intermediate POST sent a shutdown.

This PR implements solution 1, where we ignore the exception IFF we are shutting down or we are shutdown.

Solution 2 is in https://github.com/apache/activemq/pull/1413. We only need one or the other...