### PR TITLE
[#1733] Fix race condition in async exception handling by combining JMS ExceptionListener and TransportListener notifications

### DIFF
--- a/activemq-client/src/main/java/org/apache/activemq/ActiveMQConnection.java
+++ b/activemq-client/src/main/java/org/apache/activemq/ActiveMQConnection.java
@@ -2029,65 +2029,58 @@ public class ActiveMQConnection implements Connection, TopicConnection, QueueCon
      * @param error
      */
     public void onAsyncException(Throwable error) {
-        if (this.exceptionListener != null) {
-            if (!(error instanceof JMSException)) {
-                error = JMSExceptionSupport.create(error);
-            }
-            final JMSException e = (JMSException) error;
-            // Submit directly to executor bypassing closed/closing guards
-            // to ensure exception notifications are never silently dropped
-            try {
-                executor.execute(() -> exceptionListener.onException(e));
-            } catch (final RejectedExecutionException re) {
-                LOG.debug("Could not notify exception listener asynchronously (executor terminated), notifying inline: {}", error.getMessage());
-                try {
-                    exceptionListener.onException(e);
-                } catch (final Exception ex) {
-                    LOG.debug("Exception during inline ExceptionListener notification", ex);
+        if (!closed.get() && !closing.get()) {
+            if (this.exceptionListener != null) {
+                if (!(error instanceof JMSException)) {
+                    error = JMSExceptionSupport.create(error);
                 }
+                final JMSException e = (JMSException) error;
+                try {
+                    executor.execute(() -> exceptionListener.onException(e));
+                } catch (final RejectedExecutionException re) {
+                    LOG.debug("Could not notify exception listener asynchronously (executor terminated): {}", error.getMessage());
+                }
+            } else {
+                LOG.debug("Async exception with no exception listener: {}", error, error);
             }
-        } else {
-            LOG.debug("Async exception with no exception listener: {}", error, error);
         }
     }
 
     @Override
     public void onException(final IOException error) {
-        // Combine JMS ExceptionListener and TransportListener notifications
-        // into a single async task to prevent a race condition where the
-        // ExceptionListener (e.g. ConnectionPool) closes the connection and
-        // shuts down the executor before the TransportListener task is queued.
-        final Runnable exceptionTask = () -> {
-            // Notify JMS ExceptionListener first (same as onAsyncException)
-            if (exceptionListener != null) {
-                try {
-                    final JMSException jmsError = JMSExceptionSupport.create(error);
-                    exceptionListener.onException(jmsError);
-                } catch (final Exception e) {
-                    LOG.debug("Exception during JMS ExceptionListener notification", e);
+        if (!closed.get() && !closing.get()) {
+            // Combine JMS ExceptionListener and TransportListener notifications into a single
+            // async task to prevent a race condition where the ExceptionListener (e.g.
+            // ConnectionPool) closes the connection and shuts down the executor before the
+            // TransportListener task can be queued.
+            final Runnable exceptionTask = () -> {
+                if (exceptionListener != null) {
+                    try {
+                        final JMSException jmsError = JMSExceptionSupport.create(error);
+                        exceptionListener.onException(jmsError);
+                    } catch (final Exception e) {
+                        LOG.debug("Exception during JMS ExceptionListener notification", e);
+                    }
                 }
-            }
 
-            transportFailed(error);
-            ServiceSupport.dispose(ActiveMQConnection.this.transport);
-            brokerInfoReceived.countDown();
+                transportFailed(error);
+                ServiceSupport.dispose(ActiveMQConnection.this.transport);
+                brokerInfoReceived.countDown();
+                try {
+                    doCleanup(true);
+                } catch (JMSException e) {
+                    LOG.warn("Exception during connection cleanup, " + e, e);
+                }
+                for (final TransportListener listener : transportListeners) {
+                    listener.onException(error);
+                }
+            };
+
             try {
-                doCleanup(true);
-            } catch (JMSException e) {
-                LOG.warn("Exception during connection cleanup, " + e, e);
+                executor.execute(exceptionTask);
+            } catch (final RejectedExecutionException e) {
+                LOG.debug("Could not execute exception task (executor terminated, connection closing)");
             }
-            for (final TransportListener listener : transportListeners) {
-                listener.onException(error);
-            }
-        };
-
-        // Submit directly to executor bypassing closed/closing guards
-        // to ensure transport failure handling is never silently dropped
-        try {
-            executor.execute(exceptionTask);
-        } catch (final RejectedExecutionException e) {
-            LOG.debug("Could not execute exception task asynchronously (executor terminated), executing inline");
-            exceptionTask.run();
         }
     }
 


### PR DESCRIPTION
I'm not quite sure if it's possible or not, but looks like there is a race condition where the transport failed listener is invoked before the exception listener. The test requires the exception listener to be invoked first so they need to be invoked sequentially withing the same runnable.