### PR TITLE
the Apache org only allows EnricoMi/publish-unit-test-result-action

### DIFF
--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -75,27 +75,9 @@ jobs:
         with:
           name: test-results-${{ matrix.os }}-java${{ matrix.java-version }}
           path: '**/target/surefire-reports/*.xml'
-      - name: Publish Test Results (Linux)
+      - name: Publish Test Results
         if: (!cancelled()) && runner.os == 'Linux'
         uses: EnricoMi/publish-unit-test-result-action@v2
-        with:
-          large_files: true
-          report_individual_runs: true
-          report_suite_logs: error
-          check_name: Test Results (${{ matrix.os }}, Java ${{ matrix.java-version }})
-          files: '**/target/surefire-reports/*.xml'
-      - name: Publish Test Results (macOS)
-        if: (!cancelled()) && runner.os == 'macOS'
-        uses: EnricoMi/publish-unit-test-result-action/macos@v2
-        with:
-          large_files: true
-          report_individual_runs: true
-          report_suite_logs: error
-          check_name: Test Results (${{ matrix.os }}, Java ${{ matrix.java-version }})
-          files: '**/target/surefire-reports/*.xml'
-      - name: Publish Test Results (Windows)
-        if: (!cancelled()) && runner.os == 'Windows'
-        uses: EnricoMi/publish-unit-test-result-action/windows@v2
         with:
           large_files: true
           report_individual_runs: true


### PR DESCRIPTION
… but not the /macos and /windows subpaths