### PR TITLE
Upgrade Netty to 4.2.9.Final

### DIFF
--- a/activemq-amqp/src/test/java/org/apache/activemq/transport/amqp/client/transport/NettyTcpTransport.java
+++ b/activemq-amqp/src/test/java/org/apache/activemq/transport/amqp/client/transport/NettyTcpTransport.java
@@ -23,6 +23,8 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import io.netty.channel.MultiThreadIoEventLoopGroup;
+import io.netty.channel.nio.NioIoHandler;
 import org.apache.activemq.transport.amqp.client.util.IOExceptionSupport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,7 +42,6 @@ import io.netty.channel.ChannelPipeline;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.FixedRecvByteBufAllocator;
 import io.netty.channel.SimpleChannelInboundHandler;
-import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.logging.LoggingHandler;
 import io.netty.handler.ssl.SslHandler;
@@ -125,7 +126,7 @@ public class NettyTcpTransport implements NettyTransport {
             sslHandler = null;
         }
 
-        group = new NioEventLoopGroup(1);
+        group = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory());
 
         bootstrap = new Bootstrap();
         bootstrap.group(group);

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
     <osgi-version>6.0.0</osgi-version>
     <qpid-proton-version>0.34.1</qpid-proton-version>
     <qpid-jms-version>2.10.0</qpid-jms-version>
-    <netty-version>4.1.94.Final</netty-version>
+    <netty-version>4.2.9.Final</netty-version>
     <rome-version>2.1.0</rome-version>
     <shiro-version>2.0.6</shiro-version>
     <slf4j-version>2.0.17</slf4j-version>


### PR DESCRIPTION
Motivation:
Netty 4.2 supersedes 4.1, making an upgrade advisable to stay current and supported.

Modification:
1. Upgrade Dependency to 4.2.9.Final
2. Use `MultiThreadIoEventLoopGroup` instead of `NioEventLoopGroup` directly.

Result:
Latest stable release of Netty
