### PR TITLE
AMQ-9824 - Cleanup code in KahaDB classes

### DIFF
--- a/activemq-kahadb-store/src/main/java/org/apache/activemq/store/kahadb/KahaDBStore.java
+++ b/activemq-kahadb-store/src/main/java/org/apache/activemq/store/kahadb/KahaDBStore.java
@@ -76,17 +76,14 @@ import org.apache.activemq.store.TransactionStore;
 import org.apache.activemq.store.kahadb.data.KahaAddMessageCommand;
 import org.apache.activemq.store.kahadb.data.KahaDestination;
 import org.apache.activemq.store.kahadb.data.KahaDestination.DestinationType;
-import org.apache.activemq.store.kahadb.data.KahaLocation;
 import org.apache.activemq.store.kahadb.data.KahaRemoveDestinationCommand;
 import org.apache.activemq.store.kahadb.data.KahaRemoveMessageCommand;
 import org.apache.activemq.store.kahadb.data.KahaSubscriptionCommand;
 import org.apache.activemq.store.kahadb.data.KahaUpdateMessageCommand;
 import org.apache.activemq.store.kahadb.disk.journal.Location;
 import org.apache.activemq.store.kahadb.disk.page.Transaction;
-import org.apache.activemq.store.kahadb.disk.page.Transaction.CallableClosure;
 import org.apache.activemq.store.kahadb.disk.util.SequenceSet;
 import org.apache.activemq.store.kahadb.scheduler.JobSchedulerStoreImpl;
-import org.apache.activemq.usage.MemoryUsage;
 import org.apache.activemq.usage.SystemUsage;
 import org.apache.activemq.util.IOExceptionSupport;
 import org.apache.activemq.util.ServiceStopper;
@@ -109,8 +106,8 @@ public class KahaDBStore extends MessageDatabase implements PersistenceAdapter, 
 
     protected ExecutorService queueExecutor;
     protected ExecutorService topicExecutor;
-    protected final List<Map<AsyncJobKey, StoreTask>> asyncQueueMaps = new LinkedList<>();
-    protected final List<Map<AsyncJobKey, StoreTask>> asyncTopicMaps = new LinkedList<>();
+    final List<Map<AsyncJobKey, StoreTask>> asyncQueueMaps = new LinkedList<>();
+    final List<Map<AsyncJobKey, StoreTask>> asyncTopicMaps = new LinkedList<>();
     final WireFormat wireFormat = new OpenWireFormat();
     private SystemUsage usageManager;
     private LinkedBlockingQueue<Runnable> asyncQueueJobQueue;
@@ -233,26 +230,22 @@ public class KahaDBStore extends MessageDatabase implements PersistenceAdapter, 
 
         this.globalQueueSemaphore = new Semaphore(getMaxAsyncJobs());
         this.globalTopicSemaphore = new Semaphore(getMaxAsyncJobs());
-        this.asyncQueueJobQueue = new LinkedBlockingQueue<Runnable>(getMaxAsyncJobs());
-        this.asyncTopicJobQueue = new LinkedBlockingQueue<Runnable>(getMaxAsyncJobs());
-        this.queueExecutor = new StoreTaskExecutor(1, asyncExecutorMaxThreads, 0L, TimeUnit.MILLISECONDS,
-            asyncQueueJobQueue, new ThreadFactory() {
-                @Override
-                public Thread newThread(Runnable runnable) {
-                    Thread thread = new Thread(runnable, "ConcurrentQueueStoreAndDispatch");
-                    thread.setDaemon(true);
-                    return thread;
-                }
-            });
-        this.topicExecutor = new StoreTaskExecutor(1, asyncExecutorMaxThreads, 0L, TimeUnit.MILLISECONDS,
-            asyncTopicJobQueue, new ThreadFactory() {
-                @Override
-                public Thread newThread(Runnable runnable) {
-                    Thread thread = new Thread(runnable, "ConcurrentTopicStoreAndDispatch");
-                    thread.setDaemon(true);
-                    return thread;
-                }
-            });
+        this.asyncQueueJobQueue = new LinkedBlockingQueue<>(getMaxAsyncJobs());
+        this.asyncTopicJobQueue = new LinkedBlockingQueue<>(getMaxAsyncJobs());
+        this.queueExecutor = new StoreTaskExecutor(1, asyncExecutorMaxThreads, 0L,
+                TimeUnit.MILLISECONDS,
+                asyncQueueJobQueue, runnable -> {
+            Thread thread = new Thread(runnable, "ConcurrentQueueStoreAndDispatch");
+            thread.setDaemon(true);
+            return thread;
+        });
+        this.topicExecutor = new StoreTaskExecutor(1, asyncExecutorMaxThreads, 0L,
+                TimeUnit.MILLISECONDS,
+                asyncTopicJobQueue, runnable -> {
+            Thread thread = new Thread(runnable, "ConcurrentTopicStoreAndDispatch");
+            thread.setDaemon(true);
+            return thread;
+        });
     }
 
     @Override
