### PR TITLE
NO-REF: Update to spring-webmvc:5.3.41 to address CVE-2024-38819

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
     <shiro-version>1.13.0</shiro-version>
     <slf4j-version>2.0.16</slf4j-version>
     <snappy-version>1.1.2</snappy-version>
-    <spring-version>5.3.39</spring-version>
+    <spring-version>5.3.41</spring-version>
     <taglibs-version>1.2.5</taglibs-version>
     <velocity-version>2.4.1</velocity-version>
     <xpp3-version>1.1.4c</xpp3-version>


### PR DESCRIPTION
Fix for https://spring.io/blog/2024/09/12/spring-framework-5-3-40-and-6-0-24-available-now

**Impact:** An attacker can craft malicious HTTP requests and obtain any file on the file system that is also accessible to the process in which the Spring application is running.

> **Affected Spring Products and Versions**
> Spring Framework:
>
>    5.3.0 - 5.3.40
>    6.0.0 - 6.0.24
>    6.1.0 - 6.1.13
>    Older, unsupported versions are also affected
