### PR TITLE
fix(broker): improve error message for RMI registry creation failure

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/broker/jmx/ManagementContext.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/jmx/ManagementContext.java
@@ -567,9 +567,9 @@ public class ManagementContext implements Service {
             Attribute attr = new Attribute("Port", connectorPort);
             mbeanServer.setAttribute(namingServiceObjectName, attr);
         } catch(ClassNotFoundException e) {
-            LOG.debug("Probably not using JRE 1.4: {}", e.getLocalizedMessage());
+            LOG.warn("Probably not using JRE 1.4: {}", e.getLocalizedMessage());
         } catch (Throwable e) {
-            LOG.debug("Failed to create local RMI registry on port {}. This may happen when another process or broker instance "
+            LOG.warn("Failed to create local RMI registry on port {}. This may happen when another process or broker instance "
                     + "is already using the port. To resolve, either change the connectorPort in your managementContext configuration "
                     + "or set createConnector=\"false\" if remote JMX access is not required. This exception will be ignored.", connectorPort, e);
         }


### PR DESCRIPTION
Include the port number and actionable guidance in the debug log when creating the local RMI registry fails, so operators can quickly diagnose and resolve the issue.

This error usually happens if another process is using the Management Connector port. The purpose is to improve the message for the users.