### PR TITLE
fix(test): set queue prefetch in UsageBlockedDispatchTest to prevent flaky failure

### DIFF
--- a/activemq-unit-tests/src/test/java/org/apache/activemq/usecases/UsageBlockedDispatchTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/usecases/UsageBlockedDispatchTest.java
@@ -100,6 +100,7 @@ public class UsageBlockedDispatchTest extends TestSupport {
         ActiveMQConnectionFactory factory = new ActiveMQConnectionFactory(connectionUri);
         ActiveMQPrefetchPolicy prefetch = new ActiveMQPrefetchPolicy();
         prefetch.setTopicPrefetch(10);
+        prefetch.setQueuePrefetch(1);
         factory.setPrefetchPolicy(prefetch);
 
         final Connection producerConnection = factory.createConnection();


### PR DESCRIPTION
The test only set topicPrefetch but uses queues, leaving the default queue prefetch at 1000. This caused the broker to dispatch many messages to the consumer's prefetch buffer, freeing enough memory to unblock the cursor and fail the assertNull check on line 166.