### PR TITLE
add instructions to copy jetty.xml to example/conf to access web demos

### DIFF
--- a/assembly/src/release/docs/user-guide.html
+++ b/assembly/src/release/docs/user-guide.html
@@ -97,6 +97,7 @@ You would need to start the broker with the demos included, which you do as foll
 If you're using Windows, just type
 </p>
 <pre>
+    copy .\conf\jetty.xml .\examples\conf\
     cd bin
     activemq.bat start xbean:../examples/conf/activemq-demo.xml
 </pre>
@@ -104,6 +105,7 @@ If you're using Windows, just type
 On Unix-like systems, type
 </p>
 <pre>
+    cp ./conf/jetty.xml ./examples/conf/
     ./bin/activemq console xbean:examples/conf/activemq-demo.xml
 </pre>
 


### PR DESCRIPTION
### Summary
This PR addresses a configuration issue that caused the demo to fail during startup due to an XML parsing error in jetty.xml.

### Issue Fixed

Before this change, starting the demo threw the following error:

``` 
ERROR | Failed to load: file [/Users/user/workspace/activemq-brokers/apache-activemq-6.1.6/examples/conf/activemq-demo.xml], reason: IOException parsing XML document from file [/Users/user/workspace/activemq-brokers/apache-activemq-6.1.6/examples/conf/jetty.xml]
```
This was caused by the application not being able to resolve jetty.xml from the filesystem path. ~~By updating the reference to use the classpath and ensuring the correct path is included, this issue is now resolved.~~

Added instructions to copy `jetty.xml` to `example/conf` to access web demos that fixes the issue.