### PR TITLE
AMQ-9693: avoid synchronized blocks

### DIFF
--- a/activemq-ra/src/main/java/org/apache/activemq/ra/ServerSessionImpl.java
+++ b/activemq-ra/src/main/java/org/apache/activemq/ra/ServerSessionImpl.java
@@ -92,6 +92,11 @@ public class ServerSessionImpl implements ServerSession, InboundContext, Work, D
         this.endpoint = endpoint;
         this.useRAManagedTx = useRAManagedTx;
         this.batchSize = batchSize;
+
+        // Ideally we would do that in the start() method, such as we don't stack messages in the session while it's not
+        // yet started.
+        this.session.setMessageListener((MessageListener)endpoint);
+        this.session.setDeliveryListener(this);
     }
 
     private static synchronized int getNextLogId() {
@@ -126,10 +131,6 @@ public class ServerSessionImpl implements ServerSession, InboundContext, Work, D
             log.debug("Start request ignored, already running.");
             return; // already running
         }
-
-        // only start dispatching messages to the listener when we actually start the worker
-        this.session.setMessageListener((MessageListener)endpoint);
-        this.session.setDeliveryListener(this);
 
         // We get here because we need to start a async worker.
         log.debug("Starting run.");

--- a/activemq-ra/src/test/java/org/apache/activemq/ra/ServerSessionImplTest.java
+++ b/activemq-ra/src/test/java/org/apache/activemq/ra/ServerSessionImplTest.java
@@ -33,9 +33,11 @@ import org.jmock.api.Action;
 import org.jmock.api.Invocation;
 import org.jmock.imposters.ByteBuddyClassImposteriser;
 import org.jmock.integration.junit4.JMock;
+import org.jmock.integration.junit4.JUnitRuleMockery;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.slf4j.Logger;
@@ -58,12 +60,20 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @Ignore
 @RunWith(JMock.class)
 public class ServerSessionImplTest {
+
+    @Rule
+    public JUnitRuleMockery context = new JUnitRuleMockery() {
+        {
+            setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
+        }
+    };
 
     private static final Logger LOG = LoggerFactory.getLogger(ServerSessionImplTest.class);
     private static final String BROKER_URL = "vm://localhost?broker.persistent=false";
@@ -75,16 +85,9 @@ public class ServerSessionImplTest {
     private ActiveMQConnection con;
     private ActiveMQSession session;
     private ActiveMQEndpointWorker endpointWorker;
-    private Mockery context;
 
     @Before
     public void setUp() throws Exception {
-        context = new Mockery() {
-            {
-                setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
-            }
-        };
-
         org.apache.activemq.ActiveMQConnectionFactory factory = new org.apache.activemq.ActiveMQConnectionFactory(BROKER_URL);
         con = (ActiveMQConnection) factory.createConnection();
         con.start();
@@ -155,7 +158,7 @@ public class ServerSessionImplTest {
                 will(returnValue(Boolean.FALSE));
                 allowing(messageActivationSpec).isUseRAManagedTransactionEnabled();
                 will(returnValue(Boolean.TRUE));
-                allowing(messageEndpointFactory).createEndpoint(with(any(XAResource.class)));
+                allowing(messageEndpointFactory).createEndpoint(with(nullValue(XAResource.class)));
                 will(returnValue(messageEndpoint));
 
                 allowing(workManager).scheduleWork((Work) with(any(Work.class)), with(any(long.class)), with(any(ExecutionContext.class)),
@@ -190,6 +193,12 @@ public class ServerSessionImplTest {
                 });
                 allowing(messageEndpoint).afterDelivery();
                 allowing(messageEndpoint).release();
+
+                allowing(workManager).scheduleWork(
+                    with(any(Work.class)),
+                    with(any(Long.TYPE)),
+                    with(nullValue(ExecutionContext.class)),
+                    with(nullValue(WorkListener.class)));
 
             }
         });
@@ -283,7 +292,7 @@ public class ServerSessionImplTest {
                 will(returnValue(Boolean.FALSE));
                 allowing(messageActivationSpec).isUseRAManagedTransactionEnabled();
                 will(returnValue(Boolean.TRUE));
-                allowing(messageEndpointFactory).createEndpoint(with(any(XAResource.class)));
+                allowing(messageEndpointFactory).createEndpoint(with(nullValue(XAResource.class)));
                 will(returnValue(messageEndpoint));
 
                 allowing(workManager).scheduleWork((Work) with(any(Work.class)), with(any(long.class)), with(any(ExecutionContext.class)),
@@ -345,6 +354,12 @@ public class ServerSessionImplTest {
                     }
                 });
                 allowing(messageEndpoint).release();
+
+                allowing(workManager).scheduleWork(
+                    with(any(Work.class)),
+                    with(any(Long.TYPE)),
+                    with(nullValue(ExecutionContext.class)),
+                    with(nullValue(WorkListener.class)));
 
             }
         });
