### PR TITLE
[AMQ-9820]: closed connections leaking into the pool when reconnectOnException is used

### DIFF
--- a/activemq-jms-pool/src/main/java/org/apache/activemq/jms/pool/PooledConnectionFactory.java
+++ b/activemq-jms-pool/src/main/java/org/apache/activemq/jms/pool/PooledConnectionFactory.java
@@ -129,7 +129,12 @@ public class PooledConnectionFactory implements ConnectionFactory, QueueConnecti
                     @Override
                     public boolean validateObject(ConnectionKey connectionKey, PooledObject<ConnectionPool> pooledObject) {
                         ConnectionPool connection = pooledObject.getObject();
-                        if (connection != null && connection.expiredCheck()) {
+                        if (connection == null || connection.getConnection() == null) {
+                            LOG.trace("Connection has been closed and will be destroyed: {}", connection);
+                            return false;
+                        }
+
+                        if (connection.expiredCheck()) {
                             LOG.trace("Connection has expired: {} and will be destroyed", connection);
                             return false;
                         }

--- a/activemq-jms-pool/src/test/java/org/apache/activemq/jms/pool/PooledConnectionSecurityExceptionTest.java
+++ b/activemq-jms-pool/src/test/java/org/apache/activemq/jms/pool/PooledConnectionSecurityExceptionTest.java
@@ -16,13 +16,6 @@
  */
 package org.apache.activemq.jms.pool;
 
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.util.ArrayList;
-import java.util.List;
-
 import jakarta.jms.Connection;
 import jakarta.jms.ExceptionListener;
 import jakarta.jms.JMSException;
@@ -30,7 +23,6 @@ import jakarta.jms.JMSSecurityException;
 import jakarta.jms.MessageProducer;
 import jakarta.jms.Queue;
 import jakarta.jms.Session;
-
 import org.apache.activemq.ActiveMQConnectionFactory;
 import org.apache.activemq.broker.BrokerPlugin;
 import org.apache.activemq.broker.BrokerService;
@@ -49,6 +41,13 @@ import org.junit.Test;
 import org.junit.rules.TestName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Test Pooled connections ability to handle security exceptions
@@ -134,8 +133,9 @@ public class PooledConnectionSecurityExceptionTest {
 
             @Override
             public boolean isSatisified() throws Exception {
-                return connection1.getConnection() !=
-                    ((PooledConnection) pooledConnFact.createConnection("invalid", "credentials")).getConnection();
+                try (final PooledConnection newConnection = (PooledConnection) pooledConnFact.createConnection("invalid", "credentials")) {
+                    return connection1.getConnection() != newConnection.getConnection();
+                }
             }
         }));
 
@@ -232,8 +232,9 @@ public class PooledConnectionSecurityExceptionTest {
 
             @Override
             public boolean isSatisified() throws Exception {
-                return connection1.getConnection() !=
-                          ((PooledConnection) pooledConnFact.createConnection("invalid", "credentials")).getConnection();
+                try (final PooledConnection newConnection = (PooledConnection) pooledConnFact.createConnection("invalid", "credentials")) {
+                    return connection1.getConnection() != newConnection.getConnection();
+                }
             }
         }));
 


### PR DESCRIPTION
Possible bug revealed by PooledConnectionSecurityExceptionTest on faster environments (Github Actions nodes for example). 

The PR fixes the test itself leaking connections during the waitFor condition.
But it also fixes the connection pool itself because when reconnectOnException is used, commons-pool will close the underlying connection in order to reconnect. I've updated the validateObject() to consider the underlying connection state in order to decide if a connection is valid or not.

I'm not quite sure my hypothesis is correct or not and therefore if the fix is relevant.

```
[INFO] Running
  org.apache.activemq.jms.pool.PooledConnectionSecurityExceptionTest
  Error:  Tests run: 8, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.173 s <<< FAILURE! -- in org.apache.activemq.jms.pool.PooledConnectionSecurityExceptionTest
  Error:  org.apache.activemq.jms.pool.PooledConnectionSecurityExceptionTest.testFailureGetsNewConnectionOnRetryLooped -- Time elapsed: 0.056 s <<< ERROR!
  jakarta.jms.JMSException: Disposed due to prior exception
        at org.apache.activemq.util.JMSExceptionSupport.create(JMSExceptionSupport.java:67)
        at org.apache.activemq.ActiveMQConnection.syncSendPacket(ActiveMQConnection.java:1478)
        at org.apache.activemq.ActiveMQConnection.ensureConnectionInfoSent(ActiveMQConnection.java:1561)
        at org.apache.activemq.ActiveMQConnection.start(ActiveMQConnection.java:569)
        at org.apache.activemq.jms.pool.ConnectionPool.start(ConnectionPool.java:125)
        at org.apache.activemq.jms.pool.PooledConnection.start(PooledConnection.java:95)
        at org.apache.activemq.jms.pool.PooledConnectionSecurityExceptionTest.testFailureGetsNewConnectionOnRetry(PooledConnectionSecurityExceptionTest.java:127)
        at org.apache.activemq.jms.pool.PooledConnectionSecurityExceptionTest.testFailureGetsNewConnectionOnRetryLooped(PooledConnectionSecurityExceptionTest.java:116)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:569)
        at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
        at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
        at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
        at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
        at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
        at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
        at org.junit.rules.TestWatcher$1.evaluate(TestWatcher.java:61)
        at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
        at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
        at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
        at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
        at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
        at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
        at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
        at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
        at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
        at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
        at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
        at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
        at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:316)
        at org.apache.maven.surefire.junit4.JUnit4Provider.executeWithRerun(JUnit4Provider.java:240)
        at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:214)
        at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:155)
        at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:385)
        at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:162)
        at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:507)
        at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:495)
  Caused by: org.apache.activemq.transport.TransportDisposedIOException: Disposed due to prior exception
        at org.apache.activemq.transport.ResponseCorrelator.onException(ResponseCorrelator.java:125)
        at org.apache.activemq.transport.TransportFilter.onException(TransportFilter.java:114)
        at org.apache.activemq.transport.TransportFilter.onException(TransportFilter.java:114)
        at org.apache.activemq.transport.WireFormatNegotiator.onException(WireFormatNegotiator.java:173)
        at org.apache.activemq.transport.AbstractInactivityMonitor.onException(AbstractInactivityMonitor.java:349)
        at org.apache.activemq.transport.TransportSupport.onException(TransportSupport.java:96)
        at org.apache.activemq.transport.tcp.TcpTransport.run(TcpTransport.java:220)
        at java.base/java.lang.Thread.run(Thread.java:840)
  Caused by: java.io.EOFException
        at java.base/java.io.DataInputStream.readInt(DataInputStream.java:386)
        at org.apache.activemq.openwire.OpenWireFormat.unmarshal(OpenWireFormat.java:289)
        at org.apache.activemq.transport.tcp.TcpTransport.readCommand(TcpTransport.java:241)
        at org.apache.activemq.transport.tcp.TcpTransport.doRun(TcpTransport.java:233)
        at org.apache.activemq.transport.tcp.TcpTransport.run(TcpTransport.java:216)
        ... 1 more

```