### PR TITLE
AMQ-9775: Add the maxBrowsePageSize attribute to the JMX destination MBean

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/broker/jmx/DestinationView.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/jmx/DestinationView.java
@@ -31,7 +31,6 @@ import jakarta.jms.InvalidSelectorException;
 import jakarta.jms.MessageProducer;
 import jakarta.jms.Session;
 import java.util.function.Function;
-import java.util.function.Supplier;
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
 import javax.management.openmbean.CompositeData;
@@ -522,6 +521,16 @@ public class DestinationView implements DestinationViewMBean {
     @Override
     public void setMaxPageSize(int pageSize) {
         destination.setMaxPageSize(pageSize);
+    }
+
+    @Override
+    public int getMaxBrowsePageSize() {
+        return destination.getMaxBrowsePageSize();
+    }
+
+    @Override
+    public void setMaxBrowsePageSize(int browsePageSize) {
+        destination.setMaxBrowsePageSize(browsePageSize);
     }
 
     @Override

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/jmx/DestinationViewMBean.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/jmx/DestinationViewMBean.java
@@ -418,6 +418,19 @@ public interface DestinationViewMBean {
     public void setMaxPageSize(@MBeanInfo("pageSize") int pageSize);
 
     /**
+     * @return the maximum number of message to be paged into the
+     * destination for browsing
+     */
+    @MBeanInfo("Maximum number of messages to be paged in for browsing")
+    public int getMaxBrowsePageSize();
+
+    /**
+     * @param browsePageSize
+     * Set the maximum number of messages to page in the destination for browsing
+     */
+    public void setMaxBrowsePageSize(@MBeanInfo("browsePageSize") int browsePageSize);
+
+    /**
      * @return true if caching is allowed of for the destination
      */
     @MBeanInfo("Caching is allowed")


### PR DESCRIPTION
This PR adds the `maxBrowsePageSize` attribute to the JMX destination MBean.

As described in the Jira (AMQ-9775), the `maxBrowsePageSize` property can be set in the destination policies, in the broker.
I have several use cases where client applications are interested to get this metric (via JMX or REST with Jolokia):
* know the browse paging limit to "optimize" paging/browsing on client side (faster)
* get detail about the limit to "recommend" update on the paging limit
