### PR TITLE
[#] Disable fail-fast in CI strategy to improve job resilience

### DIFF
--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -54,6 +54,7 @@ jobs:
       pull-requests: write
 
     strategy:
+      fail-fast: false
       matrix:
         os: [ ubuntu-24.04, ubuntu-22.04, macos-26, macos-15, windows-2025, windows-2022 ]
         java-version: [ 17, 21 ]


### PR DESCRIPTION
The goal here is to get Github to run the entire matrix till the end. The default for `fail-fast` is true, so when one combination of [os,java] fails, Github will cancel all the other jobs.
Because it's not stable at the minute, we want to have the full view of all the failures as quickly as possible so we can fix more than one at a time.
And when it's done, I think it makes sense to get a view on all env so we know if one test is failing in one env but not in the other one.