@@ -305,21 +298,18 @@ public class KahaDBStore extends MessageDatabase implements PersistenceAdapter, 
     }
 
     private Location findMessageLocation(final String key, final KahaDestination destination) throws IOException {
-        return pageFile.tx().execute(new Transaction.CallableClosure<Location, IOException>() {
-            @Override
-            public Location execute(Transaction tx) throws IOException {
-                StoredDestination sd = getStoredDestination(destination, tx);
-                Long sequence = sd.messageIdIndex.get(tx, key);
-                if (sequence == null) {
-                    return null;
-                }
-                return sd.orderIndex.get(tx, sequence).location;
+        return pageFile.tx().execute(tx -> {
+            StoredDestination sd = getStoredDestination(destination, tx);
+            Long sequence = sd.messageIdIndex.get(tx, key);
+            if (sequence == null) {
+                return null;
             }
+            return sd.orderIndex.get(tx, sequence).location;
         });
     }
 
-    protected StoreQueueTask removeQueueTask(KahaDBMessageStore store, MessageId id) {
-        StoreQueueTask task = null;
+    StoreQueueTask removeQueueTask(KahaDBMessageStore store, MessageId id) {
+        StoreQueueTask task;
         synchronized (store.asyncTaskMap) {
             task = (StoreQueueTask) store.asyncTaskMap.remove(new AsyncJobKey(id, store.getDestination()));
         }
@@ -327,20 +317,20 @@ public class KahaDBStore extends MessageDatabase implements PersistenceAdapter, 
     }
 
     // with asyncTaskMap locked
-    protected void addQueueTask(KahaDBMessageStore store, StoreQueueTask task) throws IOException {
+    void addQueueTask(KahaDBMessageStore store, StoreQueueTask task) throws IOException {
         store.asyncTaskMap.put(new AsyncJobKey(task.getMessage().getMessageId(), store.getDestination()), task);
         this.queueExecutor.execute(task);
     }
 
-    protected StoreTopicTask removeTopicTask(KahaDBTopicMessageStore store, MessageId id) {
-        StoreTopicTask task = null;
+    StoreTopicTask removeTopicTask(KahaDBTopicMessageStore store, MessageId id) {
+        StoreTopicTask task;
         synchronized (store.asyncTaskMap) {
             task = (StoreTopicTask) store.asyncTaskMap.remove(new AsyncJobKey(id, store.getDestination()));
         }
         return task;
     }
 
-    protected void addTopicTask(KahaDBTopicMessageStore store, StoreTopicTask task) throws IOException {
+    void addTopicTask(KahaDBTopicMessageStore store, StoreTopicTask task) throws IOException {
         synchronized (store.asyncTaskMap) {
             store.asyncTaskMap.put(new AsyncJobKey(task.getMessage().getMessageId(), store.getDestination()), task);
         }
@@ -409,12 +399,12 @@ public class KahaDBStore extends MessageDatabase implements PersistenceAdapter, 
     }
 
     public class KahaDBMessageStore extends AbstractMessageStore {
-        protected final Map<AsyncJobKey, StoreTask> asyncTaskMap = new HashMap<AsyncJobKey, StoreTask>();
+        final Map<AsyncJobKey, StoreTask> asyncTaskMap = new HashMap<>();
         protected KahaDestination dest;
         private final int maxAsyncJobs;
         private final Semaphore localDestinationSemaphore;
-        protected final HashMap<String, Set<String>> ackedAndPreparedMap = new HashMap<String, Set<String>>();
-        protected final HashMap<String, Set<String>> rolledBackAcksMap = new HashMap<String, Set<String>>();
+        protected final HashMap<String, Set<String>> ackedAndPreparedMap = new HashMap<>();
+        protected final HashMap<String, Set<String>> rolledBackAcksMap = new HashMap<>();
 
         double doneTasks, canceledTasks = 0;
 
@@ -425,13 +415,7 @@ public class KahaDBStore extends MessageDatabase implements PersistenceAdapter, 
             this.localDestinationSemaphore = new Semaphore(this.maxAsyncJobs);
         }
 
-        @Override
-        public ActiveMQDestination getDestination() {
-            return destination;
-        }
-
-
-        private final String recoveredTxStateMapKey(ActiveMQDestination destination, MessageAck ack) {
+        private String recoveredTxStateMapKey(ActiveMQDestination destination, MessageAck ack) {
             return destination.isQueue() ? destination.getPhysicalName() : ack.getConsumerId().getConnectionId();
         }
 
@@ -439,25 +423,22 @@ public class KahaDBStore extends MessageDatabase implements PersistenceAdapter, 
         // till then they are skipped by the store.
         // 'at most once' XA guarantee
         public void trackRecoveredAcks(ArrayList<MessageAck> acks) {
-            indexLock.writeLock().lock();
+            indexLock.lock();
             try {
                 for (MessageAck ack : acks) {
                     final String key = recoveredTxStateMapKey(destination, ack);
-                    Set<String> ackedAndPrepared = ackedAndPreparedMap.get(key);
-                    if (ackedAndPrepared == null) {
-                        ackedAndPrepared = new LinkedHashSet<String>();
-                        ackedAndPreparedMap.put(key, ackedAndPrepared);
-                    }
+                    Set<String> ackedAndPrepared = ackedAndPreparedMap.computeIfAbsent(key,
+                            k -> new LinkedHashSet<>());
                     ackedAndPrepared.add(ack.getLastMessageId().toProducerKey());
                 }
             } finally {
-                indexLock.writeLock().unlock();
+                indexLock.unlock();
             }
         }
 
         public void forgetRecoveredAcks(ArrayList<MessageAck> acks, boolean rollback) throws IOException {
             if (acks != null) {
-                indexLock.writeLock().lock();
+                indexLock.lock();
                 try {
                     for (MessageAck ack : acks) {
                         final String id = ack.getLastMessageId().toProducerKey();
@@ -470,11 +451,8 @@ public class KahaDBStore extends MessageDatabase implements PersistenceAdapter, 
                             }
                         }
                         if (rollback) {
-                            Set<String> rolledBackAcks = rolledBackAcksMap.get(key);
-                            if (rolledBackAcks == null) {
-                                rolledBackAcks = new LinkedHashSet<String>();
-                                rolledBackAcksMap.put(key, rolledBackAcks);
-                            }
+                            Set<String> rolledBackAcks = rolledBackAcksMap.computeIfAbsent(key,
+                                    k -> new LinkedHashSet<>());
                             rolledBackAcks.add(id);
                             pageFile.tx().execute(tx -> {
                                 incrementAndAddSizeToStoreStat(tx, dest, 0);
@@ -482,7 +460,7 @@ public class KahaDBStore extends MessageDatabase implements PersistenceAdapter, 
                         }
                     }
                 } finally {
-                    indexLock.writeLock().unlock();
+                    indexLock.unlock();
                 }
             }
         }
@@ -513,7 +491,7 @@ public class KahaDBStore extends MessageDatabase implements PersistenceAdapter, 
         public void removeAsyncMessage(ConnectionContext context, MessageAck ack) throws IOException {
             if (isConcurrentStoreAndDispatchQueues()) {
                 AsyncJobKey key = new AsyncJobKey(ack.getLastMessageId(), getDestination());
-                StoreQueueTask task = null;
+                StoreQueueTask task;
                 synchronized (asyncTaskMap) {
                     task = (StoreQueueTask) asyncTaskMap.get(key);
                 }
@@ -528,11 +506,11 @@ public class KahaDBStore extends MessageDatabase implements PersistenceAdapter, 
                         }
                         removeMessage(context, ack);
                     } else {
-                        indexLock.writeLock().lock();
+                        indexLock.lock();
                         try {
                             metadata.producerSequenceIdTracker.isDuplicate(ack.getLastMessageId());
                         } finally {
-                            indexLock.writeLock().unlock();
+                            indexLock.unlock();
                         }
                         synchronized (asyncTaskMap) {
                             asyncTaskMap.remove(key);
@@ -558,7 +536,7 @@ public class KahaDBStore extends MessageDatabase implements PersistenceAdapter, 
             command.setMessage(new Buffer(packet.getData(), packet.getOffset(), packet.getLength()));
             store(command, isEnableJournalDiskSyncs() && message.isResponseRequired(), new IndexAware() {
                 // sync add? (for async, future present from getFutureOrSequenceLong)
-                Object possibleFuture = message.getMessageId().getFutureOrSequenceLong();
+                final Object possibleFuture = message.getMessageId().getFutureOrSequenceLong();
 
                 @Override
                 public void sequenceAssignedWithIndexLocked(final long sequence) {
@@ -566,12 +544,8 @@ public class KahaDBStore extends MessageDatabase implements PersistenceAdapter, 
                     if (indexListener != null) {
                         if (possibleFuture == null) {
                             trackPendingAdd(dest, sequence);
-                            indexListener.onAdd(new IndexListener.MessageContext(context, message, new Runnable() {
-                                @Override
-                                public void run() {
-                                    trackPendingAddComplete(dest, sequence);
-                                }
-                            }));
+                            indexListener.onAdd(new IndexListener.MessageContext(context, message,
+                                    () -> trackPendingAddComplete(dest, sequence)));
                         }
                     }
                 }
@@ -604,7 +578,8 @@ public class KahaDBStore extends MessageDatabase implements PersistenceAdapter, 
         @Override
         public void updateMessage(Message message) throws IOException {
             if (LOG.isTraceEnabled()) {
-                LOG.trace("updating: " + message.getMessageId() + " with deliveryCount: " + message.getRedeliveryCounter());
+                LOG.trace("updating: {} with deliveryCount: {}", message.getMessageId(),
+                        message.getRedeliveryCounter());
             }
             KahaUpdateMessageCommand updateMessageCommand = new KahaUpdateMessageCommand();
             KahaAddMessageCommand command = new KahaAddMessageCommand();
@@ -645,11 +620,11 @@ public class KahaDBStore extends MessageDatabase implements PersistenceAdapter, 
             // operations... but for now we must
             // externally synchronize...
             Location location;
-            indexLock.writeLock().lock();
+            indexLock.lock();
             try {
                 location = findMessageLocation(key, dest);
             } finally {
-                indexLock.writeLock().unlock();
+                indexLock.unlock();
             }
             if (location == null) {
                 return null;
@@ -660,80 +635,71 @@ public class KahaDBStore extends MessageDatabase implements PersistenceAdapter, 
 
         @Override
         public boolean isEmpty() throws IOException {
-            indexLock.writeLock().lock();
+            indexLock.lock();
             try {
-                return pageFile.tx().execute(new Transaction.CallableClosure<Boolean, IOException>() {
-                    @Override
-                    public Boolean execute(Transaction tx) throws IOException {
-                        // Iterate through all index entries to get a count of
-                        // messages in the destination.
-                        StoredDestination sd = getStoredDestination(dest, tx);
-                        return sd.locationIndex.isEmpty(tx);
-                    }
+                return pageFile.tx().execute(tx -> {
+                    // Iterate through all index entries to get a count of
+                    // messages in the destination.
+                    StoredDestination sd = getStoredDestination(dest, tx);
+                    return sd.locationIndex.isEmpty(tx);
                 });
             } finally {
-                indexLock.writeLock().unlock();
+                indexLock.unlock();
             }
         }
 
         @Override
         public void recover(final MessageRecoveryListener listener) throws Exception {
             // recovery may involve expiry which will modify
-            indexLock.writeLock().lock();
+            indexLock.lock();
             try {
-                pageFile.tx().execute(new Transaction.Closure<Exception>() {
-                    @Override
-                    public void execute(Transaction tx) throws Exception {
-                        StoredDestination sd = getStoredDestination(dest, tx);
-                        recoverRolledBackAcks(destination.getPhysicalName(), sd, tx, Integer.MAX_VALUE, listener);
-                        sd.orderIndex.resetCursorPosition();
-                        for (Iterator<Entry<Long, MessageKeys>> iterator = 
-                                sd.orderIndex.iterator(tx, new MessageOrderCursor()); listener.hasSpace() && 
-                                iterator.hasNext(); ) {
-                            Entry<Long, MessageKeys> entry = iterator.next();
-                            Set<String> ackedAndPrepared = ackedAndPreparedMap.get(destination.getPhysicalName());
-                            if (ackedAndPrepared != null && ackedAndPrepared.contains(entry.getValue().messageId)) {
-                                continue;
-                            }
-                            Message msg = loadMessage(entry.getValue().location);
-                            listener.recoverMessage(msg);
+                pageFile.tx().execute(tx -> {
+                    StoredDestination sd = getStoredDestination(dest, tx);
+                    recoverRolledBackAcks(destination.getPhysicalName(), sd, tx, Integer.MAX_VALUE, listener);
+                    sd.orderIndex.resetCursorPosition();
+                    for (Iterator<Entry<Long, MessageKeys>> iterator =
+                            sd.orderIndex.iterator(tx, new MessageOrderCursor()); listener.hasSpace() &&
+                            iterator.hasNext(); ) {
+                        Entry<Long, MessageKeys> entry = iterator.next();
+                        Set<String> ackedAndPrepared = ackedAndPreparedMap.get(destination.getPhysicalName());
+                        if (ackedAndPrepared != null && ackedAndPrepared.contains(entry.getValue().messageId)) {
+                            continue;
                         }
+                        Message msg = loadMessage(entry.getValue().location);
+                        listener.recoverMessage(msg);
                     }
                 });
             } finally {
-                indexLock.writeLock().unlock();
+                indexLock.unlock();
             }
         }
 
         @Override
         public void recoverNextMessages(final int maxReturned, final MessageRecoveryListener listener) throws Exception {
-            indexLock.writeLock().lock();
+            indexLock.lock();
             try {
-                pageFile.tx().execute(new Transaction.Closure<Exception>() {
-                    @Override
-                    public void execute(Transaction tx) throws Exception {
-                        StoredDestination sd = getStoredDestination(dest, tx);
-                        Entry<Long, MessageKeys> entry = null;
-                        int counter = recoverRolledBackAcks(destination.getPhysicalName(), sd, tx, maxReturned, listener);
-                        Set<String> ackedAndPrepared = ackedAndPreparedMap.get(destination.getPhysicalName());
-                        for (Iterator<Entry<Long, MessageKeys>> iterator = sd.orderIndex.iterator(tx); iterator.hasNext(); ) {
-                            entry = iterator.next();
-                            if (ackedAndPrepared != null && ackedAndPrepared.contains(entry.getValue().messageId)) {
-                                continue;
-                            }
-                            Message msg = loadMessage(entry.getValue().location);
-                            msg.getMessageId().setFutureOrSequenceLong(entry.getKey());
-                            listener.recoverMessage(msg);
-                            counter++;
-                            if (counter >= maxReturned || !listener.canRecoveryNextMessage()) {
-                                break;
-                            }
+                pageFile.tx().execute(tx -> {
+                    StoredDestination sd = getStoredDestination(dest, tx);
+                    Entry<Long, MessageKeys> entry;
+                    int counter = recoverRolledBackAcks(destination.getPhysicalName(), sd, tx, maxReturned, listener);
+                    Set<String> ackedAndPrepared = ackedAndPreparedMap.get(destination.getPhysicalName());
+                    for (Iterator<Entry<Long, MessageKeys>> iterator = sd.orderIndex.iterator(tx); iterator.hasNext(); ) {
+                        entry = iterator.next();
+                        if (ackedAndPrepared != null && ackedAndPrepared.contains(entry.getValue().messageId)) {
+                            continue;
                         }
-                        sd.orderIndex.stoppedIterating();
+                        Message msg = loadMessage(entry.getValue().location);
+                        msg.getMessageId().setFutureOrSequenceLong(entry.getKey());
+                        listener.recoverMessage(msg);
+                        counter++;
+                        if (counter >= maxReturned || !listener.canRecoveryNextMessage()) {
+                            break;
+                        }
                     }
+                    sd.orderIndex.stoppedIterating();
                 });
             } finally {
-                indexLock.writeLock().unlock();
+                indexLock.unlock();
             }
         }
 
@@ -747,86 +713,84 @@ public class KahaDBStore extends MessageDatabase implements PersistenceAdapter, 
                 throw new IllegalArgumentException("Invalid messageRecoveryContext specified");
             }
 
-            indexLock.writeLock().lock();
+            indexLock.lock();
             try {
-                pageFile.tx().execute(new Transaction.Closure<Exception>() {
-                    @Override
-                    public void execute(Transaction tx) throws Exception {
-                        StoredDestination sd = getStoredDestination(dest, tx);
+                pageFile.tx().execute(tx -> {
+                    StoredDestination sd = getStoredDestination(dest, tx);
 
-                        /**
-                         * [AMQ-9773]
-                         *
-                         * The order index sequence key value increases for every message since the beginning of the
-                         * creation of the index, so the first message available won't be at sequence key value:0 in
-                         * the index when there were older messages acknowledged.
-                         *
-                         * The MessageOrderCursor _position_ value is relative to the index, so there is a disconnect
-                         * between queue _position_ and index sequence value over time.
-                         *
-                         * The MessageRecoveryContext determines the recovery start position based off the provided
-                         * offset, or the position of the requested startMessageId. If a startMessageId is specified,
-                         * but not found in the index, then the value of 0 is used as a fallback.
-                         *
-                         * The MessageRecoveryContext determines the recovery end position based off of the provided
-                         * endMessageId (if provided), or the maximum recovered message count, or if the
-                         * MessageRecoveryListener signals that no more messages should be recovered
-                         * (ie memory is full).
-                         */
-                        Long startSequenceOffset = null;
-                        Long endSequenceOffset = null;
+                    /**
+                     * [AMQ-9773]
+                     *
+                     * The order index sequence key value increases for every message since the beginning of the
+                     * creation of the index, so the first message available won't be at sequence key value:0 in
+                     * the index when there were older messages acknowledged.
+                     *
+                     * The MessageOrderCursor _position_ value is relative to the index, so there is a disconnect
+                     * between queue _position_ and index sequence value over time.
+                     *
+                     * The MessageRecoveryContext determines the recovery start position based off the provided
+                     * offset, or the position of the requested startMessageId. If a startMessageId is specified,
+                     * but not found in the index, then the value of 0 is used as a fallback.
+                     *
+                     * The MessageRecoveryContext determines the recovery end position based off of the provided
+                     * endMessageId (if provided), or the maximum recovered message count, or if the
+                     * MessageRecoveryListener signals that no more messages should be recovered
+                     * (ie memory is full).
+                     */
+                    Long startSequenceOffset;
+                    Long endSequenceOffset = null;
 
-                        if(messageRecoveryContext.getStartMessageId() != null && !messageRecoveryContext.getStartMessageId().isBlank()) {
-                            startSequenceOffset = Optional.ofNullable(sd.messageIdIndex.get(tx, messageRecoveryContext.getStartMessageId())).orElse(0L);
-                        } else {
-                            startSequenceOffset = Optional.ofNullable(messageRecoveryContext.getOffset()).orElse(0L);
+                    if(messageRecoveryContext.getStartMessageId() != null && !messageRecoveryContext.getStartMessageId().isBlank()) {
+                        startSequenceOffset = Optional.ofNullable(sd.messageIdIndex.get(tx, messageRecoveryContext.getStartMessageId())).orElse(0L);
+                    } else {
+                        startSequenceOffset = Optional.ofNullable(messageRecoveryContext.getOffset()).orElse(0L);
+                    }
+
+                    if(messageRecoveryContext.getEndMessageId() != null && !messageRecoveryContext.getEndMessageId().isBlank()) {
+                        endSequenceOffset = Optional.ofNullable(sd.messageIdIndex.get(tx, messageRecoveryContext.getEndMessageId()))
+                                                    .orElse(startSequenceOffset + (long) messageRecoveryContext.getMaxMessageCountReturned());
+                        messageRecoveryContext.setEndSequenceId(endSequenceOffset);
+                    }
+
+                    if(endSequenceOffset != null &&
+                        endSequenceOffset < startSequenceOffset) {
+                        LOG.warn("Invalid offset parameters start:{} end:{}", startSequenceOffset, endSequenceOffset);
+                        throw new IllegalStateException("Invalid offset parameters start:" + startSequenceOffset + " end:" + endSequenceOffset);
+                    }
+
+                    Entry<Long, MessageKeys> entry;
+                    recoverRolledBackAcks(destination.getPhysicalName(), sd, tx, messageRecoveryContext.getMaxMessageCountReturned(), messageRecoveryContext);
+                    Set<String> ackedAndPrepared = ackedAndPreparedMap.get(destination.getPhysicalName());
+                    Iterator<Entry<Long, MessageKeys>> iterator = (messageRecoveryContext.isUseDedicatedCursor() ? sd.orderIndex.iterator(tx,
+                            new MessageOrderCursor(startSequenceOffset)) : sd.orderIndex.iterator(tx));
+
+                    while (iterator.hasNext()) {
+                        entry = iterator.next();
+
+                        if (ackedAndPrepared != null && ackedAndPrepared.contains(entry.getValue().messageId)) {
+                            continue;
                         }
 
-                        if(messageRecoveryContext.getEndMessageId() != null && !messageRecoveryContext.getEndMessageId().isBlank()) {
-                            endSequenceOffset = Optional.ofNullable(sd.messageIdIndex.get(tx, messageRecoveryContext.getEndMessageId()))
-                                                        .orElse(startSequenceOffset + Long.valueOf(messageRecoveryContext.getMaxMessageCountReturned()));
-                            messageRecoveryContext.setEndSequenceId(endSequenceOffset);
+                        Message msg = loadMessage(entry.getValue().location);
+                        msg.getMessageId().setFutureOrSequenceLong(entry.getKey());
+
+                        messageRecoveryContext.recoverMessage(msg);
+                        if (!messageRecoveryContext.canRecoveryNextMessage(entry.getKey())) {
+                            break;
                         }
+                    }
 
-                        if(endSequenceOffset != null &&
-                            endSequenceOffset < startSequenceOffset) {
-                            LOG.warn("Invalid offset parameters start:{} end:{}", startSequenceOffset, endSequenceOffset);
-                            throw new IllegalStateException("Invalid offset parameters start:" + startSequenceOffset + " end:" + endSequenceOffset);
-                        }
-
-                        Entry<Long, MessageKeys> entry = null;
-                        recoverRolledBackAcks(destination.getPhysicalName(), sd, tx, messageRecoveryContext.getMaxMessageCountReturned(), messageRecoveryContext);
-                        Set<String> ackedAndPrepared = ackedAndPreparedMap.get(destination.getPhysicalName());
-                        Iterator<Entry<Long, MessageKeys>> iterator = (messageRecoveryContext.isUseDedicatedCursor() ? sd.orderIndex.iterator(tx, new MessageOrderCursor(startSequenceOffset)) : sd.orderIndex.iterator(tx));
-
-                        while (iterator.hasNext()) {
-                            entry = iterator.next();
-
-                            if (ackedAndPrepared != null && ackedAndPrepared.contains(entry.getValue().messageId)) {
-                                continue;
-                            }
-
-                            Message msg = loadMessage(entry.getValue().location);
-                            msg.getMessageId().setFutureOrSequenceLong(entry.getKey());
-
-                            messageRecoveryContext.recoverMessage(msg);
-                            if (!messageRecoveryContext.canRecoveryNextMessage(entry.getKey())) {
-                                break;
-                            }
-                        }
-
-                        // [AMQ-9773] The sd.orderIndex uses the destination's cursor
-                        if(!messageRecoveryContext.isUseDedicatedCursor()) {
-                            sd.orderIndex.stoppedIterating();
-                        }
+                    // [AMQ-9773] The sd.orderIndex uses the destination's cursor
+                    if(!messageRecoveryContext.isUseDedicatedCursor()) {
+                        sd.orderIndex.stoppedIterating();
                     }
                 });
             } finally {
-                indexLock.writeLock().unlock();
+                indexLock.unlock();
             }
         }
 
-        protected int recoverRolledBackAcks(String recoveredTxStateMapKey, StoredDestination sd, Transaction tx, int maxReturned, MessageRecoveryListener listener) throws Exception {
+        int recoverRolledBackAcks(String recoveredTxStateMapKey, StoredDestination sd, Transaction tx, int maxReturned, MessageRecoveryListener listener) throws Exception {
             int counter = 0;
             String id;
 
@@ -862,55 +826,37 @@ public class KahaDBStore extends MessageDatabase implements PersistenceAdapter, 
         @Override
         public void resetBatching() {
             if (pageFile.isLoaded()) {
-                indexLock.writeLock().lock();
+                indexLock.lock();
                 try {
-                    pageFile.tx().execute(new Transaction.Closure<Exception>() {
-                        @Override
-                        public void execute(Transaction tx) throws Exception {
-                            StoredDestination sd = getExistingStoredDestination(dest, tx);
-                            if (sd != null) {
-                                sd.orderIndex.resetCursorPosition();}
-                            }
+                    pageFile.tx().execute(tx -> {
+                        StoredDestination sd = getExistingStoredDestination(dest, tx);
+                        if (sd != null) {
+                            sd.orderIndex.resetCursorPosition();}
                         });
                 } catch (Exception e) {
                     LOG.error("Failed to reset batching",e);
                 } finally {
-                    indexLock.writeLock().unlock();
+                    indexLock.unlock();
                 }
             }
         }
 
         @Override
         public void setBatch(final MessageId identity) throws IOException {
-            indexLock.writeLock().lock();
+            indexLock.lock();
             try {
-                pageFile.tx().execute(new Transaction.Closure<IOException>() {
-                    @Override
-                    public void execute(Transaction tx) throws IOException {
-                        StoredDestination sd = getStoredDestination(dest, tx);
-                        Long location = (Long) identity.getFutureOrSequenceLong();
-                        Long pending = sd.orderIndex.minPendingAdd();
-                        if (pending != null) {
-                            location = Math.min(location, pending-1);
-                        }
-                        sd.orderIndex.setBatch(tx, location);
+                pageFile.tx().execute(tx -> {
+                    StoredDestination sd = getStoredDestination(dest, tx);
+                    Long location = (Long) identity.getFutureOrSequenceLong();
+                    Long pending = sd.orderIndex.minPendingAdd();
+                    if (pending != null) {
+                        location = Math.min(location, pending-1);
                     }
+                    sd.orderIndex.setBatch(location);
                 });
             } finally {
-                indexLock.writeLock().unlock();
+                indexLock.unlock();
             }
-        }
-
-        @Override
-        public void setMemoryUsage(MemoryUsage memoryUsage) {
-        }
-        @Override
-        public void start() throws Exception {
-            super.start();
-        }
-        @Override
-        public void stop() throws Exception {
-            super.stop();
         }
 
         protected void lockAsyncJobQueue() {
@@ -919,7 +865,7 @@ public class KahaDBStore extends MessageDatabase implements PersistenceAdapter, 
                     throw new TimeoutException(this +" timeout waiting for localDestSem:" + this.localDestinationSemaphore);
                 }
             } catch (Exception e) {
-                LOG.error("Failed to lock async jobs for " + this.destination, e);
+                LOG.error("Failed to lock async jobs for {}", this.destination, e);
             }
         }
 
@@ -931,7 +877,7 @@ public class KahaDBStore extends MessageDatabase implements PersistenceAdapter, 
             try {
                 this.localDestinationSemaphore.acquire();
             } catch (InterruptedException e) {
-                LOG.error("Failed to aquire async lock for " + this.destination, e);
+                LOG.error("Failed to aquire async lock for {}", this.destination, e);
             }
         }
 
@@ -949,25 +895,22 @@ public class KahaDBStore extends MessageDatabase implements PersistenceAdapter, 
             try {
                 MessageStoreStatistics recoveredStatistics;
                 lockAsyncJobQueue();
-                indexLock.writeLock().lock();
+                indexLock.lock();
                 try {
-                    recoveredStatistics = pageFile.tx().execute(new Transaction.CallableClosure<MessageStoreStatistics, IOException>() {
-                        @Override
-                        public MessageStoreStatistics execute(Transaction tx) throws IOException {
-                            MessageStoreStatistics statistics = getStoredMessageStoreStatistics(dest, tx);
+                    recoveredStatistics = pageFile.tx().execute(tx -> {
+                        MessageStoreStatistics statistics = getStoredMessageStoreStatistics(dest, tx);
 
-                            // Iterate through all index entries to get the size of each message
-                            if (statistics == null) {
-                                StoredDestination sd = getStoredDestination(dest, tx);
-                                statistics = new MessageStoreStatistics();
-                                for (Iterator<Entry<Location, Long>> iterator = sd.locationIndex.iterator(tx); iterator.hasNext(); ) {
-                                    int locationSize = iterator.next().getKey().getSize();
-                                    statistics.getMessageCount().increment();
-                                    statistics.getMessageSize().addSize(locationSize > 0 ? locationSize : 0);
-                                }
+                        // Iterate through all index entries to get the size of each message
+                        if (statistics == null) {
+                            StoredDestination sd = getStoredDestination(dest, tx);
+                            statistics = new MessageStoreStatistics();
+                            for (Iterator<Entry<Location, Long>> iterator = sd.locationIndex.iterator(tx); iterator.hasNext(); ) {
+                                int locationSize = iterator.next().getKey().getSize();
+                                statistics.getMessageCount().increment();
+                                statistics.getMessageSize().addSize(locationSize > 0 ? locationSize : 0);
                             }
-                            return statistics;
                         }
+                        return statistics;
                     });
                     Set<String> ackedAndPrepared = ackedAndPreparedMap.get(destination.getPhysicalName());
                     if (ackedAndPrepared != null) {
@@ -976,7 +919,7 @@ public class KahaDBStore extends MessageDatabase implements PersistenceAdapter, 
                     getMessageStoreStatistics().getMessageCount().setCount(recoveredStatistics.getMessageCount().getCount());
                     getMessageStoreStatistics().getMessageSize().setTotalSize(recoveredStatistics.getMessageSize().getTotalSize());
                 } finally {
-                    indexLock.writeLock().unlock();
+                    indexLock.unlock();
                 }
             } finally {
                 unlockAsyncJobQueue();
@@ -1025,10 +968,10 @@ public class KahaDBStore extends MessageDatabase implements PersistenceAdapter, 
         @Override
         public void acknowledge(ConnectionContext context, String clientId, String subscriptionName,
                                 MessageId messageId, MessageAck ack) throws IOException {
-            String subscriptionKey = subscriptionKey(clientId, subscriptionName).toString();
+            String subscriptionKey = subscriptionKey(clientId, subscriptionName);
             if (isConcurrentStoreAndDispatchTopics()) {
                 AsyncJobKey key = new AsyncJobKey(messageId, getDestination());
-                StoreTopicTask task = null;
+                StoreTopicTask task;
                 synchronized (asyncTaskMap) {
                     task = (StoreTopicTask) asyncTaskMap.get(key);
                 }
@@ -1042,14 +985,14 @@ public class KahaDBStore extends MessageDatabase implements PersistenceAdapter, 
                         }
                     }
                 } else {
-                    doAcknowledge(context, subscriptionKey, messageId, ack);
+                    doAcknowledge(subscriptionKey, messageId, ack);
                 }
             } else {
-                doAcknowledge(context, subscriptionKey, messageId, ack);
+                doAcknowledge(subscriptionKey, messageId, ack);
             }
         }
 
-        protected void doAcknowledge(ConnectionContext context, String subscriptionKey, MessageId messageId, MessageAck ack)
+        protected void doAcknowledge(String subscriptionKey, MessageId messageId, MessageAck ack)
                 throws IOException {
             KahaRemoveMessageCommand command = new KahaRemoveMessageCommand();
             command.setDestination(dest);
@@ -1071,11 +1014,11 @@ public class KahaDBStore extends MessageDatabase implements PersistenceAdapter, 
                     .getSubscriptionName());
             KahaSubscriptionCommand command = new KahaSubscriptionCommand();
             command.setDestination(dest);
-            command.setSubscriptionKey(subscriptionKey.toString());
+            command.setSubscriptionKey(subscriptionKey);
             command.setRetroactive(retroactive);
             org.apache.activemq.util.ByteSequence packet = wireFormat.marshal(subscriptionInfo);
             command.setSubscriptionInfo(new Buffer(packet.getData(), packet.getOffset(), packet.getLength()));
-            store(command, isEnableJournalDiskSyncs() && true, null, null);
+            store(command, isEnableJournalDiskSyncs(), null, null);
             this.subscriptionCount.incrementAndGet();
         }
 
@@ -1083,33 +1026,30 @@ public class KahaDBStore extends MessageDatabase implements PersistenceAdapter, 
         public void deleteSubscription(String clientId, String subscriptionName) throws IOException {
             KahaSubscriptionCommand command = new KahaSubscriptionCommand();
             command.setDestination(dest);
-            command.setSubscriptionKey(subscriptionKey(clientId, subscriptionName).toString());
-            store(command, isEnableJournalDiskSyncs() && true, null, null);
+            command.setSubscriptionKey(subscriptionKey(clientId, subscriptionName));
+            store(command, isEnableJournalDiskSyncs(), null, null);
             this.subscriptionCount.decrementAndGet();
         }
 
         @Override
         public SubscriptionInfo[] getAllSubscriptions() throws IOException {
 
-            final ArrayList<SubscriptionInfo> subscriptions = new ArrayList<SubscriptionInfo>();
-            indexLock.writeLock().lock();
+            final ArrayList<SubscriptionInfo> subscriptions = new ArrayList<>();
+            indexLock.lock();
             try {
-                pageFile.tx().execute(new Transaction.Closure<IOException>() {
-                    @Override
-                    public void execute(Transaction tx) throws IOException {
-                        StoredDestination sd = getStoredDestination(dest, tx);
-                        for (Iterator<Entry<String, KahaSubscriptionCommand>> iterator = sd.subscriptions.iterator(tx); iterator
-                                .hasNext();) {
-                            Entry<String, KahaSubscriptionCommand> entry = iterator.next();
-                            SubscriptionInfo info = (SubscriptionInfo) wireFormat.unmarshal(new DataInputStream(entry
-                                    .getValue().getSubscriptionInfo().newInput()));
-                            subscriptions.add(info);
+                pageFile.tx().execute((Transaction.Closure<IOException>) tx -> {
+                    StoredDestination sd = getStoredDestination(dest, tx);
+                    for (Iterator<Entry<String, KahaSubscriptionCommand>> iterator = sd.subscriptions.iterator(tx); iterator
+                            .hasNext();) {
+                        Entry<String, KahaSubscriptionCommand> entry = iterator.next();
+                        SubscriptionInfo info = (SubscriptionInfo) wireFormat.unmarshal(new DataInputStream(entry
+                                .getValue().getSubscriptionInfo().newInput()));
+                        subscriptions.add(info);
 
-                        }
                     }
                 });
             } finally {
-                indexLock.writeLock().unlock();
+                indexLock.unlock();
             }
 
             SubscriptionInfo[] rc = new SubscriptionInfo[subscriptions.size()];
@@ -1120,22 +1060,19 @@ public class KahaDBStore extends MessageDatabase implements PersistenceAdapter, 
         @Override
         public SubscriptionInfo lookupSubscription(String clientId, String subscriptionName) throws IOException {
             final String subscriptionKey = subscriptionKey(clientId, subscriptionName);
-            indexLock.writeLock().lock();
+            indexLock.lock();
             try {
-                return pageFile.tx().execute(new Transaction.CallableClosure<SubscriptionInfo, IOException>() {
-                    @Override
-                    public SubscriptionInfo execute(Transaction tx) throws IOException {
-                        StoredDestination sd = getStoredDestination(dest, tx);
-                        KahaSubscriptionCommand command = sd.subscriptions.get(tx, subscriptionKey);
-                        if (command == null) {
-                            return null;
-                        }
-                        return (SubscriptionInfo) wireFormat.unmarshal(new DataInputStream(command
-                                .getSubscriptionInfo().newInput()));
+                return pageFile.tx().execute(tx -> {
+                    StoredDestination sd = getStoredDestination(dest, tx);
+                    KahaSubscriptionCommand command = sd.subscriptions.get(tx, subscriptionKey);
+                    if (command == null) {
+                        return null;
                     }
+                    return (SubscriptionInfo) wireFormat.unmarshal(new DataInputStream(command
+                            .getSubscriptionInfo().newInput()));
                 });
             } finally {
-                indexLock.writeLock().unlock();
+                indexLock.unlock();
             }
         }
 
@@ -1147,23 +1084,20 @@ public class KahaDBStore extends MessageDatabase implements PersistenceAdapter, 
                 return (int)this.messageStoreSubStats.getMessageCount(subscriptionKey).getCount();
             } else {
 
-                indexLock.writeLock().lock();
+                indexLock.lock();
                 try {
-                    return pageFile.tx().execute(new Transaction.CallableClosure<Integer, IOException>() {
-                        @Override
-                        public Integer execute(Transaction tx) throws IOException {
-                            StoredDestination sd = getStoredDestination(dest, tx);
-                            LastAck cursorPos = getLastAck(tx, sd, subscriptionKey);
-                            if (cursorPos == null) {
-                                // The subscription might not exist.
-                                return 0;
-                            }
-
-                            return (int) getStoredMessageCount(tx, sd, subscriptionKey);
+                    return pageFile.tx().execute(tx -> {
+                        StoredDestination sd = getStoredDestination(dest, tx);
+                        LastAck cursorPos = getLastAck(tx, sd, subscriptionKey);
+                        if (cursorPos == null) {
+                            // The subscription might not exist.
+                            return 0;
                         }
+
+                        return (int) getStoredMessageCount(tx, sd, subscriptionKey);
                     });
                 } finally {
-                    indexLock.writeLock().unlock();
+                    indexLock.unlock();
                 }
             }
         }
@@ -1175,23 +1109,20 @@ public class KahaDBStore extends MessageDatabase implements PersistenceAdapter, 
             if (isEnableSubscriptionStatistics()) {
                 return this.messageStoreSubStats.getMessageSize(subscriptionKey).getTotalSize();
             } else {
-                indexLock.writeLock().lock();
+                indexLock.lock();
                 try {
-                    return pageFile.tx().execute(new Transaction.CallableClosure<Long, IOException>() {
-                        @Override
-                        public Long execute(Transaction tx) throws IOException {
-                            StoredDestination sd = getStoredDestination(dest, tx);
-                            LastAck cursorPos = getLastAck(tx, sd, subscriptionKey);
-                            if (cursorPos == null) {
-                                // The subscription might not exist.
-                                return 0l;
-                            }
-
-                            return getStoredMessageSize(tx, sd, subscriptionKey);
+                    return pageFile.tx().execute(tx -> {
+                        StoredDestination sd = getStoredDestination(dest, tx);
+                        LastAck cursorPos = getLastAck(tx, sd, subscriptionKey);
+                        if (cursorPos == null) {
+                            // The subscription might not exist.
+                            return 0L;
                         }
+
+                        return getStoredMessageSize(tx, sd, subscriptionKey);
                     });
                 } finally {
-                    indexLock.writeLock().unlock();
+                    indexLock.unlock();
                 }
             }
         }
@@ -1199,39 +1130,35 @@ public class KahaDBStore extends MessageDatabase implements PersistenceAdapter, 
         protected void recoverMessageStoreSubMetrics() throws IOException {
             if (isEnableSubscriptionStatistics()) {
                 final MessageStoreSubscriptionStatistics statistics = getMessageStoreSubStatistics();
-                indexLock.writeLock().lock();
+                indexLock.lock();
                 try {
-                    pageFile.tx().execute(new Transaction.Closure<IOException>() {
-                        @Override
-                        public void execute(Transaction tx) throws IOException {
-                            StoredDestination sd = getStoredDestination(dest, tx);
+                    pageFile.tx().execute(tx -> {
+                        StoredDestination sd = getStoredDestination(dest, tx);
 
-                            List<String> subscriptionKeys = new ArrayList<>();
-                            for (Iterator<Entry<String, KahaSubscriptionCommand>> iterator = sd.subscriptions
-                                    .iterator(tx); iterator.hasNext();) {
-                                Entry<String, KahaSubscriptionCommand> entry = iterator.next();
+                        List<String> subscriptionKeys = new ArrayList<>();
+                        for (Iterator<Entry<String, KahaSubscriptionCommand>> iterator = sd.subscriptions
+                                .iterator(tx); iterator.hasNext();) {
+                            Entry<String, KahaSubscriptionCommand> entry = iterator.next();
 
-                                final String subscriptionKey = entry.getKey();
-                                final LastAck cursorPos = getLastAck(tx, sd, subscriptionKey);
-                                if (cursorPos != null) {
-                                    //add the subscriptions to a list for recovering pending sizes below
-                                    subscriptionKeys.add(subscriptionKey);
-                                    //recover just the count here as that is fast
-                                    statistics.getMessageCount(subscriptionKey)
-                                            .setCount(getStoredMessageCount(tx, sd, subscriptionKey));
-                                }
+                            final String subscriptionKey = entry.getKey();
+                            final LastAck cursorPos = getLastAck(tx, sd, subscriptionKey);
+                            if (cursorPos != null) {
+                                //add the subscriptions to a list for recovering pending sizes below
+                                subscriptionKeys.add(subscriptionKey);
+                                //recover just the count here as that is fast
+                                statistics.getMessageCount(subscriptionKey)
+                                        .setCount(getStoredMessageCount(tx, sd, subscriptionKey));
                             }
-
-                            //Recover the message sizes for each subscription by iterating only 1 time over the order index
-                            //to speed up recovery
-                            final Map<String, AtomicLong> subPendingMessageSizes = getStoredMessageSize(tx, sd, subscriptionKeys);
-                            subPendingMessageSizes.forEach((k,v) -> {
-                                statistics.getMessageSize(k).addSize(v.get() > 0 ? v.get() : 0);
-                            });
                         }
+
+                        //Recover the message sizes for each subscription by iterating only 1 time over the order index
+                        //to speed up recovery
+                        final Map<String, AtomicLong> subPendingMessageSizes = getStoredMessageSize(tx, sd, subscriptionKeys);
+                        subPendingMessageSizes.forEach((k,v) ->
+                                statistics.getMessageSize(k).addSize(v.get() > 0 ? v.get() : 0));
                     });
                 } finally {
-                    indexLock.writeLock().unlock();
+                    indexLock.unlock();
                 }
             }
         }
@@ -1242,44 +1169,41 @@ public class KahaDBStore extends MessageDatabase implements PersistenceAdapter, 
             final String subscriptionKey = subscriptionKey(clientId, subscriptionName);
             @SuppressWarnings("unused")
             final SubscriptionInfo info = lookupSubscription(clientId, subscriptionName);
-            indexLock.writeLock().lock();
+            indexLock.lock();
             try {
-                pageFile.tx().execute(new Transaction.Closure<Exception>() {
-                    @Override
-                    public void execute(Transaction tx) throws Exception {
-                        StoredDestination sd = getStoredDestination(dest, tx);
-                        LastAck cursorPos = getLastAck(tx, sd, subscriptionKey);
-                        SequenceSet subAckPositions = getSequenceSet(tx, sd, subscriptionKey);
-                        //If we have ackPositions tracked then compare the first one as individual acknowledge mode
-                        //may have bumped lastAck even though there are earlier messages to still consume
-                        if (subAckPositions != null && !subAckPositions.isEmpty()
-                                && subAckPositions.getHead().getFirst() < cursorPos.lastAckedSequence) {
-                            //we have messages to ack before lastAckedSequence
-                            sd.orderIndex.setBatch(tx, subAckPositions.getHead().getFirst() - 1);
-                        } else {
-                            subAckPositions = null;
-                            sd.orderIndex.setBatch(tx, cursorPos);
-                        }
-                        recoverRolledBackAcks(subscriptionKey, sd, tx, Integer.MAX_VALUE, listener);
-                        Set<String> ackedAndPrepared = ackedAndPreparedMap.get(subscriptionKey);
-                        for (Iterator<Entry<Long, MessageKeys>> iterator = sd.orderIndex.iterator(tx); iterator
-                                .hasNext();) {
-                            Entry<Long, MessageKeys> entry = iterator.next();
-                            if (ackedAndPrepared != null && ackedAndPrepared.contains(entry.getValue().messageId)) {
-                                continue;
-                            }
-                            //If subAckPositions is set then verify the sequence set contains the message still
-                            //and if it doesn't skip it
-                            if (subAckPositions != null && !subAckPositions.contains(entry.getKey())) {
-                                continue;
-                            }
-                            listener.recoverMessage(loadMessage(entry.getValue().location));
-                        }
-                        sd.orderIndex.resetCursorPosition();
+                pageFile.tx().execute(tx -> {
+                    StoredDestination sd = getStoredDestination(dest, tx);
+                    LastAck cursorPos = getLastAck(tx, sd, subscriptionKey);
+                    SequenceSet subAckPositions = getSequenceSet(tx, sd, subscriptionKey);
+                    //If we have ackPositions tracked then compare the first one as individual acknowledge mode
+                    //may have bumped lastAck even though there are earlier messages to still consume
+                    if (subAckPositions != null && !subAckPositions.isEmpty()
+                            && subAckPositions.getHead().getFirst() < cursorPos.lastAckedSequence) {
+                        //we have messages to ack before lastAckedSequence
+                        sd.orderIndex.setBatch(subAckPositions.getHead().getFirst() - 1);
+                    } else {
+                        subAckPositions = null;
+                        sd.orderIndex.setBatch(cursorPos);
                     }
+                    recoverRolledBackAcks(subscriptionKey, sd, tx, Integer.MAX_VALUE, listener);
+                    Set<String> ackedAndPrepared = ackedAndPreparedMap.get(subscriptionKey);
+                    for (Iterator<Entry<Long, MessageKeys>> iterator = sd.orderIndex.iterator(tx); iterator
+                            .hasNext();) {
+                        Entry<Long, MessageKeys> entry = iterator.next();
+                        if (ackedAndPrepared != null && ackedAndPrepared.contains(entry.getValue().messageId)) {
+                            continue;
+                        }
+                        //If subAckPositions is set then verify the sequence set contains the message still
+                        //and if it doesn't skip it
+                        if (subAckPositions != null && !subAckPositions.contains(entry.getKey())) {
+                            continue;
+                        }
+                        listener.recoverMessage(loadMessage(entry.getValue().location));
+                    }
+                    sd.orderIndex.resetCursorPosition();
                 });
             } finally {
-                indexLock.writeLock().unlock();
+                indexLock.unlock();
             }
         }
 
@@ -1289,73 +1213,70 @@ public class KahaDBStore extends MessageDatabase implements PersistenceAdapter, 
             final String subscriptionKey = subscriptionKey(clientId, subscriptionName);
             @SuppressWarnings("unused")
             final SubscriptionInfo info = lookupSubscription(clientId, subscriptionName);
-            indexLock.writeLock().lock();
+            indexLock.lock();
             try {
-                pageFile.tx().execute(new Transaction.Closure<Exception>() {
-                    @Override
-                    public void execute(Transaction tx) throws Exception {
-                        StoredDestination sd = getStoredDestination(dest, tx);
-                        sd.orderIndex.resetCursorPosition();
-                        MessageOrderCursor moc = sd.subscriptionCursors.get(subscriptionKey);
-                        SequenceSet subAckPositions = getSequenceSet(tx, sd, subscriptionKey);;
-                        if (moc == null) {
-                            LastAck pos = getLastAck(tx, sd, subscriptionKey);
-                            if (pos == null) {
-                                // sub deleted
-                                return;
-                            }
-                            //If we have ackPositions tracked then compare the first one as individual acknowledge mode
-                            //may have bumped lastAck even though there are earlier messages to still consume
-                            if (subAckPositions != null && !subAckPositions.isEmpty()
-                                    && subAckPositions.getHead().getFirst() < pos.lastAckedSequence) {
-                                //we have messages to ack before lastAckedSequence
-                                sd.orderIndex.setBatch(tx, subAckPositions.getHead().getFirst() - 1);
-                            } else {
-                                subAckPositions = null;
-                                sd.orderIndex.setBatch(tx, pos);
-                            }
-                            moc = sd.orderIndex.cursor;
+                pageFile.tx().execute(tx -> {
+                    StoredDestination sd = getStoredDestination(dest, tx);
+                    sd.orderIndex.resetCursorPosition();
+                    MessageOrderCursor moc = sd.subscriptionCursors.get(subscriptionKey);
+                    SequenceSet subAckPositions = getSequenceSet(tx, sd, subscriptionKey);
+                    if (moc == null) {
+                        LastAck pos = getLastAck(tx, sd, subscriptionKey);
+                        if (pos == null) {
+                            // sub deleted
+                            return;
+                        }
+                        //If we have ackPositions tracked then compare the first one as individual acknowledge mode
+                        //may have bumped lastAck even though there are earlier messages to still consume
+                        if (subAckPositions != null && !subAckPositions.isEmpty()
+                                && subAckPositions.getHead().getFirst() < pos.lastAckedSequence) {
+                            //we have messages to ack before lastAckedSequence
+                            sd.orderIndex.setBatch(subAckPositions.getHead().getFirst() - 1);
                         } else {
-                            sd.orderIndex.cursor.sync(moc);
+                            subAckPositions = null;
+                            sd.orderIndex.setBatch(pos);
                         }
+                        moc = sd.orderIndex.cursor;
+                    } else {
+                        sd.orderIndex.cursor.sync(moc);
+                    }
 
-                        Entry<Long, MessageKeys> entry = null;
-                        int counter = recoverRolledBackAcks(subscriptionKey, sd, tx, maxReturned, listener);
-                        Set<String> ackedAndPrepared = ackedAndPreparedMap.get(subscriptionKey);
-                        for (Iterator<Entry<Long, MessageKeys>> iterator = sd.orderIndex.iterator(tx, moc); iterator
-                                .hasNext();) {
-                            entry = iterator.next();
-                            if (ackedAndPrepared != null && ackedAndPrepared.contains(entry.getValue().messageId)) {
-                                continue;
-                            }
-                            //If subAckPositions is set then verify the sequence set contains the message still
-                            //and if it doesn't skip it
-                            if (subAckPositions != null && !subAckPositions.contains(entry.getKey())) {
-                                continue;
-                            }
-                            if (listener.recoverMessage(loadMessage(entry.getValue().location))) {
-                                counter++;
-                            }
-                            if (counter >= maxReturned || listener.hasSpace() == false) {
-                                break;
-                            }
+                    Entry<Long, MessageKeys> entry = null;
+                    int counter = recoverRolledBackAcks(subscriptionKey, sd, tx, maxReturned, listener);
+                    Set<String> ackedAndPrepared = ackedAndPreparedMap.get(subscriptionKey);
+                    for (Iterator<Entry<Long, MessageKeys>> iterator = sd.orderIndex.iterator(tx, moc); iterator
+                            .hasNext();) {
+                        entry = iterator.next();
+                        if (ackedAndPrepared != null && ackedAndPrepared.contains(entry.getValue().messageId)) {
+                            continue;
                         }
-                        sd.orderIndex.stoppedIterating();
-                        if (entry != null) {
-                            MessageOrderCursor copy = sd.orderIndex.cursor.copy();
-                            sd.subscriptionCursors.put(subscriptionKey, copy);
+                        //If subAckPositions is set then verify the sequence set contains the message still
+                        //and if it doesn't skip it
+                        if (subAckPositions != null && !subAckPositions.contains(entry.getKey())) {
+                            continue;
                         }
+                        if (listener.recoverMessage(loadMessage(entry.getValue().location))) {
+                            counter++;
+                        }
+                        if (counter >= maxReturned || !listener.hasSpace()) {
+                            break;
+                        }
+                    }
+                    sd.orderIndex.stoppedIterating();
+                    if (entry != null) {
+                        MessageOrderCursor copy = sd.orderIndex.cursor.copy();
+                        sd.subscriptionCursors.put(subscriptionKey, copy);
                     }
                 });
             } finally {
-                indexLock.writeLock().unlock();
+                indexLock.unlock();
             }
         }
 
         @Override
         public Map<SubscriptionKey,List<Message>> recoverExpired(Set<SubscriptionKey> subscriptions, int maxBrowse,
             MessageRecoveryListener listener) throws Exception {
-            indexLock.writeLock().lock();
+            indexLock.lock();
             try {
                 return pageFile.tx().execute(tx -> {
                         StoredDestination sd = getStoredDestination(dest, tx);
@@ -1406,7 +1327,7 @@ public class KahaDBStore extends MessageDatabase implements PersistenceAdapter, 
                         return expired;
                     });
             } finally {
-                indexLock.writeLock().unlock();
+                indexLock.unlock();
             }
         }
 
@@ -1414,17 +1335,14 @@ public class KahaDBStore extends MessageDatabase implements PersistenceAdapter, 
         public void resetBatching(String clientId, String subscriptionName) {
             try {
                 final String subscriptionKey = subscriptionKey(clientId, subscriptionName);
-                indexLock.writeLock().lock();
+                indexLock.lock();
                 try {
-                    pageFile.tx().execute(new Transaction.Closure<IOException>() {
-                        @Override
-                        public void execute(Transaction tx) throws IOException {
-                            StoredDestination sd = getStoredDestination(dest, tx);
-                            sd.subscriptionCursors.remove(subscriptionKey);
-                        }
+                    pageFile.tx().execute(tx -> {
+                        StoredDestination sd = getStoredDestination(dest, tx);
+                        sd.subscriptionCursors.remove(subscriptionKey);
                     });
                 }finally {
-                    indexLock.writeLock().unlock();
+                    indexLock.unlock();
                 }
             } catch (IOException e) {
                 throw new RuntimeException(e);
@@ -1501,22 +1419,19 @@ public class KahaDBStore extends MessageDatabase implements PersistenceAdapter, 
     @Override
     public Set<ActiveMQDestination> getDestinations() {
         try {
-            final HashSet<ActiveMQDestination> rc = new HashSet<ActiveMQDestination>();
-            indexLock.writeLock().lock();
+            final HashSet<ActiveMQDestination> rc = new HashSet<>();
+            indexLock.lock();
             try {
-                pageFile.tx().execute(new Transaction.Closure<IOException>() {
-                    @Override
-                    public void execute(Transaction tx) throws IOException {
-                        for (Iterator<Entry<String, StoredDestination>> iterator = metadata.destinations.iterator(tx); iterator
-                                .hasNext();) {
-                            Entry<String, StoredDestination> entry = iterator.next();
-                            //Removing isEmpty topic check - see AMQ-5875
-                            rc.add(convert(entry.getKey()));
-                        }
+                pageFile.tx().execute(tx -> {
+                    for (Iterator<Entry<String, StoredDestination>> iterator = metadata.destinations.iterator(tx); iterator
+                            .hasNext();) {
+                        Entry<String, StoredDestination> entry = iterator.next();
+                        //Removing isEmpty topic check - see AMQ-5875
+                        rc.add(convert(entry.getKey()));
                     }
                 });
             }finally {
-                indexLock.writeLock().unlock();
+                indexLock.unlock();
             }
             return rc;
         } catch (IOException e) {
@@ -1525,17 +1440,17 @@ public class KahaDBStore extends MessageDatabase implements PersistenceAdapter, 
     }
 
     @Override
-    public long getLastMessageBrokerSequenceId() throws IOException {
+    public long getLastMessageBrokerSequenceId() {
         return 0;
     }
 
     @Override
     public long getLastProducerSequenceId(ProducerId id) {
-        indexLock.writeLock().lock();
+        indexLock.lock();
         try {
             return metadata.producerSequenceIdTracker.getLastSeqId(id);
         } finally {
-            indexLock.writeLock().unlock();
+            indexLock.unlock();
         }
     }
 
@@ -1578,7 +1493,7 @@ public class KahaDBStore extends MessageDatabase implements PersistenceAdapter, 
     Message loadMessage(Location location) throws IOException {
         try {
             JournalCommand<?> command = load(location);
-            KahaAddMessageCommand addMessage = null;
+            KahaAddMessageCommand addMessage;
             switch (command.type()) {
                 case KAHA_UPDATE_MESSAGE_COMMAND:
                     addMessage = ((KahaUpdateMessageCommand) command).getMessage();
@@ -1592,8 +1507,7 @@ public class KahaDBStore extends MessageDatabase implements PersistenceAdapter, 
             if (!addMessage.hasMessage()) {
                 throw new IOException("Could not load journal record, null message content at location: " + location);
             }
-            Message msg = (Message) wireFormat.unmarshal(new DataInputStream(addMessage.getMessage().newInput()));
-            return msg;
+            return (Message) wireFormat.unmarshal(new DataInputStream(addMessage.getMessage().newInput()));
         } catch (Throwable t) {
             IOException ioe = IOExceptionSupport.create("Unexpected error on journal read at: " + location , t);
             LOG.error("Failed to load message at: {}", location , ioe);
@@ -1605,13 +1519,6 @@ public class KahaDBStore extends MessageDatabase implements PersistenceAdapter, 
     // /////////////////////////////////////////////////////////////////
     // Internal conversion methods.
     // /////////////////////////////////////////////////////////////////
-
-    KahaLocation convert(Location location) {
-        KahaLocation rc = new KahaLocation();
-        rc.setLogId(location.getDataFileId());
-        rc.setOffset(location.getOffset());
-        return rc;
-    }
 
     KahaDestination convert(ActiveMQDestination dest) {
         KahaDestination rc = new KahaDestination();
@@ -1642,10 +1549,6 @@ public class KahaDBStore extends MessageDatabase implements PersistenceAdapter, 
         int type = Integer.parseInt(dest.substring(0, p));
         String name = dest.substring(p + 1);
         return convert(type, name);
-    }
-
-    private ActiveMQDestination convert(KahaDestination commandDestination) {
-        return convert(commandDestination.getType().getNumber(), commandDestination.getName());
     }
 
     private ActiveMQDestination convert(int type, String name) {
@@ -1701,18 +1604,18 @@ public class KahaDBStore extends MessageDatabase implements PersistenceAdapter, 
     }
 
     public interface StoreTask {
-        public boolean cancel();
+        boolean cancel();
 
-        public void aquireLocks();
+        void aquireLocks();
 
-        public void releaseLocks();
+        void releaseLocks();
     }
 
     class StoreQueueTask implements Runnable, StoreTask {
         protected final Message message;
         protected final ConnectionContext context;
         protected final KahaDBMessageStore store;
-        protected final InnerFutureTask future;
+        final InnerFutureTask future;
         protected final AtomicBoolean done = new AtomicBoolean();
         protected final AtomicBoolean locked = new AtomicBoolean();
 
@@ -1781,7 +1684,7 @@ public class KahaDBStore extends MessageDatabase implements PersistenceAdapter, 
             return this.message;
         }
 
-        private class InnerFutureTask extends FutureTask<Object> implements ListenableFuture<Object>  {
+        private static class InnerFutureTask extends FutureTask<Object> implements ListenableFuture<Object>  {
 
             private final AtomicReference<Runnable> listenerRef = new AtomicReference<>();
 
@@ -1826,7 +1729,7 @@ public class KahaDBStore extends MessageDatabase implements PersistenceAdapter, 
 
     class StoreTopicTask extends StoreQueueTask {
         private final int subscriptionCount;
-        private final List<String> subscriptionKeys = new ArrayList<String>(1);
+        private final List<String> subscriptionKeys = new ArrayList<>(1);
         private final KahaDBTopicMessageStore topicStore;
         public StoreTopicTask(KahaDBTopicMessageStore store, ConnectionContext context, Message message,
                 int subscriptionCount) {
@@ -1880,7 +1783,7 @@ public class KahaDBStore extends MessageDatabase implements PersistenceAdapter, 
                     // apply any acks we have
                     synchronized (this.subscriptionKeys) {
                         for (String key : this.subscriptionKeys) {
-                            this.topicStore.doAcknowledge(context, key, this.message.getMessageId(), null);
+                            this.topicStore.doAcknowledge(key, this.message.getMessageId(), null);
 
                         }
                     }
@@ -1898,7 +1801,7 @@ public class KahaDBStore extends MessageDatabase implements PersistenceAdapter, 
         }
     }
 
-    public class StoreTaskExecutor extends ThreadPoolExecutor {
+    public static class StoreTaskExecutor extends ThreadPoolExecutor {
 
         public StoreTaskExecutor(int corePoolSize, int maximumPoolSize, long keepAliveTime, TimeUnit timeUnit, BlockingQueue<Runnable> queue, ThreadFactory threadFactory) {
             super(corePoolSize, maximumPoolSize, keepAliveTime, timeUnit, queue, threadFactory);
@@ -1915,7 +1818,7 @@ public class KahaDBStore extends MessageDatabase implements PersistenceAdapter, 
     }
 
     @Override
-    public JobSchedulerStore createJobSchedulerStore() throws IOException, UnsupportedOperationException {
+    public JobSchedulerStore createJobSchedulerStore() throws UnsupportedOperationException {
         return new JobSchedulerStoreImpl();
     }
 

--- a/activemq-kahadb-store/src/test/java/org/apache/activemq/store/kahadb/JournalCorruptionEofIndexRecoveryTest.java
+++ b/activemq-kahadb-store/src/test/java/org/apache/activemq/store/kahadb/JournalCorruptionEofIndexRecoveryTest.java
@@ -442,31 +442,28 @@ public class JournalCorruptionEofIndexRecoveryTest {
     private void corruptOrderIndex(final int num, final int size) throws Exception {
         //This is because of AMQ-6097, now that the MessageOrderIndex stores the size in the Location,
         //we need to corrupt that value as well
-        final KahaDBStore kahaDbStore = (KahaDBStore) ((KahaDBPersistenceAdapter) broker.getPersistenceAdapter()).getStore();
-        kahaDbStore.indexLock.writeLock().lock();
+        final KahaDBStore kahaDbStore = ((KahaDBPersistenceAdapter) broker.getPersistenceAdapter()).getStore();
+        kahaDbStore.indexLock.lock();
         try {
-            kahaDbStore.pageFile.tx().execute(new Transaction.Closure<IOException>() {
-                @Override
-                public void execute(Transaction tx) throws IOException {
-                    StoredDestination sd = kahaDbStore.getStoredDestination(kahaDbStore.convert(
-                        (ActiveMQQueue)destination), tx);
-                    int i = 1;
-                    for (Iterator<Entry<Long, MessageKeys>> iterator = sd.orderIndex.iterator(tx); iterator.hasNext();) {
-                        Entry<Long, MessageKeys> entry = iterator.next();
-                        if (i == num) {
-                            //change the size value to the wrong size
-                            sd.orderIndex.get(tx, entry.getKey());
-                            MessageKeys messageKeys = entry.getValue();
-                            messageKeys.location.setSize(size);
-                            sd.orderIndex.put(tx, sd.orderIndex.lastGetPriority(), entry.getKey(), messageKeys);
-                            break;
-                        }
-                        i++;
+            kahaDbStore.pageFile.tx().execute(tx -> {
+                StoredDestination sd = kahaDbStore.getStoredDestination(kahaDbStore.convert(
+                    (ActiveMQQueue)destination), tx);
+                int i = 1;
+                for (Iterator<Entry<Long, MessageKeys>> iterator = sd.orderIndex.iterator(tx); iterator.hasNext();) {
+                    Entry<Long, MessageKeys> entry = iterator.next();
+                    if (i == num) {
+                        //change the size value to the wrong size
+                        sd.orderIndex.get(tx, entry.getKey());
+                        MessageKeys messageKeys = entry.getValue();
+                        messageKeys.location.setSize(size);
+                        sd.orderIndex.put(tx, sd.orderIndex.lastGetPriority(), entry.getKey(), messageKeys);
+                        break;
                     }
+                    i++;
                 }
             });
         } finally {
-            kahaDbStore.indexLock.writeLock().unlock();
+            kahaDbStore.indexLock.unlock();
         }
     }
 

--- a/activemq-kahadb-store/src/test/java/org/apache/activemq/store/kahadb/KahaDBStoreOpenWireVersionTest.java
+++ b/activemq-kahadb-store/src/test/java/org/apache/activemq/store/kahadb/KahaDBStoreOpenWireVersionTest.java
@@ -164,22 +164,19 @@ public class KahaDBStoreOpenWireVersionTest {
 
         //blow up the index
         try {
-            store.indexLock.writeLock().lock();
-            pageFile.tx().execute(new Transaction.Closure<IOException>() {
-                @Override
-                public void execute(Transaction tx) throws IOException {
-                    for (Iterator<Entry<String, StoredDestination>> iterator = metadata.destinations.iterator(tx); iterator
-                            .hasNext();) {
-                        Entry<String, StoredDestination> entry = iterator.next();
-                        entry.getValue().orderIndex.nextMessageId = -100;
-                        entry.getValue().orderIndex.defaultPriorityIndex.clear(tx);
-                        entry.getValue().orderIndex.lowPriorityIndex.clear(tx);
-                        entry.getValue().orderIndex.highPriorityIndex.clear(tx);
-                    }
+            store.indexLock.lock();
+            pageFile.tx().execute(tx -> {
+                for (Iterator<Entry<String, StoredDestination>> iterator = metadata.destinations.iterator(tx); iterator
+                        .hasNext();) {
+                    Entry<String, StoredDestination> entry = iterator.next();
+                    entry.getValue().orderIndex.nextMessageId = -100;
+                    entry.getValue().orderIndex.defaultPriorityIndex.clear(tx);
+                    entry.getValue().orderIndex.lowPriorityIndex.clear(tx);
+                    entry.getValue().orderIndex.highPriorityIndex.clear(tx);
                 }
             });
         } finally {
-            store.indexLock.writeLock().unlock();
+            store.indexLock.unlock();
         }
     }
 

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/bugs/AMQ2982Test.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/bugs/AMQ2982Test.java
@@ -62,11 +62,11 @@ public class AMQ2982Test {
 
         public int getFileMapSize() throws IOException {
             // ensure save memory publishing, use the right lock
-            indexLock.readLock().lock();
+            indexLock.lock();
             try {
                 return getJournal().getFileMap().size();
             } finally {
-                indexLock.readLock().unlock();
+                indexLock.unlock();
             }
         }
     }

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/bugs/AMQ2983Test.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/bugs/AMQ2983Test.java
@@ -65,11 +65,11 @@ public class AMQ2983Test {
 
         public int getFileMapSize() throws IOException {
             // ensure save memory publishing, use the right lock
-            indexLock.readLock().lock();
+            indexLock.lock();
             try {
                 return getJournal().getFileMap().size();
             } finally {
-                indexLock.readLock().unlock();
+                indexLock.unlock();
             }
         }
     }

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/store/kahadb/KahaDBMessageStoreSizeTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/store/kahadb/KahaDBMessageStoreSizeTest.java
@@ -61,7 +61,7 @@ public class KahaDBMessageStoreSizeTest extends AbstractKahaDBMessageStoreSizeTe
 
         //Iterate over the order index and add up the size of the messages to compare
         //to the location index
-        kahaDbStore.indexLock.readLock().lock();
+        kahaDbStore.indexLock.lock();
         try {
             long size = kahaDbStore.pageFile.tx().execute(new Transaction.CallableClosure<Long, IOException>() {
                 @Override
@@ -79,7 +79,7 @@ public class KahaDBMessageStoreSizeTest extends AbstractKahaDBMessageStoreSizeTe
             assertEquals("Order index size values don't match message size",
                     size, messageStore.getMessageSize());
         } finally {
-            kahaDbStore.indexLock.readLock().unlock();
+            kahaDbStore.indexLock.unlock();
         }
     }
 


### PR DESCRIPTION
This cleanups the MessageDatabase and KahaDBStore classes.

This commit includes the following:

* Fixes the scope of several methods and types. For example, there were many cases where protected methods were referencing types that were package scope.
* Simplified the code by replacing anonymous methods with lambdas
* removed unused methods and parameters
* removed unnecessary casts
* cleaned up the use of generics where types could be inferred
* Replaced the ReentrantReadWriteLock that was used for indexLock with ReentrantLock becuase only the write lock was ever being used (the page file doesn't support concurrent reads right now). This should provide a small performance/memory improvement and simplifies the code a bit.
* removed unnecessary null initializations
* cleaned up logging to remove string concatenation and instead use parameters
* removed method overrides that are the same as the parent or just call the super method
* removed unused checked exceptions from method's throws
* marked inner classes as static when possible