### PR TITLE
[AMQ-9857] Add SSL support for JMX connector in ManagementContext

### DIFF
--- a/activemq-broker/src/test/java/org/apache/activemq/broker/jmx/ManagementContextSslTest.java
+++ b/activemq-broker/src/test/java/org/apache/activemq/broker/jmx/ManagementContextSslTest.java
@@ -1,0 +1,285 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.broker.jmx;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyStore;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.management.MBeanServerConnection;
+import javax.management.remote.JMXConnector;
+import javax.management.remote.JMXConnectorFactory;
+import javax.management.remote.JMXServiceURL;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
+import javax.rmi.ssl.SslRMIClientSocketFactory;
+
+import org.apache.activemq.broker.SslContext;
+import org.apache.activemq.util.Wait;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ManagementContextSslTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ManagementContextSslTest.class);
+    private static final String KEYSTORE_PASSWORD = "password";
+
+    private static Path tempDir;
+    private static Path keystoreFile;
+    private ManagementContext context;
+
+    @BeforeClass
+    public static void createKeyStore() throws Exception {
+        tempDir = Files.createTempDirectory("test-jmx-ssl");
+        keystoreFile = tempDir.resolve("keystore.p12");
+        final Process p = new ProcessBuilder(
+                "keytool", "-genkeypair",
+                "-keystore", keystoreFile.toString(),
+                "-storetype", "PKCS12",
+                "-storepass", KEYSTORE_PASSWORD,
+                "-keypass", KEYSTORE_PASSWORD,
+                "-alias", "test",
+                "-keyalg", "RSA",
+                "-keysize", "2048",
+                "-dname", "CN=localhost,O=Test",
+                "-validity", "1"
+        ).inheritIO().start();
+        assertEquals("keytool should succeed", 0, p.waitFor());
+    }
+
+    @AfterClass
+    public static void cleanupKeyStore() throws Exception {
+        if (keystoreFile != null) {
+            Files.deleteIfExists(keystoreFile);
+        }
+        if (tempDir != null) {
+            Files.deleteIfExists(tempDir);
+        }
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (context != null) {
+            context.stop();
+        }
+    }
+
+    @Test
+    public void testSslContextProperty() {
+        context = new ManagementContext();
+        assertNull("sslContext should be null by default", context.getSslContext());
+
+        final SslContext ssl = new SslContext();
+        context.setSslContext(ssl);
+        assertSame("sslContext should be the one we set", ssl, context.getSslContext());
+    }
+
+    @Test
+    public void testEphemeralPortResolution() throws Exception {
+        context = new ManagementContext();
+        context.setCreateConnector(true);
+        context.setConnectorPort(0);
+        context.setConnectorHost("localhost");
+
+        assertEquals("Before start, port should be 0", 0, context.getConnectorPort());
+
+        context.start();
+
+        assertTrue("Connector should be started",
+                Wait.waitFor(context::isConnectorStarted, 10_000, 100));
+
+        final int resolvedPort = context.getConnectorPort();
+        assertTrue("After start, port should be resolved to a real port (got " + resolvedPort + ")",
+                resolvedPort > 0);
+        LOG.info("Ephemeral port resolved to {}", resolvedPort);
+    }
+
+    @Test
+    public void testEphemeralPortsAreDifferentPerInstance() throws Exception {
+        context = new ManagementContext();
+        context.setCreateConnector(true);
+        context.setConnectorPort(0);
+        context.setConnectorHost("localhost");
+        context.start();
+
+        assertTrue("First connector should be started",
+                Wait.waitFor(context::isConnectorStarted, 10_000, 100));
+        final int port1 = context.getConnectorPort();
+
+        // Start a second context with ephemeral port
+        final ManagementContext context2 = new ManagementContext();
+        context2.setCreateConnector(true);
+        context2.setConnectorPort(0);
+        context2.setConnectorHost("localhost");
+        try {
+            context2.start();
+
+            assertTrue("Second connector should be started",
+                    Wait.waitFor(context2::isConnectorStarted, 10_000, 100));
+            final int port2 = context2.getConnectorPort();
+
+            assertTrue("Both ports should be > 0", port1 > 0 && port2 > 0);
+            assertTrue("Ports should be different (port1=" + port1 + ", port2=" + port2 + ")",
+                    port1 != port2);
+            LOG.info("Two ephemeral ports: {} and {}", port1, port2);
+        } finally {
+            context2.stop();
+        }
+    }
+
+    @Test
+    public void testConnectorStartsWithSsl() throws Exception {
+        // SslRMIClientSocketFactory (used internally for JNDI binding) reads the JVM default
+        // trust store, so system properties must be set BEFORE starting the connector
+        final String savedTrustStore = System.getProperty("javax.net.ssl.trustStore");
+        final String savedTrustStorePassword = System.getProperty("javax.net.ssl.trustStorePassword");
+        try {
+            System.setProperty("javax.net.ssl.trustStore", keystoreFile.toString());
+            System.setProperty("javax.net.ssl.trustStorePassword", KEYSTORE_PASSWORD);
+
+            context = createSslManagementContext();
+            context.start();
+
+            assertTrue("Connector should be started",
+                    Wait.waitFor(context::isConnectorStarted, 10_000, 100));
+            assertTrue("SSL connector port should be resolved", context.getConnectorPort() > 0);
+        } finally {
+            restoreSystemProperty("javax.net.ssl.trustStore", savedTrustStore);
+            restoreSystemProperty("javax.net.ssl.trustStorePassword", savedTrustStorePassword);
+        }
+    }
+
+    @Test
+    public void testSslJmxConnectionSucceeds() throws Exception {
+        // SslRMIClientSocketFactory (used both for JNDI binding on the server side and for
+        // client connections) reads the JVM default trust store via system properties.
+        // These must be set BEFORE context.start() so the daemon thread sees them.
+        final String savedTrustStore = System.getProperty("javax.net.ssl.trustStore");
+        final String savedTrustStorePassword = System.getProperty("javax.net.ssl.trustStorePassword");
+        try {
+            System.setProperty("javax.net.ssl.trustStore", keystoreFile.toString());
+            System.setProperty("javax.net.ssl.trustStorePassword", KEYSTORE_PASSWORD);
+
+            context = createSslManagementContext();
+            context.start();
+
+            final int port = context.getConnectorPort();
+            assertTrue("SSL connector port should be resolved", port > 0);
+
+            final JMXServiceURL url = new JMXServiceURL(
+                    "service:jmx:rmi:///jndi/rmi://localhost:" + port + "/jmxrmi");
+            final Map<String, Object> env = new HashMap<>();
+            env.put("com.sun.jndi.rmi.factory.socket", new SslRMIClientSocketFactory());
+
+            // Retry connection: isConnectorStarted() can return true (via isActive()) before
+            // the RMI server stub is fully registered in the registry
+            assertTrue("Should connect to SSL JMX", Wait.waitFor(() -> {
+                try (final JMXConnector connector = JMXConnectorFactory.connect(url, env)) {
+                    final MBeanServerConnection connection = connector.getMBeanServerConnection();
+                    LOG.info("Successfully connected to SSL JMX on port {}, found {} MBeans",
+                            port, connection.getMBeanCount());
+                    return connection.getMBeanCount() > 0;
+                } catch (final Exception e) {
+                    LOG.debug("JMX SSL connection attempt failed: {}", e.getMessage());
+                    return false;
+                }
+            }, 10_000, 500));
+        } finally {
+            restoreSystemProperty("javax.net.ssl.trustStore", savedTrustStore);
+            restoreSystemProperty("javax.net.ssl.trustStorePassword", savedTrustStorePassword);
+        }
+    }
+
+    @Test
+    public void testConnectorStartsWithoutSsl() throws Exception {
+        context = new ManagementContext();
+        context.setCreateConnector(true);
+        context.setConnectorPort(0);
+        context.setConnectorHost("localhost");
+        context.start();
+
+        final int port = context.getConnectorPort();
+        assertTrue("Port should be resolved", port > 0);
+
+        final JMXServiceURL url = new JMXServiceURL(
+                "service:jmx:rmi:///jndi/rmi://localhost:" + port + "/jmxrmi");
+
+        // Retry connection: isConnectorStarted() can return true (via isActive()) before
+        // the RMI server stub is fully registered in the registry
+        assertTrue("Should connect to non-SSL JMX", Wait.waitFor(() -> {
+            try (final JMXConnector connector = JMXConnectorFactory.connect(url)) {
+                final MBeanServerConnection connection = connector.getMBeanServerConnection();
+                LOG.info("Successfully connected to non-SSL JMX on port {}", port);
+                return connection.getMBeanCount() > 0;
+            } catch (final IOException e) {
+                LOG.debug("JMX connection not yet available: {}", e.getMessage());
+                return false;
+            }
+        }, 10_000, 500));
+    }
+
+    private ManagementContext createSslManagementContext() throws Exception {
+        final KeyStore ks = KeyStore.getInstance("PKCS12");
+        try (final InputStream fis = Files.newInputStream(keystoreFile)) {
+            ks.load(fis, KEYSTORE_PASSWORD.toCharArray());
+        }
+
+        final KeyManagerFactory kmf = KeyManagerFactory.getInstance(
+                KeyManagerFactory.getDefaultAlgorithm());
+        kmf.init(ks, KEYSTORE_PASSWORD.toCharArray());
+
+        final TrustManagerFactory tmf = TrustManagerFactory.getInstance(
+                TrustManagerFactory.getDefaultAlgorithm());
+        tmf.init(ks);
+
+        final SSLContext sslCtx = SSLContext.getInstance("TLS");
+        sslCtx.init(kmf.getKeyManagers(), tmf.getTrustManagers(), null);
+
+        final SslContext sslContext = new SslContext();
+        sslContext.setSSLContext(sslCtx);
+
+        final ManagementContext ctx = new ManagementContext();
+        ctx.setCreateConnector(true);
+        ctx.setConnectorPort(0);
+        ctx.setConnectorHost("localhost");
+        ctx.setSslContext(sslContext);
+
+        return ctx;
+    }
+
+    private static void restoreSystemProperty(final String key, final String value) {
+        if (value == null) {
+            System.clearProperty(key);
+        } else {
+            System.setProperty(key, value);
+        }
+    }
+}

