### PR TITLE
Code cleanup: use StringBuilder instead of StringBuffer

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/broker/util/LoggingBrokerPlugin.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/util/LoggingBrokerPlugin.java
@@ -216,9 +216,9 @@ public class LoggingBrokerPlugin extends BrokerPluginSupport {
 
         TransactionId[] result = super.getPreparedTransactions(context);
         if ((isLogAll() || isLogTransactionEvents()) && result != null) {
-            StringBuffer tids = new StringBuffer();
+            StringBuilder tids = new StringBuilder();
             for (TransactionId tid : result) {
-                if (tids.length() > 0) {
+                if (!tids.isEmpty()) {
                     tids.append(", ");
                 }
                 tids.append(tid.getTransactionKey());
@@ -311,9 +311,9 @@ public class LoggingBrokerPlugin extends BrokerPluginSupport {
             if (result == null) {
                 LOG.info("Get Clients returned empty list.");
             } else {
-                StringBuffer cids = new StringBuffer();
+                StringBuilder cids = new StringBuilder();
                 for (Connection c : result) {
-                    cids.append(cids.length() > 0 ? ", " : "");
+                    cids.append(!cids.isEmpty() ? ", " : "");
                     cids.append(c.getConnectionId());
                 }
                 LOG.info("Connected clients: {}", cids);
@@ -347,9 +347,9 @@ public class LoggingBrokerPlugin extends BrokerPluginSupport {
             if (result == null) {
                 LOG.info("Get Destinations returned empty list.");
             } else {
-                StringBuffer destinations = new StringBuffer();
+                StringBuilder destinations = new StringBuilder();
                 for (ActiveMQDestination dest : result) {
-                    destinations.append(destinations.length() > 0 ? ", " : "");
+                    destinations.append(!destinations.isEmpty() ? ", " : "");
                     destinations.append(dest.getPhysicalName());
                 }
                 LOG.info("Get Destinations: {}", destinations);
@@ -413,9 +413,9 @@ public class LoggingBrokerPlugin extends BrokerPluginSupport {
             if (result == null) {
                 LOG.info("Get Peer Broker Infos returned empty list.");
             } else {
-                StringBuffer peers = new StringBuffer();
+                StringBuilder peers = new StringBuilder();
                 for (BrokerInfo bi : result) {
-                    peers.append(peers.length() > 0 ? ", " : "");
+                    peers.append(!peers.isEmpty() ? ", " : "");
                     peers.append(bi.getBrokerName());
                 }
                 LOG.info("Get Peer Broker Infos: {}", peers);
@@ -455,9 +455,9 @@ public class LoggingBrokerPlugin extends BrokerPluginSupport {
             if (result == null) {
                 LOG.info("Get Durable Destinations returned empty list.");
             } else {
-                StringBuffer destinations = new StringBuffer();
+                StringBuilder destinations = new StringBuilder();
                 for (ActiveMQDestination dest : result) {
-                    destinations.append(destinations.length() > 0 ? ", " : "");
+                    destinations.append(!destinations.isEmpty() ? ", " : "");
                     destinations.append(dest.getPhysicalName());
                 }
                 LOG.info("Get Durable Destinations: {}", destinations);
@@ -563,12 +563,7 @@ public class LoggingBrokerPlugin extends BrokerPluginSupport {
     public void slowConsumer(ConnectionContext context, Destination destination, Subscription subs) {
         if (isLogAll() || isLogConsumerEvents() || isLogInternalEvents()) {
             LOG.info("Detected slow consumer on {}", destination.getName());
-            StringBuffer buf = new StringBuffer("Connection(");
-            buf.append(subs.getConsumerInfo().getConsumerId().getConnectionId());
-            buf.append(") Session(");
-            buf.append(subs.getConsumerInfo().getConsumerId().getSessionId());
-            buf.append(")");
-            LOG.info(buf.toString());
+            LOG.info("Connection({}) Session({})", subs.getConsumerInfo().getConsumerId().getConnectionId(), subs.getConsumerInfo().getConsumerId().getSessionId());
         }
         super.slowConsumer(context, destination, subs);
     }
@@ -583,24 +578,22 @@ public class LoggingBrokerPlugin extends BrokerPluginSupport {
 
     @Override
     public String toString() {
-        StringBuffer buf = new StringBuffer();
-        buf.append("LoggingBrokerPlugin(");
-        buf.append("logAll=");
-        buf.append(isLogAll());
-        buf.append(", logConnectionEvents=");
-        buf.append(isLogConnectionEvents());
-        buf.append(", logSessionEvents=");
-        buf.append(isLogSessionEvents());
-        buf.append(", logConsumerEvents=");
-        buf.append(isLogConsumerEvents());
-        buf.append(", logProducerEvents=");
-        buf.append(isLogProducerEvents());
-        buf.append(", logTransactionEvents=");
-        buf.append(isLogTransactionEvents());
-        buf.append(", logInternalEvents=");
-        buf.append(isLogInternalEvents());
-        buf.append(")");
-        return buf.toString();
+        return "LoggingBrokerPlugin(" +
+                "logAll=" +
+                isLogAll() +
+                ", logConnectionEvents=" +
+                isLogConnectionEvents() +
+                ", logSessionEvents=" +
+                isLogSessionEvents() +
+                ", logConsumerEvents=" +
+                isLogConsumerEvents() +
+                ", logProducerEvents=" +
+                isLogProducerEvents() +
+                ", logTransactionEvents=" +
+                isLogTransactionEvents() +
+                ", logInternalEvents=" +
+                isLogInternalEvents() +
+                ")";
     }
 
     public void setPerDestinationLogger(boolean perDestinationLogger) {

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/view/ConnectionDotFileInterceptor.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/view/ConnectionDotFileInterceptor.java
@@ -262,11 +262,11 @@ public class ConnectionDotFileInterceptor extends DotFileInterceptorSupport {
     }
 
     /**
-     * Lets strip out any non supported characters
+     * Let's strip out any non-supported characters
      */
     protected String asID(String name) {
-        StringBuffer buffer = new StringBuffer();
-        int size = name.length();
+        final int size = name.length();
+        StringBuilder buffer = new StringBuilder(size);
         for (int i = 0; i < size; i++) {
             char ch = name.charAt(i);
             if (Character.isLetterOrDigit(ch) || ch == '_') {

--- a/activemq-broker/src/main/java/org/apache/activemq/network/NetworkBridgeConfiguration.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/network/NetworkBridgeConfiguration.java
@@ -338,7 +338,7 @@ public class NetworkBridgeConfiguration {
     public String getDestinationFilter() {
         if (this.destinationFilter == null) {
             if (dynamicallyIncludedDestinations != null && !dynamicallyIncludedDestinations.isEmpty()) {
-                StringBuffer filter = new StringBuffer();
+                StringBuilder filter = new StringBuilder();
                 String delimiter = "";
                 for (ActiveMQDestination destination : dynamicallyIncludedDestinations) {
                     if (!destination.isTemporary()) {
@@ -360,7 +360,7 @@ public class NetworkBridgeConfiguration {
                 }
                 return filter.toString();
             }   else {
-                StringBuffer filter = new StringBuffer();
+                StringBuilder filter = new StringBuilder();
                 filter.append(AdvisorySupport.CONSUMER_ADVISORY_TOPIC_PREFIX);
                 filter.append(">");
                 if (useVirtualDestSubs) {

--- a/activemq-broker/src/main/java/org/apache/activemq/util/HexSupport.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/util/HexSupport.java
@@ -53,7 +53,7 @@ public final class HexSupport {
      * @return array of bytes
      */
     public static byte[] toBytesFromHex(String hex) {
-        byte rc[] = new byte[hex.length() / 2];
+        byte[] rc = new byte[hex.length() / 2];
         for (int i = 0; i < rc.length; i++) {
             String h = hex.substring(i * 2, i * 2 + 2);
             int x = Integer.parseInt(h, 16);
@@ -67,9 +67,9 @@ public final class HexSupport {
      * @return string hex value
      */
     public static String toHexFromBytes(byte[] bytes) {
-        StringBuffer rc = new StringBuffer(bytes.length * 2);
-        for (int i = 0; i < bytes.length; i++) {
-            rc.append(HEX_TABLE[0xFF & bytes[i]]);
+        StringBuilder rc = new StringBuilder(bytes.length * 2);
+        for (byte aByte : bytes) {
+            rc.append(HEX_TABLE[0xFF & aByte]);
         }
         return rc.toString();
     }
@@ -81,7 +81,7 @@ public final class HexSupport {
      * @return string hex value
      */
     public static String toHexFromInt(int value, boolean trim) {
-        StringBuffer rc = new StringBuffer(INT_OFFSETS.length*2);
+        StringBuilder rc = new StringBuilder(INT_OFFSETS.length*2);
         for (int i = 0; i < INT_OFFSETS.length; i++) {
             int b = 0xFF & (value>>INT_OFFSETS[i]);
             if( !(trim && b == 0) ) {

--- a/activemq-broker/src/main/java/org/apache/activemq/util/IOHelper.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/util/IOHelper.java
@@ -91,7 +91,7 @@ public final class IOHelper {
      */
     public static String toFileSystemSafeName(String name, boolean dirSeparators, int maxFileLength) {
         int size = name.length();
-        StringBuffer rc = new StringBuffer(size * 2);
+        StringBuilder rc = new StringBuilder(size * 2);
         for (int i = 0; i < size; i++) {
             char c = name.charAt(i);
             boolean valid = c >= 'a' && c <= 'z';

--- a/activemq-broker/src/main/java/org/apache/activemq/util/osgi/Activator.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/util/osgi/Activator.java
@@ -175,7 +175,7 @@ public class Activator implements BundleActivator, SynchronousBundleListener, Ob
     public Object create(String path) throws IllegalAccessException, InstantiationException, IOException, ClassNotFoundException {
         Class<?> clazz = serviceCache.get(path);
         if (clazz == null) {
-            StringBuffer warnings = new StringBuffer();
+            StringBuilder warnings = new StringBuilder();
             // We need to look for a bundle that has that class.
             int wrrningCounter=1;
             for (BundleWrapper wrapper : bundleWrappers.values()) {
@@ -188,14 +188,14 @@ public class Activator implements BundleActivator, SynchronousBundleListener, Ob
 
                 String className = properties.getProperty("class");
                 if (className == null) {
-                    warnings.append("("+(wrrningCounter++)+") Invalid service file in bundle "+wrapper+": 'class' property not defined.");
+                    warnings.append("(").append(wrrningCounter++).append(") Invalid service file in bundle ").append(wrapper).append(": 'class' property not defined.");
                     continue;
                 }
 
                 try {
                     clazz = wrapper.bundle.loadClass(className);
                 } catch (ClassNotFoundException e) {
-                    warnings.append("("+(wrrningCounter++)+") Bundle "+wrapper+" could not load "+className+": "+e);
+                    warnings.append("(").append(wrrningCounter++).append(") Bundle ").append(wrapper).append(" could not load ").append(className).append(": ").append(e);
                     continue;
                 }
 
@@ -251,7 +251,7 @@ public class Activator implements BundleActivator, SynchronousBundleListener, Ob
      * one of the packages of our interfaces
      *
      * @param bundle
-     * @return true if the bundle is improting.
+     * @return true if the bundle is importing.
      */
     private boolean isImportingUs(Bundle bundle) {
         BundleWiring wiring = bundle.adapt(BundleWiring.class);

--- a/activemq-client/src/main/java/org/apache/activemq/command/ActiveMQDestination.java
+++ b/activemq-client/src/main/java/org/apache/activemq/command/ActiveMQDestination.java
@@ -211,7 +211,7 @@ public abstract class ActiveMQDestination extends JNDIBaseStorable implements Da
         this.hashValue = 0;
         this.isPattern = false;
 
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         for (int i = 0; i < destinations.length; i++) {
             if (i != 0) {
                 sb.append(COMPOSITE_SEPERATOR);

--- a/activemq-client/src/main/java/org/apache/activemq/command/WireFormatInfo.java
+++ b/activemq-client/src/main/java/org/apache/activemq/command/WireFormatInfo.java
@@ -378,7 +378,7 @@ public class WireFormatInfo implements Command, MarshallAware {
     }
 
     private String toString(byte[] data) {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         sb.append('[');
         for (int i = 0; i < data.length; i++) {
             if (i != 0) {

--- a/activemq-client/src/main/java/org/apache/activemq/command/XATransactionId.java
+++ b/activemq-client/src/main/java/org/apache/activemq/command/XATransactionId.java
@@ -101,19 +101,18 @@ public class XATransactionId extends TransactionId implements Xid, Comparable {
 
     public synchronized String getTransactionKey() {
         if (transactionKey == null) {
-            StringBuffer s = new StringBuffer();
-            s.append("XID:[" + formatId + ",globalId=");
-            s.append(stringForm(formatId, globalTransactionId));
-            s.append(",branchId=");
-            s.append(stringForm(formatId, branchQualifier));
-            s.append("]");
-            transactionKey = s.toString();
+            String s = "XID:[" + formatId + ",globalId=" +
+                    stringForm(formatId, globalTransactionId) +
+                    ",branchId=" +
+                    stringForm(formatId, branchQualifier) +
+                    "]";
+            transactionKey = s;
         }
         return transactionKey;
     }
 
     private String stringForm(int format, byte[] uid) {
-        StringBuffer s = new StringBuffer();
+        StringBuilder s = new StringBuilder();
         switch (format) {
             case 131077:  // arjuna
                 stringFormArj(s, uid);
@@ -124,13 +123,13 @@ public class XATransactionId extends TransactionId implements Xid, Comparable {
         return s.toString();
     }
 
-    private void stringFormDefault(StringBuffer s, byte[] uid) {
-        for (int i = 0; i < uid.length; i++) {
-            s.append(Integer.toHexString(uid[i]));
+    private void stringFormDefault(StringBuilder s, byte[] uid) {
+        for (byte b : uid) {
+            s.append(Integer.toHexString(b));
         }
     }
 
-    private void stringFormArj(StringBuffer s, byte[] uid) {
+    private void stringFormArj(StringBuilder s, byte[] uid) {
         try {
             DataByteArrayInputStream byteArrayInputStream = new DataByteArrayInputStream(uid);
             s.append(Long.toString(byteArrayInputStream.readLong(), 16));

--- a/activemq-client/src/main/java/org/apache/activemq/filter/ComparisonExpression.java
+++ b/activemq-client/src/main/java/org/apache/activemq/filter/ComparisonExpression.java
@@ -84,7 +84,7 @@ public abstract class ComparisonExpression extends BinaryExpression implements B
         public LikeExpression(Expression right, String like, int escape) {
             super(right);
 
-            StringBuffer regexp = new StringBuffer(like.length() * 2);
+            StringBuilder regexp = new StringBuilder(like.length() * 2);
             regexp.append("\\A"); // The beginning of the input
             for (int i = 0; i < like.length(); i++) {
                 char c = like.charAt(i);
@@ -111,7 +111,7 @@ public abstract class ComparisonExpression extends BinaryExpression implements B
             return false;
         }
 
-        private void append(StringBuffer regexp, char c) {
+        private void append(StringBuilder regexp, char c) {
             if (c == '%') {
                 regexp.append(".*?"); // Do a non-greedy match
             } else if (c == '_') {

--- a/activemq-client/src/main/java/org/apache/activemq/filter/ConstantExpression.java
+++ b/activemq-client/src/main/java/org/apache/activemq/filter/ConstantExpression.java
@@ -148,7 +148,7 @@ public class ConstantExpression implements Expression {
      * @return
      */
     public static String encodeString(String s) {
-        StringBuffer b = new StringBuffer();
+        StringBuilder b = new StringBuilder(s.length() * 2);
         b.append('\'');
         for (int i = 0; i < s.length(); i++) {
             char c = s.charAt(i);

--- a/activemq-client/src/main/java/org/apache/activemq/filter/DestinationPath.java
+++ b/activemq-client/src/main/java/org/apache/activemq/filter/DestinationPath.java
@@ -69,7 +69,7 @@ public final class DestinationPath {
      * @return
      */
     public static String toString(String[] paths) {
-        StringBuffer buffer = new StringBuffer();
+        StringBuilder buffer = new StringBuilder();
         for (int i = 0; i < paths.length; i++) {
             if (i > 0) {
                 buffer.append(SEPARATOR);

--- a/activemq-client/src/main/java/org/apache/activemq/filter/UnaryExpression.java
+++ b/activemq-client/src/main/java/org/apache/activemq/filter/UnaryExpression.java
@@ -89,7 +89,7 @@ public abstract class UnaryExpression implements Expression {
             }
 
             public String toString() {
-                StringBuffer answer = new StringBuffer();
+                StringBuilder answer = new StringBuilder();
                 answer.append(right);
                 answer.append(" ");
                 answer.append(getExpressionSymbol());

--- a/activemq-client/src/main/java/org/apache/activemq/filter/XPathExpression.java
+++ b/activemq-client/src/main/java/org/apache/activemq/filter/XPathExpression.java
@@ -121,7 +121,7 @@ public final class XPathExpression implements BooleanExpression {
             }
         }
         if (features.size() > 0) {
-            StringBuffer featureString = new StringBuffer();
+            StringBuilder featureString = new StringBuilder();
             // just log the configured feature
             for (String feature : features) {
                 if (featureString.length() != 0) {

--- a/activemq-client/src/main/java/org/apache/activemq/management/JMSConnectionStatsImpl.java
+++ b/activemq-client/src/main/java/org/apache/activemq/management/JMSConnectionStatsImpl.java
@@ -74,7 +74,7 @@ public class JMSConnectionStatsImpl extends StatsImpl {
     }
 
     public String toString() {
-        StringBuffer buffer = new StringBuffer("connection{ ");
+        StringBuilder buffer = new StringBuilder("connection{ ");
         JMSSessionStatsImpl[] array = getSessions();
         for (int i = 0; i < array.length; i++) {
             if (i > 0) {

--- a/activemq-client/src/main/java/org/apache/activemq/management/JMSConsumerStatsImpl.java
+++ b/activemq-client/src/main/java/org/apache/activemq/management/JMSConsumerStatsImpl.java
@@ -46,13 +46,11 @@ public class JMSConsumerStatsImpl extends JMSEndpointStatsImpl {
     }
 
     public String toString() {
-        StringBuffer buffer = new StringBuffer();
-        buffer.append("consumer ");
-        buffer.append(origin);
-        buffer.append(" { ");
-        buffer.append(super.toString());
-        buffer.append(" }");
-        return buffer.toString();
+        return "consumer " +
+                origin +
+                " { " +
+                super.toString() +
+                " }";
     }
 
     public void dump(IndentPrinter out) {

--- a/activemq-client/src/main/java/org/apache/activemq/management/JMSEndpointStatsImpl.java
+++ b/activemq-client/src/main/java/org/apache/activemq/management/JMSEndpointStatsImpl.java
@@ -112,17 +112,15 @@ public class JMSEndpointStatsImpl extends StatsImpl {
     }
 
     public String toString() {
-        StringBuffer buffer = new StringBuffer();
-        buffer.append(messageCount);
-        buffer.append(" ");
-        buffer.append(messageRateTime);
-        buffer.append(" ");
-        buffer.append(pendingMessageCount);
-        buffer.append(" ");
-        buffer.append(expiredMessageCount);
-        buffer.append(" ");
-        buffer.append(messageWaitTime);
-        return buffer.toString();
+        return messageCount +
+                " " +
+                messageRateTime +
+                " " +
+                pendingMessageCount +
+                " " +
+                expiredMessageCount +
+                " " +
+                messageWaitTime;
     }
 
     public void onMessage() {

--- a/activemq-client/src/main/java/org/apache/activemq/management/JMSProducerStatsImpl.java
+++ b/activemq-client/src/main/java/org/apache/activemq/management/JMSProducerStatsImpl.java
@@ -46,13 +46,11 @@ public class JMSProducerStatsImpl extends JMSEndpointStatsImpl {
     }
 
     public String toString() {
-        StringBuffer buffer = new StringBuffer();
-        buffer.append("producer ");
-        buffer.append(destination);
-        buffer.append(" { ");
-        buffer.append(super.toString());
-        buffer.append(" }");
-        return buffer.toString();
+        return "producer " +
+                destination +
+                " { " +
+                super.toString() +
+                " }";
     }
 
     public void dump(IndentPrinter out) {

--- a/activemq-client/src/main/java/org/apache/activemq/management/JMSSessionStatsImpl.java
+++ b/activemq-client/src/main/java/org/apache/activemq/management/JMSSessionStatsImpl.java
@@ -139,7 +139,7 @@ public class JMSSessionStatsImpl extends StatsImpl {
     }
 
     public String toString() {
-        StringBuffer buffer = new StringBuffer(" ");
+        StringBuilder buffer = new StringBuilder(" ");
         buffer.append(messageCount);
         buffer.append(" ");
         buffer.append(messageRateTime);

--- a/activemq-client/src/main/java/org/apache/activemq/transport/discovery/masterslave/MasterSlaveDiscoveryAgent.java
+++ b/activemq-client/src/main/java/org/apache/activemq/transport/discovery/masterslave/MasterSlaveDiscoveryAgent.java
@@ -64,7 +64,7 @@ public class MasterSlaveDiscoveryAgent extends SimpleDiscoveryAgent {
             throw new IllegalArgumentException("Expecting at least 2 arguments");
         }
 
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
 
         buf.append("failover:(");
 

--- a/activemq-client/src/main/java/org/apache/activemq/transport/failover/FailoverTransport.java
+++ b/activemq-client/src/main/java/org/apache/activemq/transport/failover/FailoverTransport.java
@@ -903,7 +903,7 @@ public class FailoverTransport implements CompositeTransport {
         if (fileURL != null) {
             BufferedReader in = null;
             String newUris = null;
-            StringBuffer buffer = new StringBuffer();
+            StringBuilder buffer = new StringBuilder();
 
             try {
                 in = new BufferedReader(getURLStream(fileURL));

--- a/activemq-client/src/main/java/org/apache/activemq/util/IntrospectionSupport.java
+++ b/activemq-client/src/main/java/org/apache/activemq/util/IntrospectionSupport.java
@@ -311,7 +311,7 @@ public final class IntrospectionSupport {
             }
 
         }
-        StringBuffer buffer = new StringBuffer(simpleName(target.getClass()));
+        StringBuilder buffer = new StringBuilder(simpleName(target.getClass()));
         buffer.append(" {");
         Set<Entry<String, Object>> entrySet = map.entrySet();
         boolean first = true;
@@ -332,7 +332,7 @@ public final class IntrospectionSupport {
         return buffer.toString();
     }
 
-    protected static void appendToString(StringBuffer buffer, Object key, Object value) {
+    private static void appendToString(StringBuilder buffer, Object key, Object value) {
         if (value instanceof ActiveMQDestination) {
             ActiveMQDestination destination = (ActiveMQDestination)value;
             buffer.append(destination.getQualifiedName());

--- a/activemq-client/src/main/java/org/apache/activemq/util/StringArrayConverter.java
+++ b/activemq-client/src/main/java/org/apache/activemq/util/StringArrayConverter.java
@@ -55,7 +55,7 @@ public class StringArrayConverter {
             return null;
         }
 
-        StringBuffer result = new StringBuffer(String.valueOf(value[0]));
+        StringBuilder result = new StringBuilder(String.valueOf(value[0]));
         for (int i = 1; i < value.length; i++) {
             result.append(",").append(value[i]);
         }

--- a/activemq-client/src/main/java/org/apache/activemq/util/URISupport.java
+++ b/activemq-client/src/main/java/org/apache/activemq/util/URISupport.java
@@ -21,6 +21,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -72,7 +73,7 @@ public class URISupport {
         }
 
         public URI toURI() throws URISyntaxException {
-            StringBuffer sb = new StringBuffer();
+            StringBuilder sb = new StringBuilder();
             if (scheme != null) {
                 sb.append(scheme);
                 sb.append(':');
@@ -199,7 +200,7 @@ public class URISupport {
      */
     public static URI applyParameters(URI uri, Map<String, String> queryParameters, String optionPrefix) throws URISyntaxException {
         if (queryParameters != null && !queryParameters.isEmpty()) {
-            StringBuffer newQuery = uri.getRawQuery() != null ? new StringBuffer(uri.getRawQuery()) : new StringBuffer() ;
+            StringBuilder newQuery = uri.getRawQuery() != null ? new StringBuilder(uri.getRawQuery()) : new StringBuilder() ;
             for ( Map.Entry<String, String> param: queryParameters.entrySet()) {
                 if (param.getKey().startsWith(optionPrefix)) {
                     if (newQuery.length()!=0) {
@@ -489,27 +490,23 @@ public class URISupport {
      * @throws URISyntaxException
      */
     public static String createQueryString(Map<String, ? extends Object> options) throws URISyntaxException {
-        try {
-            if (options.size() > 0) {
-                StringBuffer rc = new StringBuffer();
-                boolean first = true;
-                for (String key : options.keySet()) {
-                    if (first) {
-                        first = false;
-                    } else {
-                        rc.append("&");
-                    }
-                    String value = (String)options.get(key);
-                    rc.append(URLEncoder.encode(key, "UTF-8"));
-                    rc.append("=");
-                    rc.append(URLEncoder.encode(value, "UTF-8"));
+        if (options.size() > 0) {
+            StringBuilder rc = new StringBuilder();
+            boolean first = true;
+            for (String key : options.keySet()) {
+                if (first) {
+                    first = false;
+                } else {
+                    rc.append("&");
                 }
-                return rc.toString();
-            } else {
-                return "";
+                String value = (String)options.get(key);
+                rc.append(URLEncoder.encode(key, StandardCharsets.UTF_8));
+                rc.append("=");
+                rc.append(URLEncoder.encode(value, StandardCharsets.UTF_8));
             }
-        } catch (UnsupportedEncodingException e) {
-            throw (URISyntaxException)new URISyntaxException(e.toString(), "Invalid encoding").initCause(e);
+            return rc.toString();
+        } else {
+            return "";
         }
     }
 

--- a/activemq-console/src/main/java/org/apache/activemq/console/command/store/tar/TarInputStream.java
+++ b/activemq-console/src/main/java/org/apache/activemq/console/command/store/tar/TarInputStream.java
@@ -263,7 +263,7 @@ public class TarInputStream extends FilterInputStream {
 
         if (currEntry != null && currEntry.isGNULongNameEntry()) {
             // read in the name
-            StringBuffer longName = new StringBuffer();
+            StringBuilder longName = new StringBuilder();
             byte[] buf = new byte[SMALL_BUFFER_SIZE];
             int length = 0;
             while ((length = read(buf)) >= 0) {

--- a/activemq-jaas/src/main/java/org/apache/activemq/jaas/LDAPLoginModule.java
+++ b/activemq-jaas/src/main/java/org/apache/activemq/jaas/LDAPLoginModule.java
@@ -398,7 +398,7 @@ public class LDAPLoginModule implements LoginModule {
     }
 
     protected String doRFC2254Encoding(String inputString) {
-        StringBuffer buf = new StringBuffer(inputString.length());
+        StringBuilder buf = new StringBuilder(inputString.length());
         for (int i = 0; i < inputString.length(); i++) {
             char c = inputString.charAt(i);
             switch (c) {

--- a/activemq-ra/src/main/java/org/apache/activemq/ra/ActiveMQConnectionRequestInfo.java
+++ b/activemq-ra/src/main/java/org/apache/activemq/ra/ActiveMQConnectionRequestInfo.java
@@ -266,10 +266,9 @@ public class ActiveMQConnectionRequestInfo implements ConnectionRequestInfo, Ser
 
     @Override
     public String toString() {
-        return new StringBuffer("ActiveMQConnectionRequestInfo{ userName = '").append(userName).append("' ").append(", serverUrl = '").append(serverUrl)
-            .append("' ").append(", clientid = '").append(clientid).append("' ")
-            .append(", useSessionArgs = '").append(useSessionArgs).append("' ").append(", useInboundSession = '").append(useInboundSession).append("'  }")
-            .toString();
+        return "ActiveMQConnectionRequestInfo{ userName = '" + userName + "' " + ", serverUrl = '" + serverUrl +
+                "' " + ", clientid = '" + clientid + "' " +
+                ", useSessionArgs = '" + useSessionArgs + "' " + ", useInboundSession = '" + useInboundSession + "'  }";
     }
 
     public Boolean getUseInboundSession() {

--- a/activemq-spring/src/main/java/org/apache/activemq/spring/ActiveMQConnectionFactoryFactoryBean.java
+++ b/activemq-spring/src/main/java/org/apache/activemq/spring/ActiveMQConnectionFactoryFactoryBean.java
@@ -48,7 +48,7 @@ public class ActiveMQConnectionFactoryFactoryBean implements FactoryBean {
     }
 
     public String getBrokerURL() {
-        StringBuffer buffer = new StringBuffer("failover:(");
+        StringBuilder buffer = new StringBuilder("failover:(");
         int counter = 0;
         for (String tcpHostAndPort : tcpHostAndPorts) {
             if (counter++ > 0) {
@@ -138,7 +138,7 @@ public class ActiveMQConnectionFactoryFactoryBean implements FactoryBean {
             return "";
         }
         else {
-            StringBuffer buffer = new StringBuffer("?");
+            StringBuilder buffer = new StringBuilder("?");
             buffer.append(parameters.get(0));
             for (int i = 1; i < size; i++) {
                 buffer.append("&");


### PR DESCRIPTION
cleanup: use StringBuilder instead of StringBuffer
StringBuilder is not synchronized, which makes it faster than StringBuffer
in some cases where there is no loop involved replace StringBuffer with a pure String concatenation (leaving java compiler doing the optimizations)