### PR TITLE
Remove requirement for network connector order in runtime configuration

### DIFF
--- a/activemq-runtime-config/src/test/java/org/apache/activemq/NetworkConnectorTest.java
+++ b/activemq-runtime-config/src/test/java/org/apache/activemq/NetworkConnectorTest.java
@@ -110,11 +110,17 @@ public class NetworkConnectorTest extends RuntimeConfigTestSupport {
         assertTrue("broker alive", brokerService.isStarted());
         assertEquals("correct network connectors", 2, brokerService.getNetworkConnectors().size());
 
-        NetworkConnector two = brokerService.getNetworkConnectors().get(1);
+        NetworkConnector two = null;
+        for (NetworkConnector nc : brokerService.getNetworkConnectors()) {
+            if ("two".equals(nc.getName())) {
+                two = nc;
+                break;
+            }
+        }
 
         applyNewConfig(brokerConfig, configurationSeed + "-one-nc", SLEEP);
 
-        assertTrue("expected mod on time", Wait.waitFor(new Wait.Condition() {
+        assertTrue("expected mod on time, but found " + brokerService.getNetworkConnectors().size() + " connectors", Wait.waitFor(new Wait.Condition() {
             @Override
             public boolean isSatisified() throws Exception {
                 return 1 == brokerService.getNetworkConnectors().size();

--- a/activemq-runtime-config/src/test/resources/org/apache/activemq/networkConnectorTest-two-nc.xml
+++ b/activemq-runtime-config/src/test/resources/org/apache/activemq/networkConnectorTest-two-nc.xml
@@ -27,8 +27,8 @@
     </plugins>
 
     <networkConnectors>
-      <networkConnector uri="static:(tcp://localhost:5555)" networkTTL="1" name="one"/>
       <networkConnector uri="static:(tcp://localhost:5555)" networkTTL="1" name="two"/>
+      <networkConnector uri="static:(tcp://localhost:5555)" networkTTL="1" name="one"/>
     </networkConnectors>
   </broker>
 </beans>


### PR DESCRIPTION
This change updates the runtime configuration processing for network connectors to remove the dependency on the order of connectors in the configuration.
Network connectors are now matched by object instead of relying on their position in the list.
This improves reliability when adding, modifying, or removing network connectors via configuration updates.
Includes test coverage for scenarios with reordered and removed connectors.