### PR TITLE
Update yield to use Thread.yield

### DIFF
--- a/activemq-client/src/test/java/org/apache/activemq/thread/TaskRunnerTest.java
+++ b/activemq-client/src/test/java/org/apache/activemq/thread/TaskRunnerTest.java
@@ -91,7 +91,7 @@ public class TaskRunnerTest {
                         for (int i = 0; i < enqueueCount / workerCount; i++) {
                             queue.incrementAndGet();
                             runner.wakeup();
-                            yield();
+                            Thread.yield();
                         }
                     } catch (BrokenBarrierException e) {
                     } catch (InterruptedException e) {


### PR DESCRIPTION
Unqualified call to 'yield' method is not supported in releases since Java 14, update it to use `Thread.yield`.