### PR TITLE
AMQ-9716: Fix `maxMessageSize=-1` to correctly disable message size limit

### DIFF
--- a/activemq-web/src/main/java/org/apache/activemq/web/MessageServletSupport.java
+++ b/activemq-web/src/main/java/org/apache/activemq/web/MessageServletSupport.java
@@ -359,7 +359,7 @@ public abstract class MessageServletSupport extends HttpServlet {
         if (answer == null && contentType != null && contentLengthLong > -1l) {
             LOG.debug("Content-Type={} Content-Length={} maxMessageSize={}", contentType, contentLengthLong, maxMessageSize);
 
-            if (contentLengthLong > maxMessageSize) {
+            if (maxMessageSize != -1 && contentLengthLong > maxMessageSize) {
                 LOG.warn("Message body exceeds max allowed size. Content-Type={} Content-Length={} maxMessageSize={}", contentType, contentLengthLong, maxMessageSize);
                 throw new IOException("Message body exceeds max allowed size");
             }
@@ -400,6 +400,6 @@ public abstract class MessageServletSupport extends HttpServlet {
     }
 
     private boolean isMaxBodySizeExceeded(int totalRead, int expectedBodySize) {
-        return totalRead < 0 || totalRead >= Integer.MAX_VALUE || totalRead >= maxMessageSize || totalRead > expectedBodySize;
+        return totalRead < 0 || totalRead == Integer.MAX_VALUE || (maxMessageSize != -1 && totalRead >= maxMessageSize) || totalRead > expectedBodySize;
     }
 }


### PR DESCRIPTION
This PR fixes a regression introduced in 5.19.0 where setting `maxMessageSize=-1` no longer disables message size validation, despite being [documented](https://activemq.apache.org/components/classic/documentation/rest) to do so.

The fix ensures that checks are only enforced if `maxMessageSize >= 0`.