### PR TITLE
AMQ-9823 - properly clear ack set from ackAndPreparedMap

### DIFF
--- a/activemq-kahadb-store/src/main/java/org/apache/activemq/store/kahadb/KahaDBStore.java
+++ b/activemq-kahadb-store/src/main/java/org/apache/activemq/store/kahadb/KahaDBStore.java
@@ -465,7 +465,7 @@ public class KahaDBStore extends MessageDatabase implements PersistenceAdapter, 
                         Set<String> ackedAndPrepared = ackedAndPreparedMap.get(key);
                         if (ackedAndPrepared != null) {
                             ackedAndPrepared.remove(id);
-                            if (ackedAndPreparedMap.isEmpty()) {
+                            if (ackedAndPrepared.isEmpty()) {
                                 ackedAndPreparedMap.remove(key);
                             }
                         }


### PR DESCRIPTION
Fix the logic that removes prepared acks from the ackAndPreparedMap that were loaded during XA recovery on commit/rollback so that if the set of acks for a key is empty the set it is removed from the map