### PR TITLE
AMQP: added transport factory unit tests for mutex stripping and monitor wiring.

### DIFF
--- a/activemq-amqp/src/test/java/org/apache/activemq/transport/amqp/AmqpTransportFactoryConfigurationTest.java
+++ b/activemq-amqp/src/test/java/org/apache/activemq/transport/amqp/AmqpTransportFactoryConfigurationTest.java
@@ -1,3 +1,19 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.activemq.transport.amqp;
 
 import static org.junit.Assert.assertEquals;


### PR DESCRIPTION
This PR adds focused unit coverage for AMQP transport factories to validate configuration behaviour. 

Added test:
AmqpTransportFactoryConfigurationTest.java

Factories covered:
- AmqpTransportFactory
- AmqpSslTransportFactory
- AmqpNioTransportFactory
- AmqpNioSslTransportFactory

What is verified:
- serverConfigure(...) strips broker-side MutexTransport
- compositeConfigure(...) applies AMQP and wireFormat.* properties (transformer, producerCredit, maxFrameSize, connectAttemptTimeout)
- inactivity monitor wiring is correct (AmqpInactivityMonitor is present in the transport chain and the same monitor instance is set on AmqpTransportFilter)