### PR TITLE
[AMQ-9682] allow array type permission

### DIFF
--- a/activemq-client/src/main/java/org/apache/activemq/util/XStreamSupport.java
+++ b/activemq-client/src/main/java/org/apache/activemq/util/XStreamSupport.java
@@ -18,6 +18,7 @@ package org.apache.activemq.util;
 
 import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.security.AnyTypePermission;
+import com.thoughtworks.xstream.security.ArrayTypePermission;
 import com.thoughtworks.xstream.security.NoTypePermission;
 import com.thoughtworks.xstream.security.PrimitiveTypePermission;
 import org.apache.activemq.util.ClassLoadingAwareObjectInputStream;
@@ -31,6 +32,7 @@ public class XStreamSupport {
         XStream stream = new XStream();
         stream.addPermission(NoTypePermission.NONE);
         stream.addPermission(PrimitiveTypePermission.PRIMITIVES);
+        stream.addPermission(ArrayTypePermission.ARRAYS);
         stream.allowTypeHierarchy(Collection.class);
         stream.allowTypeHierarchy(Map.class);
         stream.allowTypes(new Class[]{String.class});


### PR DESCRIPTION
The payload:
```
<?xml version="1.0" encoding="UTF-8" standalone="no"?>
<org.apache.activemq.command.DataArrayResponse>
    <commandId>0</commandId>
    <responseRequired>false</responseRequired>
    <correlationId>4</correlationId>
    <data class="org.apache.activemq.command.XATransactionId-array"/>
</org.apache.activemq.command.DataArrayResponse> 
```
causes:
```
15:38:26,650 [ActiveMQ Task-2     ] INFO  .a.t.f.FailoverTransport - Successfully reconnected to http://172.17.0.2:61618
15:38:26,650 [p://172.17.0.2:61618] WARN  .a.t.f.FailoverTransport - Transport (http://172.17.0.2:61618) failed, attempting to automatically reconnect
 java.io.IOException: Failed to perform GET on: http://172.17.0.2:61618 Reason: [Lorg.apache.activemq.command.XATransactionId;
	at org.apache.activemq.util.IOExceptionSupport.create(IOExceptionSupport.java:36) ~[activemq-client-6.1.3.jar:6.1.3]
	at org.apache.activemq.transport.http.HttpClientTransport.run(HttpClientTransport.java:209) [activemq-http-6.1.3.jar:6.1.3]
	at java.base/java.lang.Thread.run(Thread.java:840) [?:?]
Caused by: com.thoughtworks.xstream.security.ForbiddenClassException: [Lorg.apache.activemq.command.XATransactionId;
	at com.thoughtworks.xstream.security.NoTypePermission.allows(NoTypePermission.java:26) ~[xstream-1.4.20.jar:1.4.20]
	at com.thoughtworks.xstream.mapper.SecurityMapper.realClass(SecurityMapper.java:74) ~[xstream-1.4.20.jar:1.4.20]
	at com.thoughtworks.xstream.mapper.MapperWrapper.realClass(MapperWrapper.java:125) ~[xstream-1.4.20.jar:1.4.20]
	at com.thoughtworks.xstream.mapper.CachingMapper.realClass(CachingMapper.java:47) ~[xstream-1.4.20.jar:1.4.20]
	at com.thoughtworks.xstream.converters.reflection.AbstractReflectionConverter.doUnmarshal(AbstractReflectionConverter.java:420) ~[xstream-1.4.20.jar:1.4.20]
	at com.thoughtworks.xstream.converters.reflection.AbstractReflectionConverter.unmarshal(AbstractReflectionConverter.java:277) ~[xstream-1.4.20.jar:1.4.20]
	at com.thoughtworks.xstream.core.TreeUnmarshaller.convert(TreeUnmarshaller.java:74) ~[xstream-1.4.20.jar:1.4.20]
	at com.thoughtworks.xstream.core.AbstractReferenceUnmarshaller.convert(AbstractReferenceUnmarshaller.java:72) ~[xstream-1.4.20.jar:1.4.20]
	at com.thoughtworks.xstream.core.TreeUnmarshaller.convertAnother(TreeUnmarshaller.java:68) ~[xstream-1.4.20.jar:1.4.20]
	at com.thoughtworks.xstream.core.TreeUnmarshaller.convertAnother(TreeUnmarshaller.java:52) ~[xstream-1.4.20.jar:1.4.20]
	at com.thoughtworks.xstream.core.TreeUnmarshaller.start(TreeUnmarshaller.java:136) ~[xstream-1.4.20.jar:1.4.20]
	at com.thoughtworks.xstream.core.AbstractTreeMarshallingStrategy.unmarshal(AbstractTreeMarshallingStrategy.java:32) ~[xstream-1.4.20.jar:1.4.20]
	at com.thoughtworks.xstream.XStream.unmarshal(XStream.java:1464) ~[xstream-1.4.20.jar:1.4.20]
	at com.thoughtworks.xstream.XStream.unmarshal(XStream.java:1441) ~[xstream-1.4.20.jar:1.4.20]
	at com.thoughtworks.xstream.XStream.fromXML(XStream.java:1321) ~[xstream-1.4.20.jar:1.4.20]
	at com.thoughtworks.xstream.XStream.fromXML(XStream.java:1312) ~[xstream-1.4.20.jar:1.4.20]
	at org.apache.activemq.transport.xstream.XStreamWireFormat.unmarshalText(XStreamWireFormat.java:65) ~[activemq-http-6.1.3.jar:6.1.3]
	at org.apache.activemq.transport.util.TextWireFormat.unmarshal(TextWireFormat.java:56) ~[activemq-http-6.1.3.jar:6.1.3]
	at org.apache.activemq.transport.http.HttpClientTransport.run(HttpClientTransport.java:200) ~[activemq-http-6.1.3.jar:6.1.3]
	... 1 more 
```

This PR allows the array type permission.