### PR TITLE
[AMQ-9817] Fix long running KahaDBOffsetRecoveryListenerTest on CI

### DIFF
--- a/activemq-unit-tests/src/test/java/org/apache/activemq/store/kahadb/KahaDBOffsetRecoveryListenerTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/store/kahadb/KahaDBOffsetRecoveryListenerTest.java
@@ -17,11 +17,12 @@
 
 package org.apache.activemq.store.kahadb;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.LinkedList;
-import java.util.List;
-
+import jakarta.jms.Connection;
+import jakarta.jms.JMSException;
+import jakarta.jms.MessageConsumer;
+import jakarta.jms.MessageProducer;
+import jakarta.jms.Session;
+import jakarta.jms.TextMessage;
 import org.apache.activemq.ActiveMQConnectionFactory;
 import org.apache.activemq.broker.BrokerService;
 import org.apache.activemq.command.ActiveMQQueue;
@@ -30,20 +31,18 @@ import org.apache.activemq.command.MessageId;
 import org.apache.activemq.store.MessageRecoveryContext;
 import org.apache.activemq.store.MessageRecoveryListener;
 import org.apache.activemq.store.MessageStore;
+import org.apache.activemq.util.IOHelper;
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import jakarta.jms.Connection;
-import jakarta.jms.JMSException;
-import jakarta.jms.MessageConsumer;
-import jakarta.jms.MessageProducer;
-import jakarta.jms.Session;
-import jakarta.jms.TextMessage;
+import java.io.File;
+import java.io.IOException;
+import java.util.LinkedList;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 
@@ -56,16 +55,6 @@ public class KahaDBOffsetRecoveryListenerTest {
 
     @Rule
     public TestName testName = new TestName();
-
-    protected final int PRETEST_MSG_COUNT = 17531;
-
-    @Before
-    public void beforeEach() throws Exception {
-        // Send+Recv a odd number of messages beyond cache sizes
-        // to confirm the queue's sequence number gets pushed off
-        sendMessages(PRETEST_MSG_COUNT, testName.getMethodName());
-        assertEquals(Integer.valueOf(PRETEST_MSG_COUNT), Integer.valueOf(receiveMessages(testName.getMethodName())));
-    }
 
     @After
     public void afterEach() {
@@ -85,7 +74,7 @@ public class KahaDBOffsetRecoveryListenerTest {
     private KahaDBStore createStore(boolean delete) throws IOException {
         KahaDBStore kaha = new KahaDBStore();
         kaha.setJournalMaxFileLength(1024*100);
-        kaha.setDirectory(new File("target" + File.separator + "activemq-data" + File.separator + "kahadb-recovery-tests"));
+        kaha.setDirectory(new File(IOHelper.getDefaultDataDirectory(), "kahadb-recovery-tests"));
         if( delete ) {
             kaha.deleteAllMessages();
         }


### PR DESCRIPTION
This is taking about an hour to run.
The @Before code is running every single time for all the test scenario of the class. 

I'm questioning what the benefit of the @Before peace of code. If it's an actual test, I'd pull it into its own @Test method.
But for now, it's burning a lot of time because it does a lot of IO and the CI is slow for IO. Moreover, the directory used in the sendMessage call of the @Before portion is the default one, because the broker is lazily created after using the VM Transport, whereas all the other tests are actually using a different directory. 

Locally on my Mac M1 it runs on 16 min and after the removal, it runs in 2'30. 

If everyone is happy with it, I can create a JIRA and rename this PR and update the commit message