### PR TITLE
Improve exception context in BrokerService preDestroy

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/broker/BrokerService.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/BrokerService.java
@@ -788,7 +788,7 @@ public class BrokerService implements Service {
         try {
             stop();
         } catch (Exception ex) {
-            throw new RuntimeException();
+            throw new RuntimeException("Exception during broker preDestroy cleanup: " + getBrokerName(), ex);
         }
     }
 


### PR DESCRIPTION
preDestroy() executes shutdown cleanup; this message avoids incorrectly implying that broker stop itself failed.