### PR TITLE
AMQ-9739: Removed "upgrade-insecure-requests" from the Web Console's …

### DIFF
--- a/assembly/src/release/conf/jetty.xml
+++ b/assembly/src/release/conf/jetty.xml
@@ -82,13 +82,13 @@
                 <bean id="header" class="org.eclipse.jetty.rewrite.handler.HeaderPatternRule">
                     <property name="pattern" value="*"/>
                     <property name="name" value="Content-Security-Policy"/>
-                    <property name="value" value="upgrade-insecure-requests; style-src-elem 'self'; style-src 'self'; img-src 'self'; script-src-elem 'self'; default-src 'none'; object-src 'none'; frame-ancestors 'none'; base-uri 'none';" />
+                    <property name="value" value="style-src-elem 'self'; style-src 'self'; img-src 'self'; script-src-elem 'self'; default-src 'none'; object-src 'none'; frame-ancestors 'none'; base-uri 'none';" />
                 </bean>
                 <!-- More relaxed rules to allow browsers to properly render XML -->
                 <bean id="header" class="org.eclipse.jetty.rewrite.handler.HeaderPatternRule">
                     <property name="pattern" value="/admin/xml/*"/>
                     <property name="name" value="Content-Security-Policy"/>
-                    <property name="value" value="upgrade-insecure-requests; style-src-elem 'self' 'unsafe-inline'; style-src 'self'; img-src 'self' data:; script-src-elem 'self'; default-src 'none'; object-src 'none'; frame-ancestors 'none'; base-uri 'none';" />
+                    <property name="value" value="style-src-elem 'self' 'unsafe-inline'; style-src 'self'; img-src 'self' data:; script-src-elem 'self'; default-src 'none'; object-src 'none'; frame-ancestors 'none'; base-uri 'none';" />
                 </bean>
             </list>
         </property>


### PR DESCRIPTION
This change fixes an issue unintentionally introduced by a previous commit where I added the Content-Security-Policy HTTP header to the Web Console application. The "upgrade-insecure-requests" tells the browser to automatically upgrade HTTP requests to HTTPS, which ends up breaking the assets loading in some browsers when running the Web Console with HTTP only.

I tested by browsing all the Web Console tabs in Chrome and Safari.