### PR TITLE
[AMQ-9742] Add basic Helm chart for ActiveMQ

### DIFF
--- a/activemq-helm-chart/Chart.yaml
+++ b/activemq-helm-chart/Chart.yaml
@@ -1,0 +1,15 @@
+apiVersion: v2
+name: activemq
+description: A Helm chart for Apache ActiveMQ
+type: application
+version: 1.0.0
+appVersion: "latest"
+keywords:
+  - activemq
+  - message queue
+  - messaging
+home: https://activemq.apache.org
+sources:
+  - https://github.com/apache/activemq
+maintainers:
+  - name: activemq

--- a/activemq-helm-chart/README.md
+++ b/activemq-helm-chart/README.md
@@ -1,0 +1,96 @@
+# ActiveMQ Helm Chart
+
+A Helm chart for deploying Apache ActiveMQ on Kubernetes.
+
+## Introduction
+
+This chart bootstraps an ActiveMQ deployment on a Kubernetes cluster using the Helm package manager.
+
+## Prerequisites
+
+- Kubernetes 1.19+
+- Helm 3.0+
+- PV provisioner support in the underlying infrastructure (if persistence is enabled)
+
+## Installing the Chart
+
+To install the chart with the release name `my-activemq`:
+
+```bash
+helm install my-activemq .
+```
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-activemq` deployment:
+
+```bash
+helm uninstall my-activemq
+```
+
+## Configuration
+
+The following table lists the configurable parameters of the ActiveMQ chart and their default values.
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `replicaCount` | Number of replicas | `1` |
+| `image.repository` | ActiveMQ image repository | `apache/activemq-classic` |
+| `image.tag` | ActiveMQ image tag | `latest` |
+| `image.pullPolicy` | Image pull policy | `IfNotPresent` |
+| `auth.username` | ActiveMQ admin username | `admin` |
+| `auth.password` | ActiveMQ admin password | `changeme` |
+| `service.type` | Kubernetes service type | `ClusterIP` |
+| `service.port` | OpenWire service port | `61616` |
+| `service.webConsolePort` | Web Console port | `8161` |
+| `persistence.enabled` | Enable persistence using PVC | `true` |
+| `persistence.storageClass` | PVC Storage Class | `""` |
+| `persistence.accessMode` | PVC Access Mode | `ReadWriteOnce` |
+| `persistence.size` | PVC Storage Request | `8Gi` |
+| `resources.limits.cpu` | CPU limit | `1000m` |
+| `resources.limits.memory` | Memory limit | `2Gi` |
+| `resources.requests.cpu` | CPU request | `500m` |
+| `resources.requests.memory` | Memory request | `1Gi` |
+| `livenessProbe.enabled` | Enable liveness probe | `true` |
+| `readinessProbe.enabled` | Enable readiness probe | `true` |
+| `ingress.enabled` | Enable ingress | `false` |
+| `config.activemqXmlPath` | Path to custom activemq.xml file | `""` |
+
+## Accessing ActiveMQ
+
+### Web Console
+
+The ActiveMQ Web Console is accessible on port 8161. To access it locally:
+
+```bash
+kubectl port-forward svc/my-activemq 8161:8161
+```
+
+Then open http://localhost:8161 in your browser and login with the configured credentials.
+
+### OpenWire Connection
+
+Applications can connect to ActiveMQ on port 61616 using the service name:
+
+```
+tcp://my-activemq:61616
+```
+
+## Custom Configuration
+
+To use a custom `activemq.xml` configuration file, place your file in the chart directory and specify the path:
+
+```bash
+cp activemq_sample.xml mq-activemq.xml
+```
+
+```yaml
+config:
+  activemqXmlPath: "my-activemq.xml"
+```
+
+## Persistence
+
+The ActiveMQ image stores data at the `/opt/apache-activemq/data` path of the container.
+
+By default, the chart mounts a Persistent Volume at this location. The volume is created using dynamic volume provisioning.

--- a/activemq-helm-chart/README.md
+++ b/activemq-helm-chart/README.md
@@ -94,3 +94,17 @@ config:
 The ActiveMQ image stores data at the `/opt/apache-activemq/data` path of the container.
 
 By default, the chart mounts a Persistent Volume at this location. The volume is created using dynamic volume provisioning.
+
+## TLS Configuration
+
+To enable TLS, create secrets with your keystore and truststore files:
+
+```bash
+kubectl create secret generic activemq-keystore --from-file=broker.ks=/path/to/broker.ks
+kubectl create secret generic activemq-truststore --from-file=broker.ts=/path/to/broker.ts
+
+helm install my-activemq . \
+  --set tls.enabled=true \
+  --set tls.keystoreSecret=activemq-keystore \
+  --set tls.truststoreSecret=activemq-truststore
+```

--- a/activemq-helm-chart/README.md
+++ b/activemq-helm-chart/README.md
@@ -55,6 +55,7 @@ The following table lists the configurable parameters of the ActiveMQ chart and 
 | `readinessProbe.enabled` | Enable readiness probe | `true` |
 | `ingress.enabled` | Enable ingress | `false` |
 | `config.activemqXmlPath` | Path to custom activemq.xml file | `""` |
+| `config.jettyXmlPath` | Path to custom jetty.xml file | `""` |
 | `tls.enabled` | Enable TLS/SSL | `false` |
 | `tls.keystoreSecret` | Kubernetes secret containing broker.ks | `""` |
 | `tls.truststoreSecret` | Kubernetes secret containing broker.ts | `""` |
@@ -83,15 +84,12 @@ tcp://my-activemq:61616
 
 ## Custom Configuration
 
-To use a custom `activemq.xml` configuration file, place your file in the chart directory and specify the path:
-
-```bash
-cp activemq_sample.xml mq-activemq.xml
-```
+To use custom configuration files, place your files in the chart directory and specify the paths:
 
 ```yaml
 config:
   activemqXmlPath: "my-activemq.xml"
