### PR TITLE
Enable publishing of test results in CI workflows

### DIFF
--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -79,17 +79,26 @@ jobs:
         if: (!cancelled()) && runner.os == 'Linux'
         uses: EnricoMi/publish-unit-test-result-action@v2
         with:
+          large_files: true
+          report_individual_runs: true
+          report_suite_logs: error
           check_name: Test Results (${{ matrix.os }}, Java ${{ matrix.java-version }})
           files: '**/target/surefire-reports/*.xml'
       - name: Publish Test Results (macOS)
         if: (!cancelled()) && runner.os == 'macOS'
         uses: EnricoMi/publish-unit-test-result-action/macos@v2
         with:
+          large_files: true
+          report_individual_runs: true
+          report_suite_logs: error
           check_name: Test Results (${{ matrix.os }}, Java ${{ matrix.java-version }})
           files: '**/target/surefire-reports/*.xml'
       - name: Publish Test Results (Windows)
         if: (!cancelled()) && runner.os == 'Windows'
         uses: EnricoMi/publish-unit-test-result-action/windows@v2
         with:
+          large_files: true
+          report_individual_runs: true
+          report_suite_logs: error
           check_name: Test Results (${{ matrix.os }}, Java ${{ matrix.java-version }})
           files: '**/target/surefire-reports/*.xml'

--- a/.github/workflows/ci-quick.yml
+++ b/.github/workflows/ci-quick.yml
@@ -78,4 +78,7 @@ jobs:
         if: (!cancelled())
         uses: EnricoMi/publish-unit-test-result-action@v2
         with:
+          large_files: true
+          report_individual_runs: true
+          report_suite_logs: error
           files: '**/target/surefire-reports/*.xml'


### PR DESCRIPTION
I followed the documentation at https://github.com/marketplace/actions/publish-test-results but I'm not sure how it will work on our repo. Let's see

Here is the result https://github.com/apache/activemq/actions/runs/21436334968
Not too happy about it. I wanted to see individual test failures with output, but probably some tuning to do.