### PR TITLE
Protect the active branches

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -45,6 +45,20 @@ github:
         require_last_push_approval: false
         required_approving_review_count: 1
       required_linear_history: true
+    activemq-6.2.x:
+      required_pull_request_reviews:
+        require_code_owner_reviews: false
+        dismiss_stale_reviews: true
+        require_last_push_approval: false
+        required_approving_review_count: 0
+      required_linear_history: true
+    activemq-5.19.x:
+      required_pull_request_reviews:
+        require_code_owner_reviews: false
+        dismiss_stale_reviews: true
+        require_last_push_approval: false
+        required_approving_review_count: 0
+      required_linear_history: true
 
   features:
     wiki: false


### PR DESCRIPTION
The purpose of this PR is to protect our active branches (`activemq-6.2.x` and `activemq-5.19.x` as today):
- It's not allowed anymore to push directly on the branches. PR is required to change all branches.
- However, no review is necessary on the `activemq-6.2.x` and `activemq-5.19.x` (review should have happened on the `main` branch).