+  jettyXmlPath: "my-jetty.xml"
 ```
 
 ## Persistence
@@ -118,7 +116,7 @@ keytool -export -alias broker -keystore broker.ks \
 
 # Create truststore
 keytool -import -alias broker -keystore broker.ts \
-  -file broker.cert -storepass changeit -noreply
+  -file broker.cert -storepass changeit
 ```
 
 ### Create Kubernetes Secrets

--- a/activemq-helm-chart/activemq_sample.xml
+++ b/activemq-helm-chart/activemq_sample.xml
@@ -1,0 +1,130 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<!-- START SNIPPET: example -->
+<beans
+  xmlns="http://www.springframework.org/schema/beans"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+  http://activemq.apache.org/schema/core http://activemq.apache.org/schema/core/activemq-core.xsd">
+
+    <!-- Allows us to use system properties as variables in this configuration file -->
+    <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
+        <property name="locations">
+            <value>file:${activemq.conf}/credentials.properties</value>
+        </property>
+    </bean>
+
+    <!--
+        The <broker> element is used to configure the ActiveMQ broker.
+    -->
+    <broker xmlns="http://activemq.apache.org/schema/core" brokerName="localhost" dataDirectory="${activemq.data}">
+
+        <destinationPolicy>
+            <policyMap>
+              <policyEntries>
+                <policyEntry topic=">" >
+                    <!-- The constantPendingMessageLimitStrategy is used to prevent
+                         slow topic consumers to block producers and affect other consumers
+                         by limiting the number of messages that are retained
+                         For more information, see:
+
+                         http://activemq.apache.org/slow-consumer-handling.html
+
+                    -->
+                  <pendingMessageLimitStrategy>
+                    <constantPendingMessageLimitStrategy limit="1000"/>
+                  </pendingMessageLimitStrategy>
+                </policyEntry>
+              </policyEntries>
+            </policyMap>
+        </destinationPolicy>
+
+
+        <!--
+            The managementContext is used to configure how ActiveMQ is exposed in
+            JMX. By default, ActiveMQ uses the MBean server that is started by
+            the JVM. For more information, see:
+
+            http://activemq.apache.org/jmx.html
+        -->
+        <managementContext>
+            <managementContext createConnector="false"/>
+        </managementContext>
+
+        <!--
+            Configure message persistence for the broker. The default persistence
+            mechanism is the KahaDB store (identified by the kahaDB tag).
+            For more information, see:
+
+            http://activemq.apache.org/persistence.html
+        -->
+        <persistenceAdapter>
+            <kahaDB directory="${activemq.data}/kahadb"/>
+        </persistenceAdapter>
+
+
+          <!--
+            The systemUsage controls the maximum amount of space the broker will
+            use before disabling caching and/or slowing down producers. For more information, see:
+            http://activemq.apache.org/producer-flow-control.html
+          -->
+          <systemUsage>
+            <systemUsage>
+                <memoryUsage>
+                    <memoryUsage percentOfJvmHeap="70" />
+                </memoryUsage>
+                <storeUsage>
+                    <storeUsage limit="100 gb"/>
+                </storeUsage>
+                <tempUsage>
+                    <tempUsage limit="50 gb"/>
+                </tempUsage>
+            </systemUsage>
+        </systemUsage>
+
+        <!--
+            The transport connectors expose ActiveMQ over a given protocol to
+            clients and other brokers. For more information, see:
+
+            http://activemq.apache.org/configuring-transports.html
+        -->
+        <transportConnectors>
+            <!-- DOS protection, limit concurrent connections to 1000 and frame size to 100MB -->
+            <transportConnector name="openwire" uri="tcp://0.0.0.0:61616?maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/>
+            <transportConnector name="amqp" uri="amqp://0.0.0.0:5672?maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/>
+            <transportConnector name="stomp" uri="stomp://0.0.0.0:61613?maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/>
+            <transportConnector name="mqtt" uri="mqtt://0.0.0.0:1883?maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/>
+            <transportConnector name="ws" uri="ws://0.0.0.0:61614?maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/>
+        </transportConnectors>
+
+        <!-- destroy the spring context on shutdown to stop jetty -->
+        <shutdownHooks>
+            <bean xmlns="http://www.springframework.org/schema/beans" class="org.apache.activemq.hooks.SpringContextHook" />
+        </shutdownHooks>
+
+    </broker>
+
+    <!--
+        Enable web consoles, REST and Ajax APIs and demos
+        The web consoles requires by default login, you can disable this in the jetty.xml file
+
+        Take a look at ${ACTIVEMQ_HOME}/conf/jetty.xml for more details
+    -->
+    <import resource="jetty.xml"/>
+
+</beans>
+<!-- END SNIPPET: example -->

