### PR TITLE
Remove unnecessary test profiles from pom.xml and consolidate performance/load test exclusions

### DIFF
--- a/activemq-unit-tests/pom.xml
+++ b/activemq-unit-tests/pom.xml
@@ -575,30 +575,6 @@
   </build>
   <profiles>
     <profile>
-      <id>activemq.tests-all</id>
-      <activation>
-        <property>
-          <name>activemq.tests</name>
-          <value>all</value>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-              <excludes combine.children="append">
-                <!-- These are performance tests and take too long to run -->
-                <exclude>**/perf/*</exclude>
-                <!-- These are load tests and take too long to run -->
-                <exclude>**/load/*</exclude>
-              </excludes>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
       <id>activemq.tests-sanity</id>
       <activation>
         <property>

--- a/pom.xml
+++ b/pom.xml
@@ -979,6 +979,12 @@
                 <org.apache.activemq.kahaDB.files.skipMetadataUpdate>true</org.apache.activemq.kahaDB.files.skipMetadataUpdate>
             </systemPropertyVariables>
             <argLine>-enableassertions ${surefire.argLine} ${maven.surefire.allow.securitymanager}</argLine>
+
+            <!-- These are performance/load tests and take too long to run -->
+            <excludes combine.children="append">
+              <exclude>**/perf/*</exclude>
+              <exclude>**/load/*</exclude>
+            </excludes>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
There is no point in adding this inside a profile. We have enough profiles for the moment already