### PR TITLE
[NO-JIRA] Update enforcer-plugin to releasing with JDK 21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1133,7 +1133,7 @@
             <configuration>
               <rules>
                 <requireMavenVersion>
-                  <version>3.0.5</version>
+                  <version>3.6.3</version>
                 </requireMavenVersion>
               </rules>
             </configuration>
@@ -1337,6 +1337,39 @@
       </activation>
       <build>
         <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-enforcer-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>enforce-maven</id>
+                <goals>
+                  <goal>enforce</goal>
+                </goals>
+                <configuration>
+                  <rules>
+                    <requireMavenVersion>
+                      <version>3.6.3</version>
+                    </requireMavenVersion>
+                  </rules>
+                </configuration>
+              </execution>
+              <execution>
+                <id>enforce-java-version</id>
+                <goals>
+                  <goal>enforce</goal>
+                </goals>
+                <configuration>
+                  <rules>
+                    <requireJavaVersion>
+                      <version>[21,)</version>
+                      <message>You must use Java 21+ during release to support multi-release jars</message>
+                    </requireJavaVersion>
+                  </rules>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>


### PR DESCRIPTION
I tested building with JDK 21 and then running with JDK 17 without a problem.

The docs for enforcer plugin make it read that this setting impacts _runtime_, but it does _**not**_ in fact change the compiler-plugin values used for source/target/release.

NOTE: This needs to be merged into main after main is updated to 6.3.0-SNAPSHOT