### PR TITLE
AMQ-9392 - Rework fix for read check Timer leak 

### DIFF
--- a/activemq-client/src/main/java/org/apache/activemq/transport/AbstractInactivityMonitor.java
+++ b/activemq-client/src/main/java/org/apache/activemq/transport/AbstractInactivityMonitor.java
@@ -437,6 +437,17 @@ public abstract class AbstractInactivityMonitor extends TransportFilter {
             synchronized (AbstractInactivityMonitor.class) {
                 READ_CHECK_TIMER.purge();
                 CHECKER_COUNTER--;
+                if (CHECKER_COUNTER == 0) {
+                    if (READ_CHECK_TIMER != null) {
+                        READ_CHECK_TIMER.cancel();
+                        READ_CHECK_TIMER = null;
+                    }
+                    try {
+                        ThreadPoolUtils.shutdownGraceful(ASYNC_TASKS, 0);
+                    } finally {
+                        ASYNC_TASKS = null;
+                    }
+                }
             }
         }
     }
@@ -497,10 +508,14 @@ public abstract class AbstractInactivityMonitor extends TransportFilter {
                 READ_CHECK_TIMER.purge();
                 CHECKER_COUNTER--;
                 if (CHECKER_COUNTER == 0) {
-                    WRITE_CHECK_TIMER.cancel();
-                    READ_CHECK_TIMER.cancel();
-                    WRITE_CHECK_TIMER = null;
-                    READ_CHECK_TIMER = null;
+                    if (WRITE_CHECK_TIMER != null) {
+                        WRITE_CHECK_TIMER.cancel();
+                        WRITE_CHECK_TIMER = null;
+                    }
+                    if (READ_CHECK_TIMER != null) {
+                        READ_CHECK_TIMER.cancel();
+                        READ_CHECK_TIMER = null;
+                    }
                     try {
                         ThreadPoolUtils.shutdownGraceful(ASYNC_TASKS, 0);
                     } finally {

--- a/activemq-client/src/main/java/org/apache/activemq/transport/AbstractInactivityMonitor.java
+++ b/activemq-client/src/main/java/org/apache/activemq/transport/AbstractInactivityMonitor.java
@@ -46,6 +46,9 @@ public abstract class AbstractInactivityMonitor extends TransportFilter {
 
     private static final Logger LOG = LoggerFactory.getLogger(AbstractInactivityMonitor.class);
 
+    public static final String READ_CHECK_THREAD_NAME = "ActiveMQ InactivityMonitor ReadCheckTimer";
+    public static final String WRITE_CHECK_THREAD_NAME = "ActiveMQ InactivityMonitor WriteCheckTimer";
+
     private static final long DEFAULT_CHECK_TIME_MILLS = 30000;
 
     private static ThreadPoolExecutor ASYNC_TASKS;
@@ -419,7 +422,7 @@ public abstract class AbstractInactivityMonitor extends TransportFilter {
                         ASYNC_TASKS = createExecutor();
                     }
                     if (READ_CHECK_TIMER == null) {
-                        READ_CHECK_TIMER = new Timer("ActiveMQ InactivityMonitor ReadCheckTimer", true);
+                        READ_CHECK_TIMER = new Timer(READ_CHECK_THREAD_NAME, true);
                     }
                 }
                 CHECKER_COUNTER++;
@@ -474,10 +477,10 @@ public abstract class AbstractInactivityMonitor extends TransportFilter {
                     ASYNC_TASKS = createExecutor();
                 }
                 if (READ_CHECK_TIMER == null) {
-                    READ_CHECK_TIMER = new Timer("ActiveMQ InactivityMonitor ReadCheckTimer", true);
+                    READ_CHECK_TIMER = new Timer(READ_CHECK_THREAD_NAME, true);
                 }
                 if (WRITE_CHECK_TIMER == null) {
-                    WRITE_CHECK_TIMER = new Timer("ActiveMQ InactivityMonitor WriteCheckTimer", true);
+                    WRITE_CHECK_TIMER = new Timer(WRITE_CHECK_THREAD_NAME, true);
                 }
 
                 CHECKER_COUNTER++;


### PR DESCRIPTION
This commit updates the previous fix for preventing a read check Timer
leak by the inactivity monitor when TCP connections fail
This is a follow on to https://github.com/apache/activemq/pull/1119

This updated version has the following improvements:

  1) The logic to cancel timers and shutdown the executor has been
consolidated into one location and only done during stopping of the
transport. Previously, the update could stop the task/executor during
normal broker operation (see next point)
  2) stopConnectCheckTask() is called under normal circumstances during
initialization of a connection and the previous change caused the read
task to be cancelled and the executor to be stopped, only to be
immediately restarted again during the first connection creation.
  3) Null checks were added to guarantee no null pointer issues when
referencing tasks/timers during stop
  4) Helper methods and some comments were added to simplify the code
and make it easier to understand what is going on.