@@ -474,12 +489,18 @@ public class ServerSessionImplTest {
                 will(returnValue(Boolean.FALSE));
                 allowing(messageActivationSpec).isUseRAManagedTransactionEnabled();
                 will(returnValue(Boolean.TRUE));
-                allowing(messageEndpointFactory).createEndpoint(with(any(XAResource.class)));
+                allowing(messageEndpointFactory).createEndpoint(with(nullValue(XAResource.class)));
                 will(returnValue(messageEndpoint));
 
                 allowing(workManager).scheduleWork((Work) with(any(Work.class)), with(any(long.class)), with(any(ExecutionContext.class)),
                         with(any(WorkListener.class)));
                 allowing(messageEndpoint).release();
+
+                allowing(workManager).scheduleWork(
+                    with(any(Work.class)),
+                    with(any(Long.TYPE)),
+                    with(nullValue(ExecutionContext.class)),
+                    with(nullValue(WorkListener.class)));
             }
         });
 

--- a/pom.xml
+++ b/pom.xml
@@ -31,9 +31,6 @@
   <inceptionYear>2005</inceptionYear>
 
   <properties>
-    <!-- for reproducible builds -->
-    <project.build.outputTimestamp>2024-04-29T15:51:45Z</project.build.outputTimestamp>
-
     <maven.compiler.target>17</maven.compiler.target>
 
     <!-- for reproducible builds -->	

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,10 @@
     <project.build.outputTimestamp>2024-04-29T15:51:45Z</project.build.outputTimestamp>
 
     <maven.compiler.target>17</maven.compiler.target>
+
+    <!-- for reproducible builds -->	
+    <project.build.outputTimestamp>2024-04-29T15:51:45Z</project.build.outputTimestamp>
+
     <siteId>activemq-${project.version}</siteId>
     <projectName>Apache ActiveMQ</projectName>
     <!-- base url for site deployment.  See distribution management for full url.  Override this in settings.xml for staging -->

--- a/pom.xml
+++ b/pom.xml
@@ -33,9 +33,6 @@
   <properties>
     <maven.compiler.target>17</maven.compiler.target>
 
-    <!-- for reproducible builds -->	
-    <project.build.outputTimestamp>2024-04-29T15:51:45Z</project.build.outputTimestamp>
-
     <siteId>activemq-${project.version}</siteId>
     <projectName>Apache ActiveMQ</projectName>
     <!-- base url for site deployment.  See distribution management for full url.  Override this in settings.xml for staging -->

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,9 @@
   <inceptionYear>2005</inceptionYear>
 
   <properties>
+    <!-- for reproducible builds -->
+    <project.build.outputTimestamp>2024-04-29T15:51:45Z</project.build.outputTimestamp>
+
     <maven.compiler.target>17</maven.compiler.target>
     <siteId>activemq-${project.version}</siteId>
     <projectName>Apache ActiveMQ</projectName>


### PR DESCRIPTION
This PR fixes a couple of issues in the RA.

- move the running flag to a non-blocking approach (remove synchronized on a mutex and use AtomicBoolean)
- update the running to false if we can shedule a task in the worker
- move the listener initialization to the #start which is functionally better and avoid stacking messages in the session while it's not started
- avoid pulling a stale (or not running) session from the pool if we can find otherwise