### PR TITLE
AMQ-9698 - Fix message expiration on durable subs

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/broker/region/DurableTopicSubscription.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/region/DurableTopicSubscription.java
@@ -299,6 +299,16 @@ public class DurableTopicSubscription extends PrefetchSubscription implements Us
     }
 
     @Override
+    protected void processExpiredAck(ConnectionContext context, Destination dest,
+        MessageReference node) {
+
+        // Each subscription needs to expire both on the store and
+        // decrement the reference count
+        super.processExpiredAck(context, dest, node);
+        node.decrementReferenceCount();
+    }
+
+    @Override
     protected void doAddRecoveredMessage(MessageReference message) throws Exception {
         synchronized (pending) {
             pending.addRecoveredMessage(message);

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/region/PrefetchSubscription.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/region/PrefetchSubscription.java
@@ -298,9 +298,8 @@ public abstract class PrefetchSubscription extends AbstractSubscription {
                         inAckRange = true;
                     }
                     if (inAckRange) {
-                        Destination regionDestination = nodeDest;
                         if (broker.isExpired(node)) {
-                            regionDestination.messageExpired(context, this, node);
+                            processExpiredAck(context, nodeDest, node);
                         }
                         iter.remove();
                         decrementPrefetchCounter(node);
@@ -394,6 +393,11 @@ public abstract class PrefetchSubscription extends AbstractSubscription {
         } else {
             LOG.debug("Acknowledgment out of sync (Normally occurs when failover connection reconnects): {}", ack);
         }
+    }
+
+    protected void processExpiredAck(final ConnectionContext context, final Destination dest,
+        final MessageReference node) {
+        dest.messageExpired(context, this, node);
     }
 
     private void registerRemoveSync(ConnectionContext context, final MessageReference node) {

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/region/Topic.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/region/Topic.java
@@ -21,6 +21,8 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -29,6 +31,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
+import java.util.stream.Collectors;
 import org.apache.activemq.advisory.AdvisorySupport;
 import org.apache.activemq.broker.BrokerService;
 import org.apache.activemq.broker.ConnectionContext;
@@ -53,6 +56,7 @@ import org.apache.activemq.filter.MessageEvaluationContext;
 import org.apache.activemq.filter.NonCachedMessageEvaluationContext;
 import org.apache.activemq.management.MessageFlowStats;
 import org.apache.activemq.store.MessageRecoveryListener;
+import org.apache.activemq.store.MessageStore.StoreType;
 import org.apache.activemq.store.NoLocalSubscriptionAware;
 import org.apache.activemq.store.PersistenceAdapter;
 import org.apache.activemq.store.TopicMessageStore;
@@ -826,14 +830,51 @@ public class Topic extends BaseDestination implements Task {
     }
 
     private final AtomicBoolean expiryTaskInProgress = new AtomicBoolean(false);
-    private final Runnable expireMessagesWork = new Runnable() {
-        @Override
-        public void run() {
-            List<Message> browsedMessages = new InsertionCountList<Message>();
-            doBrowse(browsedMessages, getMaxExpirePageSize());
+    private final Runnable expireMessagesWork = () -> {
+        try {
+            final TopicMessageStore store = Topic.this.topicStore;
+            if (store != null && store.getType() == StoreType.KAHADB) {
+                // get the sub keys that should be checked for expired messages
+                final var subs = durableSubscribers.entrySet().stream()
+                    .filter(entry -> isEligibleForExpiration(entry.getValue()))
+                    .map(Entry::getKey).collect(Collectors.toSet());
+
+                // For each eligible subscription, return the messages in the store that are expired
+                // The same message refs are shared between subs if duplicated so this is efficient
+                var expired = store.recoverExpired(subs, getMaxExpirePageSize());
+
+                final ConnectionContext connectionContext = createConnectionContext();
+                // Go through any expired messages and remove for each sub
+                for (Entry<SubscriptionKey, List<Message>> entry : expired.entrySet()) {
+                    DurableTopicSubscription sub = durableSubscribers.get(entry.getKey());
+                    List<Message> expiredMessages = entry.getValue();
+
+                    // If the sub still exists and there are expired messages then process
+                    if (sub != null && !expiredMessages.isEmpty()) {
+                        // double check still in active inside the pendingLock
+                        // and iterate over each message and expire. There's a small race condition
+                        // here if the sub comes online, but it's not a big deal as at worst there
+                        // maybe be duplicate acks for the expired message but the store can handle it
+                        if (isEligibleForExpiration(sub)) {
+                            expiredMessages.forEach(message -> {
+                                message.setRegionDestination(Topic.this);
+                                messageExpired(connectionContext, sub, message);
+                            });
+                        }
+                    }
+                }
+            } else {
+                // If not KahaDB, fall back to the legacy browse method because
+                // the recoverExpired() method is not supported
+                doBrowse(new InsertionCountList<>(), getMaxExpirePageSize());
+            }
+        } catch (Throwable e) {
+            LOG.warn("Failed to expire messages on Topic: {}", getActiveMQDestination().getPhysicalName(), e);
+        } finally {
             expiryTaskInProgress.set(false);
         }
     };
+
     private final Runnable expireMessagesTask = new Runnable() {
         @Override
         public void run() {
@@ -925,6 +966,10 @@ public class Topic extends BaseDestination implements Task {
                         exception);
             }
         }
+    }
+
+    private static boolean isEligibleForExpiration(DurableTopicSubscription sub) {
+        return sub.isEnableMessageExpirationOnActiveDurableSubs() || !sub.isActive();
     }
 
     public Map<SubscriptionKey, DurableTopicSubscription> getDurableTopicSubs() {

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/region/Topic.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/region/Topic.java
@@ -861,10 +861,9 @@ public class Topic extends BaseDestination implements Task {
 
                     // If the sub still exists and there are expired messages then process
                     if (sub != null && !expiredMessages.isEmpty()) {
-                        // double check still in active inside the pendingLock
-                        // and iterate over each message and expire. There's a small race condition
-                        // here if the sub comes online, but it's not a big deal as at worst there
-                        // maybe be duplicate acks for the expired message but the store can handle it
+                        // There's a small race condition here if the sub comes online,
+                        // but it's not a big deal as at worst there maybe be duplicate acks for
+                        // the expired message but the store can handle it
                         if (isEligibleForExpiration(sub)) {
                             expiredMessages.forEach(message -> {
                                 message.setRegionDestination(Topic.this);

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/region/cursors/AbstractStoreCursor.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/region/cursors/AbstractStoreCursor.java
@@ -114,7 +114,7 @@ public abstract class AbstractStoreCursor extends AbstractPendingMessageCursor i
                 }
             }
             message.incrementReferenceCount();
-            batchList.addMessageLast(message);
+            batchList.addMessageLast(createBatchListRef(message));
             clearIterator(true);
             recovered = true;
         } else if (!cached) {
@@ -134,6 +134,10 @@ public abstract class AbstractStoreCursor extends AbstractPendingMessageCursor i
             }
         }
         return recovered;
+    }
+
+    protected MessageReference createBatchListRef(Message message) {
+        return message;
     }
 
     protected boolean duplicateFromStoreExcepted(Message message) {
@@ -448,12 +452,14 @@ public abstract class AbstractStoreCursor extends AbstractPendingMessageCursor i
 
     @Override
     public final synchronized void remove(MessageReference node) {
-        if (batchList.remove(node) != null) {
+        final PendingNode message = batchList.remove(node);
+        if (message != null) {
             size--;
             setCacheEnabled(false);
+            // decrement reference count if removed from batchList
+            message.getMessage().decrementReferenceCount();
         }
     }
-
 
     @Override
     public final synchronized void clear() {

--- a/activemq-broker/src/main/java/org/apache/activemq/store/MessageStore.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/store/MessageStore.java
@@ -215,4 +215,10 @@ public interface MessageStore extends Service {
 
     void registerIndexListener(IndexListener indexListener);
 
+    StoreType getType();
+
+    enum StoreType {
+        MEMORY, JDBC, KAHADB, TEMP_KAHADB
+    }
+
 }

--- a/activemq-broker/src/main/java/org/apache/activemq/store/ProxyMessageStore.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/store/ProxyMessageStore.java
@@ -185,4 +185,8 @@ public class ProxyMessageStore implements MessageStore {
         return delegate.getMessageStoreStatistics();
     }
 
+    @Override
+    public StoreType getType() {
+        return delegate.getType();
+    }
 }

--- a/activemq-broker/src/main/java/org/apache/activemq/store/ProxyTopicMessageStore.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/store/ProxyTopicMessageStore.java
@@ -18,6 +18,9 @@ package org.apache.activemq.store;
 
 import java.io.IOException;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import org.apache.activemq.broker.ConnectionContext;
 import org.apache.activemq.command.ActiveMQDestination;
 import org.apache.activemq.command.Message;
@@ -25,6 +28,7 @@ import org.apache.activemq.command.MessageAck;
 import org.apache.activemq.command.MessageId;
 import org.apache.activemq.command.SubscriptionInfo;
 import org.apache.activemq.usage.MemoryUsage;
+import org.apache.activemq.util.SubscriptionKey;
 
 /**
  * A simple proxy that delegates to another MessageStore.
@@ -234,5 +238,10 @@ public class ProxyTopicMessageStore extends ProxyMessageStore implements TopicMe
     @Override
     public MessageStoreSubscriptionStatistics getMessageStoreSubStatistics() {
         return ((TopicMessageStore)delegate).getMessageStoreSubStatistics();
+    }
+
+    @Override
+    public Map<SubscriptionKey, List<Message>> recoverExpired(Set<SubscriptionKey> subs, int max) throws Exception {
+        return ((TopicMessageStore)delegate).recoverExpired(subs, max);
     }
 }

--- a/activemq-broker/src/main/java/org/apache/activemq/store/TopicMessageStore.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/store/TopicMessageStore.java
@@ -20,10 +20,15 @@ import java.io.IOException;
 
 import jakarta.jms.JMSException;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import org.apache.activemq.broker.ConnectionContext;
+import org.apache.activemq.command.Message;
 import org.apache.activemq.command.MessageAck;
 import org.apache.activemq.command.MessageId;
 import org.apache.activemq.command.SubscriptionInfo;
+import org.apache.activemq.util.SubscriptionKey;
 
 /**
  * A MessageStore for durable topic subscriptions
@@ -154,4 +159,16 @@ public interface TopicMessageStore extends MessageStore {
      * @throws IOException
      */
     void addSubscription(SubscriptionInfo subscriptionInfo, boolean retroactive) throws IOException;
+
+    /**
+     * Iterates over the pending messages in a topic and recovers any expired messages found for
+     * each of the subscriptions up to the maximum number of messages to search.
+     *
+     * @param subs
+     * @param max
+     * @return
+     * @throws Exception
+     */
+    Map<SubscriptionKey,List<Message>> recoverExpired(Set<SubscriptionKey> subs, int max) throws Exception;
+
 }

--- a/activemq-broker/src/main/java/org/apache/activemq/store/TopicMessageStore.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/store/TopicMessageStore.java
@@ -162,11 +162,12 @@ public interface TopicMessageStore extends MessageStore {
 
     /**
      * Iterates over the pending messages in a topic and recovers any expired messages found for
-     * each of the subscriptions up to the maximum number of messages to search.
+     * each of the subscriptions up to the maximum number of messages to search. Only subscriptions
+     * that have at least 1 expired message will be returned in the map.
      *
      * @param subs
      * @param max
-     * @return
+     * @return Expired messages for each subscription
      * @throws Exception
      */
     Map<SubscriptionKey,List<Message>> recoverExpired(Set<SubscriptionKey> subs, int max) throws Exception;

--- a/activemq-broker/src/main/java/org/apache/activemq/store/memory/MemoryMessageStore.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/store/memory/MemoryMessageStore.java
@@ -177,6 +177,11 @@ public class MemoryMessageStore extends AbstractMessageStore {
         }
     }
 
+    @Override
+    public StoreType getType() {
+        return StoreType.MEMORY;
+    }
+
     protected static final void incMessageStoreStatistics(final MessageStoreStatistics stats, final Message message) {
         if (stats != null && message != null) {
             stats.getMessageCount().increment();

--- a/activemq-broker/src/main/java/org/apache/activemq/store/memory/MemoryTopicMessageStore.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/store/memory/MemoryTopicMessageStore.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import java.util.Set;
 import org.apache.activemq.broker.ConnectionContext;
 import org.apache.activemq.command.ActiveMQDestination;
 import org.apache.activemq.command.Message;
@@ -178,6 +179,11 @@ public class MemoryTopicMessageStore extends MemoryMessageStore implements Topic
         if (sub != null) {
             sub.resetBatching();
         }
+    }
+
+    @Override
+    public Map<SubscriptionKey, List<Message>> recoverExpired(Set<SubscriptionKey> subs, int max) {
+        throw new UnsupportedOperationException("recoverExpired not supported");
     }
 
     // Disabled for the memory store, can be enabled later if necessary

--- a/activemq-jdbc-store/src/main/java/org/apache/activemq/store/jdbc/JDBCMessageStore.java
+++ b/activemq-jdbc-store/src/main/java/org/apache/activemq/store/jdbc/JDBCMessageStore.java
@@ -482,4 +482,10 @@ public class JDBCMessageStore extends AbstractMessageStore {
         return destination.getPhysicalName() + ",pendingSize:" + pendingAdditions.size();
     }
 
+
+    @Override
+    public StoreType getType() {
+        return StoreType.JDBC;
+    }
+
 }

--- a/activemq-jdbc-store/src/main/java/org/apache/activemq/store/jdbc/JDBCTopicMessageStore.java
+++ b/activemq-jdbc-store/src/main/java/org/apache/activemq/store/jdbc/JDBCTopicMessageStore.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -40,6 +41,7 @@ import org.apache.activemq.store.MessageStoreSubscriptionStatistics;
 import org.apache.activemq.store.TopicMessageStore;
 import org.apache.activemq.util.ByteSequence;
 import org.apache.activemq.util.IOExceptionSupport;
+import org.apache.activemq.util.SubscriptionKey;
 import org.apache.activemq.wireformat.WireFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -358,6 +360,11 @@ public class JDBCTopicMessageStore extends JDBCMessageStore implements TopicMess
         } finally {
             c.close();
         }
+    }
+
+    @Override
+    public Map<SubscriptionKey, List<Message>> recoverExpired(Set<SubscriptionKey> subs, int max) {
+        throw new UnsupportedOperationException("recoverExpired not supported");
     }
 
     /**

--- a/activemq-kahadb-store/src/main/java/org/apache/activemq/store/kahadb/KahaDBStore.java
+++ b/activemq-kahadb-store/src/main/java/org/apache/activemq/store/kahadb/KahaDBStore.java
@@ -83,12 +83,14 @@ import org.apache.activemq.store.kahadb.data.KahaSubscriptionCommand;
 import org.apache.activemq.store.kahadb.data.KahaUpdateMessageCommand;
 import org.apache.activemq.store.kahadb.disk.journal.Location;
 import org.apache.activemq.store.kahadb.disk.page.Transaction;
+import org.apache.activemq.store.kahadb.disk.page.Transaction.CallableClosure;
 import org.apache.activemq.store.kahadb.disk.util.SequenceSet;
 import org.apache.activemq.store.kahadb.scheduler.JobSchedulerStoreImpl;
 import org.apache.activemq.usage.MemoryUsage;
 import org.apache.activemq.usage.SystemUsage;
 import org.apache.activemq.util.IOExceptionSupport;
 import org.apache.activemq.util.ServiceStopper;
+import org.apache.activemq.util.SubscriptionKey;
 import org.apache.activemq.util.ThreadPoolUtils;
 import org.apache.activemq.wireformat.WireFormat;
 import org.slf4j.Logger;
@@ -958,9 +960,14 @@ public class KahaDBStore extends MessageDatabase implements PersistenceAdapter, 
                 unlockAsyncJobQueue();
             }
         }
+
+        @Override
+        public StoreType getType() {
+            return StoreType.KAHADB;
+        }
     }
 
-    class KahaDBTopicMessageStore extends KahaDBMessageStore implements TopicMessageStore {
+    class KahaDBTopicMessageStore extends KahaDBMessageStore implements TopicMessageStore{
         private final AtomicInteger subscriptionCount = new AtomicInteger();
         protected final MessageStoreSubscriptionStatistics messageStoreSubStats =
                 new MessageStoreSubscriptionStatistics(isEnableSubscriptionStatistics());
@@ -1318,6 +1325,58 @@ public class KahaDBStore extends MessageDatabase implements PersistenceAdapter, 
                         }
                     }
                 });
+            } finally {
+                indexLock.writeLock().unlock();
+            }
+        }
+
+        @Override
+        public Map<SubscriptionKey,List<Message>> recoverExpired(Set<SubscriptionKey> subscriptions, int max) throws Exception {
+            indexLock.writeLock().lock();
+            try {
+                return pageFile.tx().execute(
+                    (CallableClosure<Map<SubscriptionKey,List<Message>>, Exception>) tx -> {
+                        StoredDestination sd = getStoredDestination(dest, tx);
+                        sd.orderIndex.resetCursorPosition();
+                        int count = 0;
+                        final Map<SubscriptionKey, List<Message>> expired = new HashMap<>();
+                        final Map<String, SubscriptionKey> subKeys = new HashMap<>();
+
+                        // Check each subscription and track the ones that exist
+                        for (SubscriptionKey sub : subscriptions) {
+                            final String subKeyString = subscriptionKey(sub.getClientId(), sub.getSubscriptionName());
+                            if (sd.subscriptionCache.contains(subKeyString)) {
+                                subKeys.put(subKeyString, sub);
+                            }
+                        }
+
+                        // Iterate one time through the topic and check each message, stopping if we run out
+                        // or reach the max
+                        for (Iterator<Entry<Long, MessageKeys>> iterator =
+                            sd.orderIndex.iterator(tx, new MessageOrderCursor()); count < max && iterator.hasNext(); ) {
+                            count++;
+                            Entry<Long, MessageKeys> entry = iterator.next();
+                            Set<String> ackedAndPrepared = ackedAndPreparedMap.get(destination.getPhysicalName());
+                            if (ackedAndPrepared != null && ackedAndPrepared.contains(entry.getValue().messageId)) {
+                                continue;
+                            }
+
+                            final Message msg = loadMessage(entry.getValue().location);
+                            if (msg.isExpired()) {
+                                // For every message that is expired, go through and check each subscription to see
+                                // if the message has already been acked. We don't want to return subs that have already
+                                // acked the message.
+                                for(Entry<String, SubscriptionKey> subKeyEntry : subKeys.entrySet()) {
+                                    SequenceSet sequence = sd.ackPositions.get(tx, subKeyEntry.getKey());
+                                    if (sequence != null && sequence.contains(entry.getKey())) {
+                                        List<Message> expMessages = expired.computeIfAbsent(subKeyEntry.getValue(), m -> new ArrayList<>());
+                                        expMessages.add(msg);
+                                    }
+                                }
+                            }
+                        }
+                        return expired;
+                    });
             } finally {
                 indexLock.writeLock().unlock();
             }

--- a/activemq-kahadb-store/src/main/java/org/apache/activemq/store/kahadb/TempKahaDBStore.java
+++ b/activemq-kahadb-store/src/main/java/org/apache/activemq/store/kahadb/TempKahaDBStore.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -63,6 +64,7 @@ import org.apache.activemq.store.kahadb.disk.page.Transaction;
 import org.apache.activemq.usage.MemoryUsage;
 import org.apache.activemq.usage.SystemUsage;
 import org.apache.activemq.util.ByteSequence;
+import org.apache.activemq.util.SubscriptionKey;
 import org.apache.activemq.wireformat.WireFormat;
 
 public class TempKahaDBStore extends TempMessageDatabase implements PersistenceAdapter, BrokerServiceAware {
@@ -299,6 +301,10 @@ public class TempKahaDBStore extends TempMessageDatabase implements PersistenceA
             getMessageStoreStatistics().getMessageCount().setCount(count);
         }
 
+        @Override
+        public StoreType getType() {
+            return StoreType.TEMP_KAHADB;
+        }
     }
 
     class KahaDBTopicMessageStore extends KahaDBMessageStore implements TopicMessageStore {
@@ -330,6 +336,11 @@ public class TempKahaDBStore extends TempMessageDatabase implements PersistenceA
             org.apache.activemq.util.ByteSequence packet = wireFormat.marshal(subscriptionInfo);
             command.setSubscriptionInfo(new Buffer(packet.getData(), packet.getOffset(), packet.getLength()));
             process(command);
+        }
+
+        @Override
+        public Map<SubscriptionKey, List<Message>> recoverExpired(Set<SubscriptionKey> subs, int max) {
+            throw new UnsupportedOperationException("recoverExpired not supported");
         }
 
         @Override

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/broker/MessageExpirationTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/broker/MessageExpirationTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.activemq.broker;
 
+import static org.junit.Assert.assertEquals;
+
 import jakarta.jms.DeliveryMode;
 
 import junit.framework.Test;
@@ -30,6 +32,7 @@ import org.apache.activemq.command.Message;
 import org.apache.activemq.command.MessageAck;
 import org.apache.activemq.command.ProducerInfo;
 import org.apache.activemq.command.SessionInfo;
+import org.apache.activemq.util.Wait;
 
 public class MessageExpirationTest extends BrokerTestSupport {
 
@@ -261,6 +264,11 @@ public class MessageExpirationTest extends BrokerTestSupport {
         assertNoMessagesLeft(connection);
 
         connection.send(closeConnectionInfo(connectionInfo));
+
+        if (!destination.isTemporary()) {
+            assertTrue(Wait.waitFor(
+                () -> broker.getDestination(destination).getMemoryUsage().getUsage() == 0, 1000, 100));
+        }
     }
 
     public static Test suite() {

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/broker/region/cursors/AbstractPendingMessageCursorTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/broker/region/cursors/AbstractPendingMessageCursorTest.java
@@ -76,7 +76,7 @@ public abstract class AbstractPendingMessageCursorTest extends AbstractStoreStat
     protected boolean enableSubscriptionStatistics;
 
     @Rule
-    public Timeout globalTimeout= new Timeout(60, TimeUnit.SECONDS);
+    public Timeout globalTimeout = new Timeout(60, TimeUnit.SECONDS);
 
     /**
      * @param prioritizedMessages

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/broker/region/cursors/StoreCursorRemoveFromCacheTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/broker/region/cursors/StoreCursorRemoveFromCacheTest.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.broker.region.cursors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.function.BiConsumer;
+import org.apache.activemq.broker.BrokerService;
+import org.apache.activemq.broker.region.DestinationStatistics;
+import org.apache.activemq.broker.region.MessageReference;
+import org.apache.activemq.broker.region.Queue;
+import org.apache.activemq.command.ActiveMQQueue;
+import org.apache.activemq.command.ActiveMQTextMessage;
+import org.apache.activemq.command.MessageId;
+import org.apache.activemq.store.MessageStore;
+import org.apache.activemq.store.kahadb.KahaDBStore;
+import org.apache.activemq.usage.SystemUsage;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class StoreCursorRemoveFromCacheTest {
+
+    @Rule
+    public TemporaryFolder dataFileDir = new TemporaryFolder();
+
+    private final ActiveMQQueue destination = new ActiveMQQueue("queue");
+    private BrokerService broker;
+    private SystemUsage systemUsage;
+    private KahaDBStore store;
+
+    @Before
+    public void setUp() throws Exception {
+        broker = new BrokerService();
+        broker.setUseJmx(false);
+        broker.setPersistent(true);
+        KahaDBStore store = new KahaDBStore();
+        store.setDirectory(dataFileDir.getRoot());
+        broker.setPersistenceAdapter(store);
+        broker.start();
+        systemUsage = broker.getSystemUsage();
+        this.store = (KahaDBStore) broker.getPersistenceAdapter();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        broker.stop();
+    }
+
+    @Test(timeout = 10000)
+    public void testRemoveFromCacheIterator() throws Exception {
+        testRemoveFromCache((cursor, ref) -> {
+            // test removing using the iterator
+            cursor.remove();
+        });
+    }
+
+    @Test(timeout = 10000)
+    public void testRemoveFromCacheRemoveMethod() throws Exception {
+        testRemoveFromCache((cursor, ref) -> {
+            // test using the remove method directly
+            // remove should also decrement after AMQ-9698, previously it did not
+            cursor.remove(ref);
+            assertEquals(0, ref.getReferenceCount());
+
+            // Call a second time to make sure we don't go negative
+            // and it will skip
+            cursor.remove(ref);
+            assertEquals(0, ref.getReferenceCount());
+        });
+    }
+
+    private void testRemoveFromCache(BiConsumer<QueueStorePrefetch, MessageReference> remove) throws Exception {
+        var systemUsage = broker.getSystemUsage();
+        final KahaDBStore store = (KahaDBStore) broker.getPersistenceAdapter();
+        final MessageStore messageStore = store.createQueueMessageStore(destination);
+        final Queue queue = new Queue(broker, destination, messageStore, new DestinationStatistics(), null);
+        var memoryUsage = queue.getMemoryUsage();
+
+        // create cursor and make sure cache is enabled
+        QueueStorePrefetch cursor = new QueueStorePrefetch(queue, broker.getBroker());
+        cursor.setSystemUsage(systemUsage);
+        cursor.start();
+        assertTrue("cache enabled", cursor.isUseCache() && cursor.isCacheEnabled());
+
+        for (int i = 0; i < 10; i++) {
+            ActiveMQTextMessage msg = getMessage(i);
+            msg.setMemoryUsage(memoryUsage);
+            cursor.addMessageLast(msg);
+            // reference count of 1 for the cache
+            assertEquals(1, msg.getReferenceCount());
+        }
+
+        assertTrue(memoryUsage.getUsage() > 0);
+
+        cursor.reset();
+        while (cursor.hasNext()) {
+            // next will increment again so need to decrement the reference
+            // next is required to be called for remove() to work
+            var ref = cursor.next();
+            assertEquals(2, ref.getReferenceCount());
+            ref.decrementReferenceCount();
+            remove.accept(cursor, ref);
+            assertEquals(0, ref.getReferenceCount());
+        }
+
+        assertEquals(0, memoryUsage.getUsage());
+        assertEquals(0, cursor.size());
+    }
+
+    private ActiveMQTextMessage getMessage(int i) throws Exception {
+        ActiveMQTextMessage message = new ActiveMQTextMessage();
+        MessageId id = new MessageId("11111:22222:" + i);
+        id.setBrokerSequenceId(i);
+        id.setProducerSequenceId(i);
+        message.setMessageId(id);
+        message.setDestination(destination);
+        message.setPersistent(true);
+        message.setResponseRequired(true);
+        message.setText("Msg:" + i + " " + "test");
+        assertEquals(message.getMessageId().getProducerSequenceId(), i);
+        return message;
+    }
+
+}

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/broker/region/cursors/StoreQueueCursorOrderTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/broker/region/cursors/StoreQueueCursorOrderTest.java
@@ -517,6 +517,11 @@ public class StoreQueueCursorOrderTest {
         }
 
         @Override
+        public StoreType getType() {
+            return StoreType.MEMORY;
+        }
+
+        @Override
         public void recoverMessageStoreStatistics() throws IOException {
             this.getMessageStoreStatistics().reset();
         }

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/store/kahadb/KahaDBRecoverExpiredTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/store/kahadb/KahaDBRecoverExpiredTest.java
@@ -1,0 +1,286 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.store.kahadb;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import jakarta.jms.Connection;
+import jakarta.jms.JMSException;
+import jakarta.jms.Message;
+import jakarta.jms.MessageProducer;
+import jakarta.jms.Session;
+import jakarta.jms.TopicSession;
+import java.io.File;
+import java.net.URI;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import org.apache.activemq.ActiveMQConnectionFactory;
+import org.apache.activemq.broker.BrokerService;
+import org.apache.activemq.broker.TransportConnector;
+import org.apache.activemq.broker.region.Destination;
+import org.apache.activemq.command.ActiveMQTextMessage;
+import org.apache.activemq.command.ActiveMQTopic;
+import org.apache.activemq.command.MessageAck;
+import org.apache.activemq.store.TopicMessageStore;
+import org.apache.activemq.util.SubscriptionKey;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.rules.Timeout;
+
+/**
+ * Test for {@link TopicMessageStore#recoverExpired(Set, int)}
+ */
+public class KahaDBRecoverExpiredTest {
+
+  @Rule
+  public Timeout globalTimeout = new Timeout(60, TimeUnit.SECONDS);
+
+  @Rule
+  public TemporaryFolder dataFileDir = new TemporaryFolder(new File("target"));
+
+  private BrokerService broker;
+  private URI brokerConnectURI;
+  private final ActiveMQTopic topic = new ActiveMQTopic("test.topic");
+  private final SubscriptionKey subKey1 = new SubscriptionKey("clientId", "sub1");
+  private final SubscriptionKey subKey2 = new SubscriptionKey("clientId", "sub2");
+
+  @Before
+  public void startBroker() throws Exception {
+    broker = new BrokerService();
+    broker.setPersistent(true);
+    KahaDBPersistenceAdapter persistenceAdapter = new KahaDBPersistenceAdapter();
+    persistenceAdapter.setDirectory(dataFileDir.getRoot());
+    broker.setPersistenceAdapter(persistenceAdapter);
+    //set up a transport
+    TransportConnector connector = broker
+        .addConnector(new TransportConnector());
+    connector.setUri(new URI("tcp://0.0.0.0:0"));
+    connector.setName("tcp");
+    broker.start();
+    broker.waitUntilStarted();
+    brokerConnectURI = broker.getConnectorByName("tcp").getConnectUri();
+  }
+
+  @After
+  public void stopBroker() throws Exception {
+    broker.stop();
+    broker.waitUntilStopped();
+  }
+
+  private Session initializeSubs() throws JMSException {
+    Connection connection = new ActiveMQConnectionFactory(brokerConnectURI).createConnection();
+    connection.setClientID("clientId");
+    connection.start();
+
+    Session session = connection.createSession(false, TopicSession.AUTO_ACKNOWLEDGE);
+    session.createDurableSubscriber(topic, "sub1");
+    session.createDurableSubscriber(topic, "sub2");
+
+    return session;
+  }
+
+  // test recover expired works in general, verify does not return
+  // expired if subs have already acked
+  @Test
+  public void testRecoverExpired() throws Exception {
+    try (Session session = initializeSubs()) {
+      MessageProducer prod = session.createProducer(topic);
+
+      Destination dest = broker.getDestination(topic);
+      TopicMessageStore store = (TopicMessageStore) dest.getMessageStore();
+
+      // nothing should be expired yet, no messags
+      var expired = store.recoverExpired(Set.of(subKey1, subKey2), 100);
+      assertTrue(expired.isEmpty());
+
+      // Sent 10 messages, alternating no expiration and 1 second ttl
+      for (int i = 0; i < 10; i++) {
+        ActiveMQTextMessage message = new ActiveMQTextMessage();
+        message.setText("message" + i);
+        var ttl = i % 2 == 0 ? 1000 : 0;
+        prod.send(message, Message.DEFAULT_DELIVERY_MODE, Message.DEFAULT_PRIORITY, ttl);
+      }
+
+      // wait for the time to pass the point of needing expiration
+      Thread.sleep(1500);
+      // We should now find both durables have 5 expired messages
+      expired = store.recoverExpired(Set.of(subKey1, subKey2), 100);
+      assertEquals(2, expired.size());
+      assertEquals(5, expired.get(subKey1).size());
+      assertEquals(5, expired.get(subKey2).size());
+
+      // Acknowledge the first 2 messages of only the first sub
+      for (int i = 0; i < 2; i++) {
+        MessageAck ack = new MessageAck();
+        ack.setLastMessageId(expired.get(subKey1).get(i).getMessageId());
+        ack.setAckType(MessageAck.EXPIRED_ACK_TYPE);
+        ack.setDestination(topic);
+        store.acknowledge(broker.getAdminConnectionContext(),"clientId", "sub1",
+            ack.getLastMessageId(), ack);
+      }
+
+      // Now the first sub should only have 3 expired, but still 5 on the second
+      expired = store.recoverExpired(Set.of(subKey1, subKey2), 100);
+      assertEquals(3, expired.get(subKey1).size());
+      assertEquals(5, expired.get(subKey2).size());
+
+      // ack all remaining
+      for (Entry<SubscriptionKey, List<org.apache.activemq.command.Message>> entry : expired.entrySet()) {
+        for (org.apache.activemq.command.Message message : entry.getValue()) {
+          MessageAck ack = new MessageAck();
+          ack.setLastMessageId(message.getMessageId());
+          ack.setAckType(MessageAck.EXPIRED_ACK_TYPE);
+          ack.setDestination(topic);
+          store.acknowledge(broker.getAdminConnectionContext(),entry.getKey().getClientId(),
+              entry.getKey().getSubscriptionName(), ack.getLastMessageId(), ack);
+        }
+      }
+
+      // should be empty again
+      expired = store.recoverExpired(Set.of(subKey1, subKey2), 100);
+      assertTrue(expired.isEmpty());
+    }
+
+  }
+
+  // test max number of messages to check works
+  @Test
+  public void testRecoverExpiredMax() throws Exception {
+    try (Session session = initializeSubs()) {
+      MessageProducer prod = session.createProducer(topic);
+
+      Destination dest = broker.getDestination(topic);
+      TopicMessageStore store = (TopicMessageStore) dest.getMessageStore();
+
+      // nothing should be expired yet, no messags
+      var expired = store.recoverExpired(Set.of(subKey1, subKey2), 100);
+      assertTrue(expired.isEmpty());
+
+      // Sent 50 messages with no ttl followed by 50 with ttl
+      ActiveMQTextMessage message = new ActiveMQTextMessage();
+      for (int i = 0; i < 100; i++) {
+        message.setText("message" + i);
+        var ttl = i >= 50 ? 1000 : 0;
+        prod.send(message, Message.DEFAULT_DELIVERY_MODE, Message.DEFAULT_PRIORITY, ttl);
+      }
+
+      // wait for the time to pass the point of needing expiration
+      Thread.sleep(1500);
+
+      // We should now find both durables have 50 expired messages
+      expired = store.recoverExpired(Set.of(subKey1, subKey2), 100);
+      assertEquals(2, expired.size());
+      assertEquals(50, expired.get(subKey1).size());
+      assertEquals(50, expired.get(subKey2).size());
+
+      // Max is 50, should find none expired
+      expired = store.recoverExpired(Set.of(subKey1, subKey2), 50);
+      assertTrue(expired.isEmpty());
+
+      // We should now find both durables have 25 expired messages with
+      // max at 75
+      expired = store.recoverExpired(Set.of(subKey1, subKey2), 75);
+      assertEquals(2, expired.size());
+      assertEquals(25, expired.get(subKey1).size());
+      assertEquals(25, expired.get(subKey2).size());
+
+      // Acknowledge the first 25 messages of only the first sub
+      for (int i = 0; i < 25; i++) {
+        MessageAck ack = new MessageAck();
+        ack.setLastMessageId(expired.get(subKey1).get(i).getMessageId());
+        ack.setAckType(MessageAck.EXPIRED_ACK_TYPE);
+        ack.setDestination(topic);
+        store.acknowledge(broker.getAdminConnectionContext(),"clientId", "sub1",
+            ack.getLastMessageId(), ack);
+      }
+
+      // We should now find 25 on sub1 and 50 on sub2 with a max of 100
+      expired = store.recoverExpired(Set.of(subKey1, subKey2), 100);
+      assertEquals(2, expired.size());
+      assertEquals(25, expired.get(subKey1).size());
+      assertEquals(50, expired.get(subKey2).size());
+
+    }
+
+  }
+
+  // Test that filtering works by the set of subscriptions
+  @Test
+  public void testRecoverExpiredSubSet() throws Exception {
+    try (Session session = initializeSubs()) {
+      MessageProducer prod = session.createProducer(topic);
+
+      Destination dest = broker.getDestination(topic);
+      TopicMessageStore store = (TopicMessageStore) dest.getMessageStore();
+
+      // nothing should be expired yet, no messags
+      var expired = store.recoverExpired(Set.of(subKey1, subKey2), 100);
+      assertTrue(expired.isEmpty());
+
+      // Send 10 expired
+      for (int i = 0; i < 10; i++) {
+        ActiveMQTextMessage message = new ActiveMQTextMessage();
+        message.setText("message" + i);
+        prod.send(message, Message.DEFAULT_DELIVERY_MODE, Message.DEFAULT_PRIORITY, 1000);
+      }
+
+      // wait for the time to pass the point of needing expiration
+      Thread.sleep(1500);
+
+      // Test getting each sub individually, get sub2 first
+      expired = store.recoverExpired(Set.of(subKey2), 100);
+      assertEquals(1, expired.size());
+      assertEquals(10, expired.get(subKey2).size());
+
+      // ack the first message of sub2
+      MessageAck ack = new MessageAck();
+      ack.setLastMessageId(expired.get(subKey2).get(0).getMessageId());
+      ack.setAckType(MessageAck.EXPIRED_ACK_TYPE);
+      ack.setDestination(topic);
+      store.acknowledge(broker.getAdminConnectionContext(),"clientId", "sub2",
+          ack.getLastMessageId(), ack);
+
+      // check only sub2 has 9
+      expired = store.recoverExpired(Set.of(subKey2), 100);
+      assertEquals(1, expired.size());
+      assertEquals(9, expired.get(subKey2).size());
+
+      // check only sub1 still has 10
+      expired = store.recoverExpired(Set.of(subKey1), 100);
+      assertEquals(1, expired.size());
+      assertEquals(10, expired.get(subKey1).size());
+
+      // verify passing in unmatched sub leaves it out of the result set
+      var unmatched = new SubscriptionKey("clientId", "sub3");
+      expired = store.recoverExpired(Set.of(unmatched), 100);
+      assertTrue(expired.isEmpty());
+
+      // try 2 that exist and 1 that doesn't
+      expired = store.recoverExpired(Set.of(subKey1, subKey2, unmatched), 100);
+      assertEquals(2, expired.size());
+
+    }
+
+  }
+
+}


### PR DESCRIPTION
This commit fixes multiple problems with handling message expiration on durable topic subscriptions.

1) Memory usage tracking is fixed on expiration by correctly decrementing the counter inside AbstractStoreCursor when calling the remove(message) method, which was previously missed. 2) A new refrence type is used to wrap references in TopicStorePrefetch so that if multiple subscriptions share a reference in their cursors each one can expire the message. Previously only one would expire as the message would be marked as expired and skipped.
3) On client expiration, the references are properly decremented so memory tracking is correct.
4) The expiration thread for Topics has been improved to be much more efficient for KahaDB by only scanning for expired messages if there are durables eligible for expiration. The thread also now checks the index to see if expired messages are associated with the subs still so we don't expire the same sub multiple times. Only messages that need to still be processed are returned which further cuts down memory usage.