### PR TITLE
fix(test): fix MQTTTest#testReceiveMessageSentWhileOffline flakiness

### DIFF
--- a/activemq-mqtt/src/test/java/org/apache/activemq/transport/mqtt/MQTTTest.java
+++ b/activemq-mqtt/src/test/java/org/apache/activemq/transport/mqtt/MQTTTest.java
@@ -1696,7 +1696,7 @@ public class MQTTTest extends MQTTTestSupport {
             // ConsumerInfo asynchronously, so messages may not be ready for dispatch yet.
             assertTrue("Subscription should become active in run " + (j + 1),
                     Wait.waitFor(() -> isSubscriptionActive(topics[0], mqttSub.getClientId().toString()),
-                            TimeUnit.SECONDS.toMillis(15), 100));
+                            TimeUnit.SECONDS.toMillis(30), 100));
 
             for (int i = 0; i < messagesPerRun; ++i) {
                 Message message = connectionSub.receive(5, TimeUnit.SECONDS);


### PR DESCRIPTION
`subscribe()` returns on `SUBACK` but the broker processes `ConsumerInfo` asynchronously, so the durable subscription may not be fully reactivated when `receive()` is called. Add `Wait.waitFor` on `isSubscriptionActive()` after subscribe to ensure the broker has activated the subscription before attempting to receive queued messages.

Also remove the try/catch that silently swallowed assertion failures mid-loop, which masked the real failure with a misleading count mismatch.