### PR TITLE
AMQ-9740: Fixes "org.apache.commons.lang3.StringEscapeUtils cannot be resolved to a type" in the  Web Console.

### DIFF
--- a/activemq-web-console/src/main/webapp/WEB-INF/tags/form/short.tag
+++ b/activemq-web-console/src/main/webapp/WEB-INF/tags/form/short.tag
@@ -14,16 +14,15 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 --%>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@ attribute name="text" type="java.lang.String" required="true"  %>
 <%@ attribute name="length" type="java.lang.Integer" required="false" %>
 <%
- text = org.apache.commons.lang3.StringEscapeUtils.escapeHtml4(text);
- text = org.apache.commons.lang3.StringEscapeUtils.escapeEcmaScript(text);
- if (length == null || length < 20)
-    length = 20;
- if (text.length() <= length) {
-     out.print(text);
- } else {
-     out.println(text.substring(0, (length-10)) + "..." + text.substring(text.length() - 5));
+ if (length == null || length < 20) {
+     length = 20;
+ }
+ if (text.length() > length) {
+     text = text.substring(0, (length-10)) + "..." + text.substring(text.length() - 5);
  }
 %>
+<c:out value="<%= text %>" />

--- a/activemq-web-console/src/main/webapp/WEB-INF/tags/form/text.tag
+++ b/activemq-web-console/src/main/webapp/WEB-INF/tags/form/text.tag
@@ -14,6 +14,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 --%>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@ attribute name="name" type="java.lang.String" required="true"  %>
 <%@ attribute name="defaultValue" type="java.lang.String" required="false"  %>
 <%
@@ -24,7 +25,6 @@
 	if (value == null) {
 		value = "";
 	}
-	value = org.apache.commons.lang3.StringEscapeUtils.escapeHtml4(value);
-
 %>
-<input type="text" name="${name}" value="<%= value %>"/>
+<c:set var="sanitizedValue"><c:out value="<%= value %>" /></c:set>
+<input type="text" name="${name}" value="${sanitizedValue}"/>


### PR DESCRIPTION
The Web Console depends on `commons-lang3`, this commit adds back the Maven dependency and updates the commons-lang3 to 3.17.0. It also updates it to version 3.17.0 (latest)

The dependency on `commons-lang3` was removed in https://github.com/apache/activemq/commit/f5014221d027b71e842988cf6a3b23e2feed4d18. However it seems to cause issues in the Web Console, were some pages cause the error:

```
2025-07-03 19:43:34,007 | WARN  | /admin/send.jsp | org.eclipse.jetty.server.HttpChannel | qtp1910813448-74
jakarta.servlet.ServletException: jakarta.servlet.ServletException: org.apache.jasper.JasperException: Unable to compile class for JSP:An error occurred at line: [27] in the jsp file: [/WEB-INF/tags/form/text.tag]
org.apache.commons.lang3.StringEscapeUtils cannot be resolved to a type
24:     if (value == null) {
25:         value = "";
26:     }
27:     value = org.apache.commons.lang3.StringEscapeUtils.escapeHtml4(value);
28:
29: %>
30: <input type="text" name="${name}" value="<%= value %>"/>
```

`commons-lang3` is still used in a couple of tags: https://github.com/search?q=repo%3Aapache%2Factivemq%20%20org.apache.commons.lang3&type=code

Please let me know if there is a more appropriate way to add the dependency.

