### PR TITLE
AMQ-9721 - Fix performance issues during non-persistent cursor removal

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/broker/region/Topic.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/region/Topic.java
@@ -17,6 +17,7 @@
 package org.apache.activemq.broker.region;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
@@ -704,6 +705,11 @@ public class Topic extends BaseDestination implements Task {
                     for (DurableTopicSubscription sub : durableSubscribers.values()) {
                         if (!sub.isActive() || sub.isEnableMessageExpirationOnActiveDurableSubs()) {
                             message.setRegionDestination(this);
+                            // AMQ-9721 - Remove message from the cursor if it exists after
+                            // loading from the store.  Store recoverExpired() does not inc
+                            // the ref count so we don't need to decrement here, but if
+                            // the cursor finds its own copy in memory it will dec that ref.
+                            sub.removePending(message);
                             messageExpired(connectionContext, sub, message);
                         }
                     }
@@ -894,6 +900,15 @@ public class Topic extends BaseDestination implements Task {
                         if (isEligibleForExpiration(sub)) {
                             expiredMessages.forEach(message -> {
                                 message.setRegionDestination(Topic.this);
+                                try {
+                                    // AMQ-9721 - Remove message from the cursor if it exists after
+                                    // loading from the store.  Store recoverExpired() does not inc
+                                    // the ref count so we don't need to decrement here, but if
+                                    // the cursor finds its own copy in memory it will dec that ref.
+                                    sub.removePending(message);
+                                } catch (IOException e) {
+                                    throw new UncheckedIOException(e);
+                                }
                                 messageExpired(connectionContext, sub, message);
                             });
                         }
@@ -932,9 +947,6 @@ public class Topic extends BaseDestination implements Task {
         ack.setDestination(destination);
         ack.setMessageID(reference.getMessageId());
         try {
-            if (subs instanceof DurableTopicSubscription) {
-                ((DurableTopicSubscription)subs).removePending(reference);
-            }
             acknowledge(context, subs, ack, reference);
         } catch (Exception e) {
             LOG.error("Failed to remove expired Message from the store ", e);

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/region/TopicSubscription.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/region/TopicSubscription.java
@@ -188,6 +188,9 @@ public class TopicSubscription extends AbstractSubscription {
                                 messagesToEvict = oldMessages.length;
                                 for (int i = 0; i < messagesToEvict; i++) {
                                     MessageReference oldMessage = oldMessages[i];
+                                    // AMQ-9721 - discard no longer removes from matched so remove here
+                                    oldMessage.decrementReferenceCount();
+                                    matched.remove(oldMessage);
                                     //Expired here is false as we are discarding due to the messageEvictingStrategy
                                     discard(oldMessage, false);
                                 }
@@ -751,8 +754,6 @@ public class TopicSubscription extends AbstractSubscription {
     private void discard(MessageReference message, boolean expired) {
         discarding = true;
         try {
-            message.decrementReferenceCount();
-            matched.remove(message);
             if (destination != null) {
                 destination.getDestinationStatistics().getDequeues().increment();
                 if(destination.isAdvancedNetworkStatisticsEnabled() && getContext() != null && getContext().isNetworkConnection()) {

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/broker/region/cursors/KahaDBPendingMessageCursorTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/broker/region/cursors/KahaDBPendingMessageCursorTest.java
@@ -35,9 +35,12 @@ import jakarta.jms.TopicSubscriber;
 import org.apache.activemq.ActiveMQConnectionFactory;
 import org.apache.activemq.broker.BrokerService;
 import org.apache.activemq.broker.region.DurableTopicSubscription;
+import org.apache.activemq.broker.region.MessageReference;
 import org.apache.activemq.broker.region.Topic;
+import org.apache.activemq.command.ActiveMQDestination;
 import org.apache.activemq.command.ActiveMQTextMessage;
 import org.apache.activemq.command.ActiveMQTopic;
+import org.apache.activemq.command.MessageAck;
 import org.apache.activemq.store.MessageStoreSubscriptionStatistics;
 import org.apache.activemq.store.TopicMessageStore;
 import org.apache.activemq.store.kahadb.KahaDBPersistenceAdapter;
@@ -352,4 +355,55 @@ public class KahaDBPendingMessageCursorTest extends
 
     }
 
+    // Test for AMQ-9721
+    @Test
+    public void testDurableCursorRemoveRefMessageSize() throws Exception {
+        AtomicLong publishedMessageSize = new AtomicLong();
+
+        Connection connection = new ActiveMQConnectionFactory(brokerConnectURI).createConnection();
+        connection.setClientID("clientId");
+        connection.start();
+
+        // send 100 persistent and non persistent
+        Topic topic = publishTestMessagesDurable(connection, new String[] {"sub1"}, 100,
+            publishedMessageSize, DeliveryMode.NON_PERSISTENT);
+        publishTestMessagesDurable(connection, new String[] {"sub1"}, 100,
+            publishedMessageSize, DeliveryMode.PERSISTENT);
+
+        SubscriptionKey subKey = new SubscriptionKey("clientId", "sub1");
+
+        // verify the count and size
+        verifyPendingStats(topic, subKey, 200, publishedMessageSize.get());
+
+        // Iterate and remove using the pending cursor to test removal
+        final DurableTopicSubscription sub = topic.getDurableTopicSubs().get(subKey);
+        PendingMessageCursor pending = sub.getPending();
+        try {
+            pending.reset();
+            while (pending.hasNext()) {
+                MessageReference node = pending.next();
+                node.decrementReferenceCount();
+                // test the remove(ref) method which has been updated
+                // to check persistence type
+                pending.remove(node);
+
+                // If persistent remove out of the store
+                if (node.isPersistent()) {
+                    MessageAck ack = new MessageAck();
+                    ack.setLastMessageId(node.getMessageId());
+                    ack.setAckType(MessageAck.STANDARD_ACK_TYPE);
+                    ack.setDestination(topic.getActiveMQDestination());
+                    topic.acknowledge(sub.getContext(), sub, ack, node);
+                }
+            }
+        } finally {
+            pending.release();
+        }
+
+        // verify everything has been cleared correctly, persistent and
+        // non-persistent
+        verifyPendingStats(topic, subKey, 0, 0);
+        // Memory usage should be 0 after removal
+        assertEquals(0, topic.getMemoryUsage().getUsage());
+    }
 }


### PR DESCRIPTION
This fixes the broker so multiple removals are no longer done for the same message leading to having to search the entire non persistent pending list. Durable subscriptions now check the persistence type of the message so the cursor will no longer search everything in a non-persistent pending list when the message is persistent.

Since the fixes are primarily performance related it's a little bit tricky to test but  I added one new test for the durable sub cursor removal and the existing tests should cover everything else including memory usage being correct (such as the test added recently in AMQ-9698)