### PR TITLE
Proper Appender lifecycle to assert log messages

### DIFF
--- a/activemq-broker/src/test/java/org/apache/activemq/util/DefaultTestAppender.java
+++ b/activemq-broker/src/test/java/org/apache/activemq/util/DefaultTestAppender.java
@@ -23,7 +23,8 @@ import org.apache.logging.log4j.core.Layout;
 import org.apache.logging.log4j.core.LogEvent;
 
 public abstract class DefaultTestAppender implements Appender {
-    
+
+    private volatile boolean started = false;
     String name = this.getClass().getSimpleName();
 
     @Override
@@ -68,21 +69,21 @@ public abstract class DefaultTestAppender implements Appender {
 
     @Override
     public void start() {
-
+        started = true;
     }
 
     @Override
     public void stop() {
-
+        started = false;
     }
 
     @Override
     public boolean isStarted() {
-        return false;
+        return started;
     }
 
     @Override
     public boolean isStopped() {
-        return false;
+        return !started;
     }
 }

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/ProducerFlowControlTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/ProducerFlowControlTest.java
@@ -34,6 +34,7 @@ import org.apache.activemq.broker.region.policy.VMPendingSubscriberMessageStorag
 import org.apache.activemq.command.ActiveMQQueue;
 import org.apache.activemq.transport.tcp.TcpTransport;
 import org.apache.activemq.util.DefaultTestAppender;
+import org.apache.activemq.util.Wait;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.Appender;
@@ -285,6 +286,9 @@ public class ProducerFlowControlTest extends JmsTestSupport {
             connection.start();
 
             fillQueue(queueB);
+            // Wait for the warning to be logged - there's a small delay between
+            // the producer being blocked and the Log4j appender processing the event
+            assertTrue("Warning should be logged", Wait.waitFor(() -> warnings.get() >= 1, TimeUnit.SECONDS.toMillis(5), 100));
             assertEquals(1, warnings.get());
 
             broker.getDestinationPolicy().getDefaultEntry().setBlockedProducerWarningInterval(0);


### PR DESCRIPTION
I already fixed one test last month that was not overriding the isStarted() method and now Log4j ignores the appender if that returns false