--- a/activemq-helm-chart/templates/NOTES.txt
+++ b/activemq-helm-chart/templates/NOTES.txt
@@ -1,0 +1,29 @@
+1. Get the ActiveMQ Web Console URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[1].nodePort}" services {{ include "activemq.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "activemq.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "activemq.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.webConsolePort }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "activemq.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[1].containerPort}")
+  echo "Visit http://127.0.0.1:8161 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8161:$CONTAINER_PORT
+{{- end }}
+
+2. Login credentials:
+   Username: {{ .Values.auth.username }}
+   Password: {{ .Values.auth.password }}
+
+3. To connect to ActiveMQ from applications:
+   Connection URL: tcp://{{ include "activemq.fullname" . }}:{{ .Values.service.port }}

--- a/activemq-helm-chart/templates/NOTES.txt
+++ b/activemq-helm-chart/templates/NOTES.txt
@@ -6,19 +6,19 @@
   {{- end }}
 {{- end }}
 {{- else if contains "NodePort" .Values.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[1].nodePort}" services {{ include "activemq.fullname" . }})
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "activemq.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-  echo http://$NODE_IP:$NODE_PORT
+  echo {{ if .Values.tls.enabled }}https{{ else }}http{{ end }}://$NODE_IP:$NODE_PORT
 {{- else if contains "LoadBalancer" .Values.service.type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
            You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "activemq.fullname" . }}'
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "activemq.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
-  echo http://$SERVICE_IP:{{ .Values.service.webConsolePort }}
+  echo {{ if .Values.tls.enabled }}https{{ else }}http{{ end }}://$SERVICE_IP:{{ if .Values.tls.enabled }}{{ .Values.tls.webConsoleSslPort }}{{ else }}{{ .Values.service.webConsolePort }}{{ end }}
 {{- else if contains "ClusterIP" .Values.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "activemq.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[1].containerPort}")
-  echo "Visit http://127.0.0.1:8161 to use your application"
-  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8161:$CONTAINER_PORT
+  echo "Visit {{ if .Values.tls.enabled }}https://127.0.0.1:{{ .Values.tls.webConsoleSslPort }}{{ else }}http://127.0.0.1:{{ .Values.service.webConsolePort }}{{ end }} to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME {{ if .Values.tls.enabled }}{{ .Values.tls.webConsoleSslPort }}{{ else }}{{ .Values.service.webConsolePort }}{{ end }}:$CONTAINER_PORT
 {{- end }}
 
 2. Login credentials:
@@ -26,9 +26,10 @@
    Password: {{ .Values.auth.password }}
 
 3. To connect to ActiveMQ from applications:
-   Connection URL: tcp://{{ include "activemq.fullname" . }}:{{ .Values.service.port }}
 {{- if .Values.tls.enabled }}
-   SSL Connection URL: ssl://{{ include "activemq.fullname" . }}:{{ .Values.tls.sslPort }}
+   Connection URL: ssl://{{ include "activemq.fullname" . }}:{{ .Values.tls.sslPort }}
+{{- else }}
+   Connection URL: tcp://{{ include "activemq.fullname" . }}:{{ .Values.service.port }}
 {{- end }}
 
 {{- if .Values.tls.enabled }}

--- a/activemq-helm-chart/templates/NOTES.txt
+++ b/activemq-helm-chart/templates/NOTES.txt
@@ -27,3 +27,12 @@
 
 3. To connect to ActiveMQ from applications:
    Connection URL: tcp://{{ include "activemq.fullname" . }}:{{ .Values.service.port }}
+{{- if .Values.tls.enabled }}
+   SSL Connection URL: ssl://{{ include "activemq.fullname" . }}:{{ .Values.tls.sslPort }}
+{{- end }}
+
+{{- if .Values.tls.enabled }}
+4. TLS is enabled. Ensure you have created the required secrets:
+   - Keystore secret: {{ .Values.tls.keystoreSecret }}
+   - Truststore secret: {{ .Values.tls.truststoreSecret }}
+{{- end }}

--- a/activemq-helm-chart/templates/_helpers.tpl
+++ b/activemq-helm-chart/templates/_helpers.tpl
@@ -1,0 +1,49 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "activemq.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "activemq.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "activemq.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "activemq.labels" -}}
+helm.sh/chart: {{ include "activemq.chart" . }}
+{{ include "activemq.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "activemq.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "activemq.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/activemq-helm-chart/templates/configmap.yaml
+++ b/activemq-helm-chart/templates/configmap.yaml
@@ -13,3 +13,7 @@ data:
   activemq.xml: |
 {{ .Files.Get .Values.config.activemqXmlPath | indent 4 }}
   {{- end }}
+  {{- if .Values.config.jettyXmlPath }}
+  jetty.xml: |
+{{ .Files.Get .Values.config.jettyXmlPath | indent 4 }}
+  {{- end }}

--- a/activemq-helm-chart/templates/configmap.yaml
+++ b/activemq-helm-chart/templates/configmap.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "activemq.fullname" . }}-config
+  labels:
+    {{- include "activemq.labels" . | nindent 4 }}
+data:
+  users.properties: |
+    {{ .Values.auth.username }}={{ .Values.auth.password }}
+  groups.properties: |
+    admins={{ .Values.auth.username }}
+  {{- if .Values.config.activemqXmlPath }}
+  activemq.xml: |
+{{ .Files.Get .Values.config.activemqXmlPath | indent 4 }}
+  {{- end }}

--- a/activemq-helm-chart/templates/service.yaml
+++ b/activemq-helm-chart/templates/service.yaml
@@ -7,6 +7,7 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
+  {{- if not .Values.tls.enabled }}
   - name: openwire
     port: {{ .Values.service.port }}
     targetPort: openwire
@@ -15,5 +16,15 @@ spec:
     port: {{ .Values.service.webConsolePort }}
     targetPort: webconsole
     protocol: TCP
+  {{- else }}
+  - name: openwire-ssl
+    port: {{ .Values.tls.sslPort }}
+    targetPort: openwire-ssl
+    protocol: TCP
+  - name: webconsole-ssl
+    port: {{ .Values.tls.webConsoleSslPort }}
+    targetPort: webconsole-ssl
+    protocol: TCP
+  {{- end }}
   selector:
     {{- include "activemq.selectorLabels" . | nindent 4 }}

--- a/activemq-helm-chart/templates/service.yaml
+++ b/activemq-helm-chart/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "activemq.fullname" . }}
+  labels:
+    {{- include "activemq.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+  - name: openwire
+    port: {{ .Values.service.port }}
+    targetPort: openwire
+    protocol: TCP
+  - name: webconsole
+    port: {{ .Values.service.webConsolePort }}
+    targetPort: webconsole
+    protocol: TCP
+  selector:
+    {{- include "activemq.selectorLabels" . | nindent 4 }}

--- a/activemq-helm-chart/templates/statefulset.yaml
+++ b/activemq-helm-chart/templates/statefulset.yaml
@@ -24,16 +24,25 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
+        {{- if not .Values.tls.enabled }}
         - name: openwire
           containerPort: 61616
           protocol: TCP
         - name: webconsole
           containerPort: 8161
           protocol: TCP
+        {{- else }}
+        - name: openwire-ssl
+          containerPort: {{ .Values.tls.sslPort }}
+          protocol: TCP
+        - name: webconsole-ssl
+          containerPort: {{ .Values.tls.webConsoleSslPort }}
+          protocol: TCP
+        {{- end }}
         {{- if .Values.livenessProbe.enabled }}
         livenessProbe:
           tcpSocket:
-            port: openwire
+            port: {{ if .Values.tls.enabled }}openwire-ssl{{ else }}openwire{{ end }}
           initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
           timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
@@ -43,7 +52,7 @@ spec:
         {{- if .Values.readinessProbe.enabled }}
         readinessProbe:
           tcpSocket:
-            port: openwire
+            port: {{ if .Values.tls.enabled }}openwire-ssl{{ else }}openwire{{ end }}
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
           timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
@@ -63,6 +72,16 @@ spec:
         - name: config
           mountPath: /opt/apache-activemq/conf/activemq.xml
           subPath: activemq.xml
+        {{- end }}
+        {{- if .Values.tls.enabled }}
+        - name: keystore
+          mountPath: /opt/apache-activemq/conf/broker.ks
+          subPath: broker.ks
+          readOnly: true
+        - name: truststore
+          mountPath: /opt/apache-activemq/conf/broker.ts
+          subPath: broker.ts
+          readOnly: true
         {{- end }}
         {{- with .Values.resources }}
         resources:
@@ -84,6 +103,14 @@ spec:
       - name: config
         configMap:
           name: {{ include "activemq.fullname" . }}-config
+      {{- if .Values.tls.enabled }}
+      - name: keystore
+        secret:
+          secretName: {{ .Values.tls.keystoreSecret }}
+      - name: truststore
+        secret:
+          secretName: {{ .Values.tls.truststoreSecret }}
+      {{- end }}
   {{- if not .Values.persistence.enabled }}
       - name: data
         emptyDir: {}

--- a/activemq-helm-chart/templates/statefulset.yaml
+++ b/activemq-helm-chart/templates/statefulset.yaml
@@ -73,6 +73,11 @@ spec:
           mountPath: /opt/apache-activemq/conf/activemq.xml
           subPath: activemq.xml
         {{- end }}
+        {{- if .Values.config.jettyXmlPath }}
+        - name: config
+          mountPath: /opt/apache-activemq/conf/jetty.xml
+          subPath: jetty.xml
+        {{- end }}
         {{- if .Values.tls.enabled }}
         - name: keystore
           mountPath: /opt/apache-activemq/conf/broker.ks

--- a/activemq-helm-chart/templates/statefulset.yaml
+++ b/activemq-helm-chart/templates/statefulset.yaml
@@ -1,0 +1,104 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "activemq.fullname" . }}
+  labels:
+    {{- include "activemq.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ include "activemq.fullname" . }}
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "activemq.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "activemq.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+      - name: activemq
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        ports:
+        - name: openwire
+          containerPort: 61616
+          protocol: TCP
+        - name: webconsole
+          containerPort: 8161
+          protocol: TCP
+        {{- if .Values.livenessProbe.enabled }}
+        livenessProbe:
+          tcpSocket:
+            port: openwire
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          successThreshold: {{ .Values.livenessProbe.successThreshold }}
+        {{- end }}
+        {{- if .Values.readinessProbe.enabled }}
+        readinessProbe:
+          tcpSocket:
+            port: openwire
+          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          successThreshold: {{ .Values.readinessProbe.successThreshold }}
+        {{- end }}
+        volumeMounts:
+        - name: data
+          mountPath: /opt/apache-activemq/data
+        - name: config
+          mountPath: /opt/apache-activemq/conf/users.properties
+          subPath: users.properties
+        - name: config
+          mountPath: /opt/apache-activemq/conf/groups.properties
+          subPath: groups.properties
+        {{- if .Values.config.activemqXmlPath }}
+        - name: config
+          mountPath: /opt/apache-activemq/conf/activemq.xml
+          subPath: activemq.xml
+        {{- end }}
+        {{- with .Values.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+      - name: config
+        configMap:
+          name: {{ include "activemq.fullname" . }}-config
+  {{- if not .Values.persistence.enabled }}
+      - name: data
+        emptyDir: {}
+  {{- end }}
+  {{- if .Values.persistence.enabled }}
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes:
+        - {{ .Values.persistence.accessMode | quote }}
+      {{- if .Values.persistence.storageClass }}
+      storageClassName: {{ .Values.persistence.storageClass | quote }}
+      {{- end }}
+      resources:
+        requests:
+          storage: {{ .Values.persistence.size | quote }}
+  {{- end }}

--- a/activemq-helm-chart/values.yaml
+++ b/activemq-helm-chart/values.yaml
@@ -14,6 +14,7 @@ auth:
 
 config:
   activemqXmlPath: ""
+  jettyXmlPath: ""
 
 service:
   type: ClusterIP

--- a/activemq-helm-chart/values.yaml
+++ b/activemq-helm-chart/values.yaml
@@ -1,0 +1,70 @@
+replicaCount: 1
+
+image:
+  repository: apache/activemq-classic
+  tag: "latest"
+  pullPolicy: IfNotPresent
+
+nameOverride: ""
+fullnameOverride: ""
+
+auth:
+  username: admin
+  password: changeme
+
+config:
+  activemqXmlPath: ""
+
+service:
+  type: ClusterIP
+  port: 61616
+  webConsolePort: 8161
+
+persistence:
+  enabled: false
+  storageClass: ""
+  accessMode: ReadWriteOnce
+  size: 8Gi
+
+resources:
+  limits:
+    cpu: 1000m
+    memory: 2Gi
+  requests:
+    cpu: 500m
+    memory: 1Gi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+podAnnotations: {}
+
+livenessProbe:
+  enabled: true
+  initialDelaySeconds: 120
+  periodSeconds: 30
+  timeoutSeconds: 20
+  failureThreshold: 6
+  successThreshold: 1
+
+readinessProbe:
+  enabled: true
+  initialDelaySeconds: 60
+  periodSeconds: 30
+  timeoutSeconds: 20
+  failureThreshold: 3
+  successThreshold: 1
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: activemq.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []

--- a/activemq-helm-chart/values.yaml
+++ b/activemq-helm-chart/values.yaml
@@ -68,3 +68,10 @@ ingress:
         - path: /
           pathType: Prefix
   tls: []
+
+tls:
+  enabled: false
+  keystoreSecret: "activemq-keystore"  # kubectl create secret generic activemq-keystore --from-file=broker.ks=<path>
+  truststoreSecret: "activemq-truststore"  # kubectl create secret generic activemq-truststore --from-file=broker.ts=<path>
+  sslPort: 61617
+  webConsoleSslPort: 8162


### PR DESCRIPTION
Basic Helm chart for ActiveMQ. Right now it lets user provision single instance ActiveMQ broker in the k8s cluster. It offers the following features:

1.  Specify basic username and password for basic auth
2. Specify custom activemq.xml configuration
3. Specify custom jetty.xml configuration
4. Configure TLS