### PR TITLE
Fix copy-paste bug in MessageGroupLateArrivalsTest assertion

### DIFF
--- a/activemq-unit-tests/src/test/java/org/apache/activemq/usecases/MessageGroupLateArrivalsTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/usecases/MessageGroupLateArrivalsTest.java
@@ -217,7 +217,7 @@ public class MessageGroupLateArrivalsTest {
 
         log.info("worker2  received " + messageCount.get("worker2") + " messages from groups " + messageGroups.get("worker2"));
         assertEquals("worker2 received " + messageCount.get("worker2") + " messages from groups " + messageGroups.get("worker2")
-                , 2 * perBatch, messageCount.get("worker1").intValue());
+                , perBatch, messageCount.get("worker2").intValue());
         assertEquals("worker2 received " + messageCount.get("worker2") + " messages from groups " + messageGroups.get("worker2")
                 , 1, messageGroups.get("worker2").size());
     }


### PR DESCRIPTION
testConsumerLateToBigPartyGetsNewGroup had two errors on line 220:
   1. Checked messageCount.get("worker1") instead of "worker2"
   2. Expected 2*perBatch (4) instead of perBatch (2)