--- a/activemq-broker/src/test/java/org/apache/activemq/broker/jmx/ManagementContextSslTest.java
+++ b/activemq-broker/src/test/java/org/apache/activemq/broker/jmx/ManagementContextSslTest.java
@@ -61,7 +61,6 @@ public class ManagementContextSslTest {
     private SSLContext savedDefaultSslContext;
     private String savedTrustStore;
     private String savedTrustStorePassword;
-    private String savedRmiHostname;
 
     @BeforeClass
     public static void createKeyStore() throws Exception {
@@ -110,7 +109,6 @@ public class ManagementContextSslTest {
         savedDefaultSslContext = SSLContext.getDefault();
         savedTrustStore = System.getProperty("javax.net.ssl.trustStore");
         savedTrustStorePassword = System.getProperty("javax.net.ssl.trustStorePassword");
-        savedRmiHostname = System.getProperty("java.rmi.server.hostname");
     }
 
     @After
@@ -121,7 +119,6 @@ public class ManagementContextSslTest {
         SSLContext.setDefault(savedDefaultSslContext);
         restoreSystemProperty("javax.net.ssl.trustStore", savedTrustStore);
         restoreSystemProperty("javax.net.ssl.trustStorePassword", savedTrustStorePassword);
-        restoreSystemProperty("java.rmi.server.hostname", savedRmiHostname);
     }
 
     @Test
@@ -195,9 +192,6 @@ public class ManagementContextSslTest {
         SSLContext.setDefault(testSslContext);
         System.setProperty("javax.net.ssl.trustStore", keystoreFile.toString());
         System.setProperty("javax.net.ssl.trustStorePassword", KEYSTORE_PASSWORD);
-        // Force RMI stubs to advertise "localhost" so SSL hostname verification
-        // matches the certificate SAN (dns:localhost) instead of the machine's IP.
-        System.setProperty("java.rmi.server.hostname", "localhost");
 
         context = createSslManagementContext();
         context.start();
@@ -217,11 +211,6 @@ public class ManagementContextSslTest {
         SSLContext.setDefault(testSslContext);
         System.setProperty("javax.net.ssl.trustStore", keystoreFile.toString());
         System.setProperty("javax.net.ssl.trustStorePassword", KEYSTORE_PASSWORD);
-        // Force RMI stubs to advertise "localhost" so SSL hostname verification
-        // matches the certificate SAN (dns:localhost) instead of the machine's actual IP.
-        // RMI normally embeds InetAddress.getLocalHost() in stubs; on a multi-homed
-        // machine this can be an IP not covered by the test certificate.
-        System.setProperty("java.rmi.server.hostname", "localhost");
 
         context = createSslManagementContext();
         context.start();

--- a/activemq-broker/src/test/java/org/apache/activemq/broker/jmx/ManagementContextSslTest.java
+++ b/activemq-broker/src/test/java/org/apache/activemq/broker/jmx/ManagementContextSslTest.java
@@ -76,6 +76,7 @@ public class ManagementContextSslTest {
                 "-keyalg", "RSA",
                 "-keysize", "2048",
                 "-dname", "CN=localhost,O=Test",
+                "-ext", "SAN=dns:localhost,ip:127.0.0.1",
                 "-validity", "1"
         ).inheritIO().start();
         assertEquals("keytool should succeed", 0, p.waitFor());

--- a/activemq-broker/src/test/java/org/apache/activemq/broker/jmx/ManagementContextSslTest.java
+++ b/activemq-broker/src/test/java/org/apache/activemq/broker/jmx/ManagementContextSslTest.java
@@ -61,6 +61,7 @@ public class ManagementContextSslTest {
     private SSLContext savedDefaultSslContext;
     private String savedTrustStore;
     private String savedTrustStorePassword;
+    private String savedRmiHostname;
 
     @BeforeClass
     public static void createKeyStore() throws Exception {
@@ -109,6 +110,7 @@ public class ManagementContextSslTest {
         savedDefaultSslContext = SSLContext.getDefault();
         savedTrustStore = System.getProperty("javax.net.ssl.trustStore");
         savedTrustStorePassword = System.getProperty("javax.net.ssl.trustStorePassword");
+        savedRmiHostname = System.getProperty("java.rmi.server.hostname");
     }
 
     @After
@@ -119,6 +121,7 @@ public class ManagementContextSslTest {
         SSLContext.setDefault(savedDefaultSslContext);
         restoreSystemProperty("javax.net.ssl.trustStore", savedTrustStore);
         restoreSystemProperty("javax.net.ssl.trustStorePassword", savedTrustStorePassword);
+        restoreSystemProperty("java.rmi.server.hostname", savedRmiHostname);
     }
 
     @Test
@@ -192,6 +195,9 @@ public class ManagementContextSslTest {
         SSLContext.setDefault(testSslContext);
         System.setProperty("javax.net.ssl.trustStore", keystoreFile.toString());
         System.setProperty("javax.net.ssl.trustStorePassword", KEYSTORE_PASSWORD);
+        // Force RMI stubs to advertise "localhost" so SSL hostname verification
+        // matches the certificate SAN (dns:localhost) instead of the machine's IP.
+        System.setProperty("java.rmi.server.hostname", "localhost");
 
         context = createSslManagementContext();
         context.start();
@@ -211,6 +217,11 @@ public class ManagementContextSslTest {
         SSLContext.setDefault(testSslContext);
         System.setProperty("javax.net.ssl.trustStore", keystoreFile.toString());
         System.setProperty("javax.net.ssl.trustStorePassword", KEYSTORE_PASSWORD);
+        // Force RMI stubs to advertise "localhost" so SSL hostname verification
+        // matches the certificate SAN (dns:localhost) instead of the machine's actual IP.
+        // RMI normally embeds InetAddress.getLocalHost() in stubs; on a multi-homed
+        // machine this can be an IP not covered by the test certificate.
+        System.setProperty("java.rmi.server.hostname", "localhost");
 
         context = createSslManagementContext();
         context.start();


### PR DESCRIPTION
Thoughts on reusing the SSL Context to configure the SSL connector for JMX to avoid duplication of configuration and allow Jasypt to cipher passwords.

