### PR TITLE
[6.2.x] Bump jolokia-version from 2.4.0 to 2.4.3 (#1611)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
     <javassist-version>3.30.2-GA</javassist-version>
     <jettison-version>1.5.4</jettison-version>
     <jmock-version>2.13.1</jmock-version>
-    <jolokia-version>2.4.0</jolokia-version>
+    <jolokia-version>2.4.3</jolokia-version>
     <junit-version>4.13.2</junit-version>
     <hamcrest-version>1.3</hamcrest-version>
     <karaf-version>4.3.7</karaf-version>


### PR DESCRIPTION
Bumps `jolokia-version` from 2.4.0 to 2.4.3.

Updates `org.jolokia:jolokia-server-core` from 2.4.0 to 2.4.3
- [Release notes](https://github.com/jolokia/jolokia/releases)
- [Commits](https://github.com/jolokia/jolokia/compare/v2.4.0...v2.4.3)

Updates `org.jolokia:jolokia-service-jmx` from 2.4.0 to 2.4.3

Updates `org.jolokia:jolokia-service-serializer` from 2.4.0 to 2.4.3

---
updated-dependencies:
- dependency-name: org.jolokia:jolokia-server-core dependency-version: 2.4.3 dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: org.jolokia:jolokia-service-jmx dependency-version: 2.4.3 dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: org.jolokia:jolokia-service-serializer dependency-version: 2.4.3 dependency-type: direct:production update-type: version-update:semver-patch ...