### PR TITLE
AMQ-7517: Remove lib in the default classpath

### DIFF
--- a/assembly/src/release/bin/activemq
+++ b/assembly/src/release/bin/activemq
@@ -108,7 +108,7 @@ if [ -z "$ACTIVEMQ_USER_CLASSPATH" ] ; then
 fi
 
 # ActiveMQ Classpath configuration
-ACTIVEMQ_CLASSPATH="${ACTIVEMQ_BASE%/}/../lib/:$ACTIVEMQ_USER_CLASSPATH"
+ACTIVEMQ_CLASSPATH="$ACTIVEMQ_USER_CLASSPATH"
 
 # Active MQ configuration directory
 if [ -z "$ACTIVEMQ_CONF" ] ; then


### PR DESCRIPTION
lib is useless in the classpath (resolved by ActiveMQ `main`), but keep user custom classpath.