### PR TITLE
AMQ-9771: Enable security features when building XML Schema in activemq-runtime-config.

### DIFF
--- a/activemq-runtime-config/src/main/java/org/apache/activemq/plugin/RuntimeConfigurationBroker.java
+++ b/activemq-runtime-config/src/main/java/org/apache/activemq/plugin/RuntimeConfigurationBroker.java
@@ -228,8 +228,9 @@ public class RuntimeConfigurationBroker extends AbstractRuntimeConfigurationBrok
 
     private Schema getSchema() throws SAXException, IOException {
         if (schema == null) {
-            SchemaFactory schemaFactory = SchemaFactory.newInstance(
-                    XMLConstants.W3C_XML_SCHEMA_NS_URI);
+            SchemaFactory schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+            schemaFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            schemaFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
 
             ArrayList<StreamSource> schemas = new ArrayList<StreamSource>();
             schemas.add(new StreamSource(getClass().getResource("/activemq.xsd").toExternalForm()));


### PR DESCRIPTION
Enables XML security features in the runtime-config plugin similar to how we do in other modules.

I tested by running an ActiveMQ broker with the `runtimeConfigurationPlugin` enabled, the plugin started and picked up changes in activemq.xml.