### PR TITLE
AMQ-9851 Set preallocation scope to NONE in JournalFdRecoveryTest

### DIFF
--- a/activemq-kahadb-store/src/test/java/org/apache/activemq/store/kahadb/JournalFdRecoveryTest.java
+++ b/activemq-kahadb-store/src/test/java/org/apache/activemq/store/kahadb/JournalFdRecoveryTest.java
@@ -212,6 +212,7 @@ public class JournalFdRecoveryTest {
     public void testRecoveryWithMissingMssagesWithValidAcks() throws Exception {
 
         doCreateBroker(true);
+        adapter.setPreallocationScope(Journal.PreallocationScope.NONE.name());
         adapter.setCheckpointInterval(50000);
         adapter.setCleanupInterval(50000);
         broker.start();


### PR DESCRIPTION
This only happens in the nightly build because it needs to run on MacOS. On linux the test passes just fine.
So we need unfortunately to merge and see on the next run