### PR TITLE
feat(otel): Add OpenTelemetry distributed tracing support

### DIFF
--- a/activemq-opentelemetry/pom.xml
+++ b/activemq-opentelemetry/pom.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.activemq</groupId>
+        <artifactId>activemq-parent</artifactId>
+        <version>6.3.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>activemq-opentelemetry</artifactId>
+    <packaging>bundle</packaging>
+    <name>ActiveMQ :: OpenTelemetry</name>
+    <description>ActiveMQ OpenTelemetry tracing support</description>
+
+    <dependencies>
+
+        <!-- =============================== -->
+        <!-- Required Dependencies -->
+        <!-- =============================== -->
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>activemq-broker</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-context</artifactId>
+        </dependency>
+
+        <!-- =============================== -->
+        <!-- Testing Dependencies            -->
+        <!-- =============================== -->
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>activemq-kahadb-store</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>activemq-broker</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>org.apache.activemq.opentelemetry</Bundle-SymbolicName>
+                        <Export-Package>org.apache.activemq.broker.util.opentelemetry*;version=${project.version};-noimport:=true;-split-package:=merge-first</Export-Package>
+                        <Import-Package>
+                            org.apache.activemq*;version=${project.version};resolution:=optional,
+                            io.opentelemetry.*;resolution:=optional,
+                            *
+                        </Import-Package>
+                        <_noee>true</_noee>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/activemq-opentelemetry/src/main/java/org/apache/activemq/broker/util/opentelemetry/ActiveMQMessageTextMapGetter.java
+++ b/activemq-opentelemetry/src/main/java/org/apache/activemq/broker/util/opentelemetry/ActiveMQMessageTextMapGetter.java
@@ -1,0 +1,53 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.broker.util.opentelemetry;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import io.opentelemetry.context.propagation.TextMapGetter;
+import org.apache.activemq.command.Message;
+
+public class ActiveMQMessageTextMapGetter implements TextMapGetter<Message> {
+
+    public static final ActiveMQMessageTextMapGetter INSTANCE = new ActiveMQMessageTextMapGetter();
+
+    @Override
+    public Iterable<String> keys(Message message) {
+        try {
+            if (message.getProperties() != null) {
+                return message.getProperties().keySet();
+            }
+        } catch (IOException e) {
+            // ignore
+        }
+        return Collections.emptyList();
+    }
+
+    @Override
+    public String get(Message message, String key) {
+        try {
+            Object value = message.getProperty(key);
+            if (value instanceof String) {
+                return (String) value;
+            }
+        } catch (IOException e) {
+            // ignore
+        }
+        return null;
+    }
+}

--- a/activemq-opentelemetry/src/main/java/org/apache/activemq/broker/util/opentelemetry/ActiveMQMessageTextMapSetter.java
+++ b/activemq-opentelemetry/src/main/java/org/apache/activemq/broker/util/opentelemetry/ActiveMQMessageTextMapSetter.java
@@ -1,0 +1,41 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.broker.util.opentelemetry;
+
+import java.io.IOException;
+
+import io.opentelemetry.context.propagation.TextMapSetter;
+import org.apache.activemq.command.Message;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ActiveMQMessageTextMapSetter implements TextMapSetter<Message> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ActiveMQMessageTextMapSetter.class);
+
+    public static final ActiveMQMessageTextMapSetter INSTANCE = new ActiveMQMessageTextMapSetter();
+
+    @Override
+    public void set(Message message, String key, String value) {
+        try {
+            message.setProperty(key, value);
+            message.setMarshalledProperties(null);
+        } catch (IOException e) {
+            LOG.warn("Failed to set trace context property '{}' on message", key, e);
+        }
+    }
+}

--- a/activemq-opentelemetry/src/main/java/org/apache/activemq/broker/util/opentelemetry/ActiveMQMessageTextMapSetter.java
+++ b/activemq-opentelemetry/src/main/java/org/apache/activemq/broker/util/opentelemetry/ActiveMQMessageTextMapSetter.java
@@ -33,6 +33,7 @@ public class ActiveMQMessageTextMapSetter implements TextMapSetter<Message> {
     public void set(Message message, String key, String value) {
         try {
             message.setProperty(key, value);
+            // Clear the cached marshalled form so the injected property is included on next serialization.
             message.setMarshalledProperties(null);
         } catch (IOException e) {
             LOG.warn("Failed to set trace context property '{}' on message", key, e);

--- a/activemq-opentelemetry/src/main/java/org/apache/activemq/broker/util/opentelemetry/OpenTelemetryBrokerPlugin.java
+++ b/activemq-opentelemetry/src/main/java/org/apache/activemq/broker/util/opentelemetry/OpenTelemetryBrokerPlugin.java
@@ -1,0 +1,202 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.broker.util.opentelemetry;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanBuilder;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.propagation.TextMapPropagator;
+import org.apache.activemq.broker.BrokerPluginSupport;
+import org.apache.activemq.broker.ConsumerBrokerExchange;
+import org.apache.activemq.broker.ProducerBrokerExchange;
+import org.apache.activemq.command.Message;
+import org.apache.activemq.command.MessageAck;
+import org.apache.activemq.command.MessageDispatch;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A broker plugin that provides OpenTelemetry distributed tracing support.
+ * Traces message send, dispatch, and acknowledge operations with proper
+ * context propagation via W3C TraceContext.
+ *
+ * @org.apache.xbean.XBean element="openTelemetryPlugin"
+ */
+public class OpenTelemetryBrokerPlugin extends BrokerPluginSupport {
+
+    private static final Logger LOG = LoggerFactory.getLogger(OpenTelemetryBrokerPlugin.class);
+    private static final String INSTRUMENTATION_NAME = "org.apache.activemq";
+
+    private boolean traceProducer = true;
+    private boolean traceConsumer = true;
+    private boolean traceAcknowledge = true;
+
+    private final ConcurrentHashMap<MessageDispatch, Span> dispatchSpans = new ConcurrentHashMap<>();
+
+    public boolean isTraceProducer() {
+        return traceProducer;
+    }
+
+    public void setTraceProducer(boolean traceProducer) {
+        this.traceProducer = traceProducer;
+    }
+
+    public boolean isTraceConsumer() {
+        return traceConsumer;
+    }
+
+    public void setTraceConsumer(boolean traceConsumer) {
+        this.traceConsumer = traceConsumer;
+    }
+
+    public boolean isTraceAcknowledge() {
+        return traceAcknowledge;
+    }
+
+    public void setTraceAcknowledge(boolean traceAcknowledge) {
+        this.traceAcknowledge = traceAcknowledge;
+    }
+
+    @Override
+    public void send(ProducerBrokerExchange producerExchange, Message messageSend) throws Exception {
+        if (!traceProducer) {
+            super.send(producerExchange, messageSend);
+            return;
+        }
+
+        TextMapPropagator propagator = GlobalOpenTelemetry.getPropagators().getTextMapPropagator();
+        Tracer tracer = GlobalOpenTelemetry.getTracer(INSTRUMENTATION_NAME);
+
+        // Extract any existing context from the message (e.g., set by client)
+        Context parentContext = propagator.extract(Context.current(), messageSend, ActiveMQMessageTextMapGetter.INSTANCE);
+
+        String destinationName = messageSend.getDestination().getPhysicalName();
+        SpanBuilder spanBuilder = tracer.spanBuilder(destinationName + " publish")
+                .setSpanKind(SpanKind.PRODUCER)
+                .setParent(parentContext)
+                .setAttribute("messaging.system", "activemq")
+                .setAttribute("messaging.destination.name", destinationName)
+                .setAttribute("messaging.operation", "publish");
+
+        if (messageSend.getMessageId() != null) {
+            spanBuilder.setAttribute("messaging.message.id", messageSend.getMessageId().toString());
+        }
+        if (producerExchange.getConnectionContext() != null
+                && producerExchange.getConnectionContext().getClientId() != null) {
+            spanBuilder.setAttribute("messaging.client_id", producerExchange.getConnectionContext().getClientId());
+        }
+
+        Span span = spanBuilder.startSpan();
+        try {
+            // Inject trace context into the message for downstream propagation
+            Context contextWithSpan = parentContext.with(span);
+            propagator.inject(contextWithSpan, messageSend, ActiveMQMessageTextMapSetter.INSTANCE);
+
+            super.send(producerExchange, messageSend);
+        } catch (Exception e) {
+            span.setStatus(StatusCode.ERROR, e.getMessage());
+            span.recordException(e);
+            throw e;
+        } finally {
+            span.end();
+        }
+    }
+
+    @Override
+    public void preProcessDispatch(MessageDispatch messageDispatch) {
+        if (traceConsumer && messageDispatch != null && messageDispatch.getMessage() != null) {
+            try {
+                TextMapPropagator propagator = GlobalOpenTelemetry.getPropagators().getTextMapPropagator();
+                Tracer tracer = GlobalOpenTelemetry.getTracer(INSTRUMENTATION_NAME);
+
+                Message message = messageDispatch.getMessage();
+                Context extractedContext = propagator.extract(Context.current(), message, ActiveMQMessageTextMapGetter.INSTANCE);
+
+                String destinationName = message.getDestination().getPhysicalName();
+                SpanBuilder spanBuilder = tracer.spanBuilder(destinationName + " deliver")
+                        .setSpanKind(SpanKind.CONSUMER)
+                        .setParent(extractedContext)
+                        .setAttribute("messaging.system", "activemq")
+                        .setAttribute("messaging.destination.name", destinationName)
+                        .setAttribute("messaging.operation", "deliver");
+
+                if (message.getMessageId() != null) {
+                    spanBuilder.setAttribute("messaging.message.id", message.getMessageId().toString());
+                }
+
+                Span span = spanBuilder.startSpan();
+                dispatchSpans.put(messageDispatch, span);
+            } catch (Exception e) {
+                LOG.warn("Failed to create deliver span", e);
+            }
+        }
+        super.preProcessDispatch(messageDispatch);
+    }
+
+    @Override
+    public void postProcessDispatch(MessageDispatch messageDispatch) {
+        if (messageDispatch != null) {
+            Span span = dispatchSpans.remove(messageDispatch);
+            if (span != null) {
+                span.end();
+            }
+        }
+        super.postProcessDispatch(messageDispatch);
+    }
+
+    @Override
+    public void acknowledge(ConsumerBrokerExchange consumerExchange, MessageAck ack) throws Exception {
+        if (!traceAcknowledge) {
+            super.acknowledge(consumerExchange, ack);
+            return;
+        }
+
+        Tracer tracer = GlobalOpenTelemetry.getTracer(INSTRUMENTATION_NAME);
+
+        String destinationName = ack.getDestination() != null ? ack.getDestination().getPhysicalName() : "unknown";
+        SpanBuilder spanBuilder = tracer.spanBuilder(destinationName + " ack")
+                .setSpanKind(SpanKind.INTERNAL)
+                .setAttribute("messaging.system", "activemq")
+                .setAttribute("messaging.destination.name", destinationName)
+                .setAttribute("messaging.operation", "ack");
+
+        if (ack.getLastMessageId() != null) {
+            spanBuilder.setAttribute("messaging.message.id", ack.getLastMessageId().toString());
+        }
+        if (consumerExchange.getConnectionContext() != null
+                && consumerExchange.getConnectionContext().getClientId() != null) {
+            spanBuilder.setAttribute("messaging.client_id", consumerExchange.getConnectionContext().getClientId());
+        }
+
+        Span span = spanBuilder.startSpan();
+        try {
+            super.acknowledge(consumerExchange, ack);
+        } catch (Exception e) {
+            span.setStatus(StatusCode.ERROR, e.getMessage());
+            span.recordException(e);
+            throw e;
+        } finally {
+            span.end();
+        }
+    }
+}

--- a/activemq-opentelemetry/src/main/java/org/apache/activemq/broker/util/opentelemetry/OpenTelemetryBrokerPlugin.java
+++ b/activemq-opentelemetry/src/main/java/org/apache/activemq/broker/util/opentelemetry/OpenTelemetryBrokerPlugin.java
@@ -16,7 +16,9 @@
  */
 package org.apache.activemq.broker.util.opentelemetry;
 
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.trace.Span;
@@ -40,6 +42,9 @@ import org.slf4j.LoggerFactory;
  * Traces message send, dispatch, and acknowledge operations with proper
  * context propagation via W3C TraceContext.
  *
+ * <p>For topic destinations, each subscriber dispatch creates its own span,
+ * so a single published message may produce multiple deliver spans.
+ *
  * @org.apache.xbean.XBean element="openTelemetryPlugin"
  */
 public class OpenTelemetryBrokerPlugin extends BrokerPluginSupport {
@@ -47,11 +52,34 @@ public class OpenTelemetryBrokerPlugin extends BrokerPluginSupport {
     private static final Logger LOG = LoggerFactory.getLogger(OpenTelemetryBrokerPlugin.class);
     private static final String INSTRUMENTATION_NAME = "org.apache.activemq";
 
+    // Cap in-flight dispatch spans to avoid unbounded growth when postProcessDispatch is missed.
+    // The eldest entry is ended and evicted if this limit is exceeded.
+    private static final int MAX_DISPATCH_SPANS = 1000;
+
     private boolean traceProducer = true;
     private boolean traceConsumer = true;
     private boolean traceAcknowledge = true;
 
-    private final ConcurrentHashMap<MessageDispatch, Span> dispatchSpans = new ConcurrentHashMap<>();
+    private final TextMapPropagator propagator;
+    private final Tracer tracer;
+
+    private final Map<MessageDispatch, Span> dispatchSpans = Collections.synchronizedMap(
+            new LinkedHashMap<MessageDispatch, Span>(256, 0.75f, false) {
+                @Override
+                protected boolean removeEldestEntry(Map.Entry<MessageDispatch, Span> eldest) {
+                    if (size() > MAX_DISPATCH_SPANS) {
+                        LOG.warn("dispatchSpans exceeded max size; ending oldest span to prevent leak");
+                        eldest.getValue().end();
+                        return true;
+                    }
+                    return false;
+                }
+            });
+
+    public OpenTelemetryBrokerPlugin() {
+        this.propagator = GlobalOpenTelemetry.getPropagators().getTextMapPropagator();
+        this.tracer = GlobalOpenTelemetry.getTracer(INSTRUMENTATION_NAME);
+    }
 
     public boolean isTraceProducer() {
         return traceProducer;
@@ -84,31 +112,26 @@ public class OpenTelemetryBrokerPlugin extends BrokerPluginSupport {
             return;
         }
 
-        TextMapPropagator propagator = GlobalOpenTelemetry.getPropagators().getTextMapPropagator();
-        Tracer tracer = GlobalOpenTelemetry.getTracer(INSTRUMENTATION_NAME);
-
-        // Extract any existing context from the message (e.g., set by client)
         Context parentContext = propagator.extract(Context.current(), messageSend, ActiveMQMessageTextMapGetter.INSTANCE);
 
         String destinationName = messageSend.getDestination().getPhysicalName();
         SpanBuilder spanBuilder = tracer.spanBuilder(destinationName + " publish")
                 .setSpanKind(SpanKind.PRODUCER)
                 .setParent(parentContext)
-                .setAttribute("messaging.system", "activemq")
+                .setAttribute("messaging.system.name", "activemq")
                 .setAttribute("messaging.destination.name", destinationName)
-                .setAttribute("messaging.operation", "publish");
+                .setAttribute("messaging.operation.type", "publish");
 
         if (messageSend.getMessageId() != null) {
             spanBuilder.setAttribute("messaging.message.id", messageSend.getMessageId().toString());
         }
         if (producerExchange.getConnectionContext() != null
                 && producerExchange.getConnectionContext().getClientId() != null) {
-            spanBuilder.setAttribute("messaging.client_id", producerExchange.getConnectionContext().getClientId());
+            spanBuilder.setAttribute("messaging.client.id", producerExchange.getConnectionContext().getClientId());
         }
 
         Span span = spanBuilder.startSpan();
         try {
-            // Inject trace context into the message for downstream propagation
             Context contextWithSpan = parentContext.with(span);
             propagator.inject(contextWithSpan, messageSend, ActiveMQMessageTextMapSetter.INSTANCE);
 
@@ -126,9 +149,6 @@ public class OpenTelemetryBrokerPlugin extends BrokerPluginSupport {
     public void preProcessDispatch(MessageDispatch messageDispatch) {
         if (traceConsumer && messageDispatch != null && messageDispatch.getMessage() != null) {
             try {
-                TextMapPropagator propagator = GlobalOpenTelemetry.getPropagators().getTextMapPropagator();
-                Tracer tracer = GlobalOpenTelemetry.getTracer(INSTRUMENTATION_NAME);
-
                 Message message = messageDispatch.getMessage();
                 Context extractedContext = propagator.extract(Context.current(), message, ActiveMQMessageTextMapGetter.INSTANCE);
 
@@ -136,9 +156,9 @@ public class OpenTelemetryBrokerPlugin extends BrokerPluginSupport {
                 SpanBuilder spanBuilder = tracer.spanBuilder(destinationName + " deliver")
                         .setSpanKind(SpanKind.CONSUMER)
                         .setParent(extractedContext)
-                        .setAttribute("messaging.system", "activemq")
+                        .setAttribute("messaging.system.name", "activemq")
                         .setAttribute("messaging.destination.name", destinationName)
-                        .setAttribute("messaging.operation", "deliver");
+                        .setAttribute("messaging.operation.type", "deliver");
 
                 if (message.getMessageId() != null) {
                     spanBuilder.setAttribute("messaging.message.id", message.getMessageId().toString());
@@ -171,21 +191,19 @@ public class OpenTelemetryBrokerPlugin extends BrokerPluginSupport {
             return;
         }
 
-        Tracer tracer = GlobalOpenTelemetry.getTracer(INSTRUMENTATION_NAME);
-
         String destinationName = ack.getDestination() != null ? ack.getDestination().getPhysicalName() : "unknown";
         SpanBuilder spanBuilder = tracer.spanBuilder(destinationName + " ack")
                 .setSpanKind(SpanKind.INTERNAL)
-                .setAttribute("messaging.system", "activemq")
+                .setAttribute("messaging.system.name", "activemq")
                 .setAttribute("messaging.destination.name", destinationName)
-                .setAttribute("messaging.operation", "ack");
+                .setAttribute("messaging.operation.type", "ack");
 
         if (ack.getLastMessageId() != null) {
             spanBuilder.setAttribute("messaging.message.id", ack.getLastMessageId().toString());
         }
         if (consumerExchange.getConnectionContext() != null
                 && consumerExchange.getConnectionContext().getClientId() != null) {
-            spanBuilder.setAttribute("messaging.client_id", consumerExchange.getConnectionContext().getClientId());
+            spanBuilder.setAttribute("messaging.client.id", consumerExchange.getConnectionContext().getClientId());
         }
 
         Span span = spanBuilder.startSpan();

--- a/activemq-opentelemetry/src/test/java/org/apache/activemq/broker/util/opentelemetry/OpenTelemetryBrokerPluginTest.java
+++ b/activemq-opentelemetry/src/test/java/org/apache/activemq/broker/util/opentelemetry/OpenTelemetryBrokerPluginTest.java
@@ -1,0 +1,244 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.broker.util.opentelemetry;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import jakarta.jms.Connection;
+import jakarta.jms.DeliveryMode;
+import jakarta.jms.MessageConsumer;
+import jakarta.jms.MessageProducer;
+import jakarta.jms.Session;
+import jakarta.jms.TextMessage;
+
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
+import io.opentelemetry.context.propagation.ContextPropagators;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import org.apache.activemq.ActiveMQConnectionFactory;
+import org.apache.activemq.broker.BrokerPlugin;
+import org.apache.activemq.broker.BrokerService;
+import org.apache.activemq.broker.TransportConnector;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class OpenTelemetryBrokerPluginTest {
+
+    private BrokerService broker;
+    private TransportConnector connector;
+    private InMemorySpanExporter spanExporter;
+    private Connection connection;
+    private Session session;
+    private final String queueName = "TEST.OTEL";
+
+    @Before
+    public void setUp() throws Exception {
+        GlobalOpenTelemetry.resetForTest();
+
+        spanExporter = InMemorySpanExporter.create();
+        SdkTracerProvider tracerProvider = SdkTracerProvider.builder()
+                .addSpanProcessor(SimpleSpanProcessor.create(spanExporter))
+                .build();
+
+        OpenTelemetrySdk.builder()
+                .setTracerProvider(tracerProvider)
+                .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.getInstance()))
+                .buildAndRegisterGlobal();
+
+        OpenTelemetryBrokerPlugin plugin = new OpenTelemetryBrokerPlugin();
+
+        broker = new BrokerService();
+        broker.setBrokerName("otelTestBroker");
+        broker.setPersistent(false);
+        broker.setUseJmx(false);
+        broker.setPlugins(new BrokerPlugin[]{plugin});
+        connector = broker.addConnector("tcp://localhost:0");
+        broker.start();
+        broker.waitUntilStarted();
+
+        connection = new ActiveMQConnectionFactory(connector.getConnectUri()).createConnection();
+        connection.start();
+        session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (session != null) session.close();
+        if (connection != null) connection.close();
+        if (broker != null) {
+            broker.stop();
+            broker.waitUntilStopped();
+        }
+        GlobalOpenTelemetry.resetForTest();
+    }
+
+    @Test
+    public void testPublishSpanCreatedOnSend() throws Exception {
+        MessageProducer producer = session.createProducer(session.createQueue(queueName));
+        producer.setDeliveryMode(DeliveryMode.NON_PERSISTENT);
+
+        TextMessage message = session.createTextMessage("test");
+        producer.send(message);
+        producer.close();
+
+        // Allow async broker processing to complete
+        Thread.sleep(500);
+
+        List<SpanData> spans = spanExporter.getFinishedSpanItems();
+        assertTrue("Expected at least one span", spans.size() >= 1);
+
+        SpanData publishSpan = findSpan(spans, queueName + " publish");
+        assertNotNull("Publish span should exist", publishSpan);
+        assertEquals(SpanKind.PRODUCER, publishSpan.getKind());
+        assertEquals("activemq", publishSpan.getAttributes().get(io.opentelemetry.api.common.AttributeKey.stringKey("messaging.system")));
+        assertEquals(queueName, publishSpan.getAttributes().get(io.opentelemetry.api.common.AttributeKey.stringKey("messaging.destination.name")));
+        assertEquals("publish", publishSpan.getAttributes().get(io.opentelemetry.api.common.AttributeKey.stringKey("messaging.operation")));
+    }
+
+    @Test
+    public void testTraceContextPropagatedInMessageProperties() throws Exception {
+        MessageProducer producer = session.createProducer(session.createQueue(queueName));
+        producer.setDeliveryMode(DeliveryMode.NON_PERSISTENT);
+
+        TextMessage message = session.createTextMessage("propagation test");
+        producer.send(message);
+        producer.close();
+
+        MessageConsumer consumer = session.createConsumer(session.createQueue(queueName));
+        jakarta.jms.Message received = consumer.receive(5000);
+        assertNotNull("Should receive message", received);
+
+        // The message should have traceparent property injected by the plugin
+        String traceparent = received.getStringProperty("traceparent");
+        assertNotNull("traceparent property should be set", traceparent);
+        assertTrue("traceparent should follow W3C format", traceparent.startsWith("00-"));
+
+        consumer.close();
+    }
+
+    @Test
+    public void testDeliverSpanCreatedOnDispatch() throws Exception {
+        MessageConsumer consumer = session.createConsumer(session.createQueue(queueName));
+
+        MessageProducer producer = session.createProducer(session.createQueue(queueName));
+        producer.setDeliveryMode(DeliveryMode.NON_PERSISTENT);
+        producer.send(session.createTextMessage("deliver test"));
+        producer.close();
+
+        jakarta.jms.Message received = consumer.receive(5000);
+        assertNotNull("Should receive message", received);
+        consumer.close();
+
+        // Allow time for postProcessDispatch
+        Thread.sleep(500);
+
+        List<SpanData> spans = spanExporter.getFinishedSpanItems();
+        SpanData deliverSpan = findSpan(spans, queueName + " deliver");
+        assertNotNull("Deliver span should exist", deliverSpan);
+        assertEquals(SpanKind.CONSUMER, deliverSpan.getKind());
+        assertEquals("activemq", deliverSpan.getAttributes().get(io.opentelemetry.api.common.AttributeKey.stringKey("messaging.system")));
+        assertEquals("deliver", deliverSpan.getAttributes().get(io.opentelemetry.api.common.AttributeKey.stringKey("messaging.operation")));
+    }
+
+    @Test
+    public void testAckSpanCreatedOnAcknowledge() throws Exception {
+        MessageConsumer consumer = session.createConsumer(session.createQueue(queueName));
+
+        MessageProducer producer = session.createProducer(session.createQueue(queueName));
+        producer.setDeliveryMode(DeliveryMode.NON_PERSISTENT);
+        producer.send(session.createTextMessage("ack test"));
+        producer.close();
+
+        jakarta.jms.Message received = consumer.receive(5000);
+        assertNotNull("Should receive message", received);
+        consumer.close();
+
+        // Allow time for ack processing
+        Thread.sleep(500);
+
+        List<SpanData> spans = spanExporter.getFinishedSpanItems();
+        SpanData ackSpan = findSpan(spans, queueName + " ack");
+        assertNotNull("Ack span should exist", ackSpan);
+        assertEquals(SpanKind.INTERNAL, ackSpan.getKind());
+        assertEquals("activemq", ackSpan.getAttributes().get(io.opentelemetry.api.common.AttributeKey.stringKey("messaging.system")));
+        assertEquals("ack", ackSpan.getAttributes().get(io.opentelemetry.api.common.AttributeKey.stringKey("messaging.operation")));
+    }
+
+    @Test
+    public void testDisabledProducerTracing() throws Exception {
+        // Stop and reconfigure with tracing disabled
+        connection.close();
+        broker.stop();
+        broker.waitUntilStopped();
+        spanExporter.reset();
+
+        OpenTelemetryBrokerPlugin plugin = new OpenTelemetryBrokerPlugin();
+        plugin.setTraceProducer(false);
+        plugin.setTraceConsumer(false);
+        plugin.setTraceAcknowledge(false);
+
+        broker = new BrokerService();
+        broker.setBrokerName("otelTestBroker2");
+        broker.setPersistent(false);
+        broker.setUseJmx(false);
+        broker.setPlugins(new BrokerPlugin[]{plugin});
+        connector = broker.addConnector("tcp://localhost:0");
+        broker.start();
+        broker.waitUntilStarted();
+
+        connection = new ActiveMQConnectionFactory(connector.getConnectUri()).createConnection();
+        connection.start();
+        session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+
+        MessageProducer producer = session.createProducer(session.createQueue(queueName));
+        producer.setDeliveryMode(DeliveryMode.NON_PERSISTENT);
+        producer.send(session.createTextMessage("no trace"));
+        producer.close();
+
+        MessageConsumer consumer = session.createConsumer(session.createQueue(queueName));
+        consumer.receive(5000);
+        consumer.close();
+
+        Thread.sleep(500);
+
+        List<SpanData> spans = spanExporter.getFinishedSpanItems();
+        assertFalse("Should have no publish spans when tracing disabled",
+                spans.stream().anyMatch(s -> s.getName().contains("publish")));
+        assertFalse("Should have no deliver spans when tracing disabled",
+                spans.stream().anyMatch(s -> s.getName().contains("deliver")));
+        assertFalse("Should have no ack spans when tracing disabled",
+                spans.stream().anyMatch(s -> s.getName().contains("ack")));
+    }
+
+    private SpanData findSpan(List<SpanData> spans, String name) {
+        return spans.stream()
+                .filter(s -> s.getName().equals(name))
+                .findFirst()
+                .orElse(null);
+    }
+}

--- a/activemq-opentelemetry/src/test/java/org/apache/activemq/broker/util/opentelemetry/OpenTelemetryBrokerPluginTest.java
+++ b/activemq-opentelemetry/src/test/java/org/apache/activemq/broker/util/opentelemetry/OpenTelemetryBrokerPluginTest.java
@@ -43,6 +43,7 @@ import org.apache.activemq.ActiveMQConnectionFactory;
 import org.apache.activemq.broker.BrokerPlugin;
 import org.apache.activemq.broker.BrokerService;
 import org.apache.activemq.broker.TransportConnector;
+import org.apache.activemq.util.Wait;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -106,18 +107,15 @@ public class OpenTelemetryBrokerPluginTest {
         producer.send(message);
         producer.close();
 
-        // Allow async broker processing to complete
-        Thread.sleep(500);
+        assertTrue("Expected at least one span", Wait.waitFor(() -> spanExporter.getFinishedSpanItems().size() >= 1));
 
         List<SpanData> spans = spanExporter.getFinishedSpanItems();
-        assertTrue("Expected at least one span", spans.size() >= 1);
-
         SpanData publishSpan = findSpan(spans, queueName + " publish");
         assertNotNull("Publish span should exist", publishSpan);
         assertEquals(SpanKind.PRODUCER, publishSpan.getKind());
-        assertEquals("activemq", publishSpan.getAttributes().get(io.opentelemetry.api.common.AttributeKey.stringKey("messaging.system")));
+        assertEquals("activemq", publishSpan.getAttributes().get(io.opentelemetry.api.common.AttributeKey.stringKey("messaging.system.name")));
         assertEquals(queueName, publishSpan.getAttributes().get(io.opentelemetry.api.common.AttributeKey.stringKey("messaging.destination.name")));
-        assertEquals("publish", publishSpan.getAttributes().get(io.opentelemetry.api.common.AttributeKey.stringKey("messaging.operation")));
+        assertEquals("publish", publishSpan.getAttributes().get(io.opentelemetry.api.common.AttributeKey.stringKey("messaging.operation.type")));
     }
 
     @Test
@@ -133,7 +131,6 @@ public class OpenTelemetryBrokerPluginTest {
         jakarta.jms.Message received = consumer.receive(5000);
         assertNotNull("Should receive message", received);
 
-        // The message should have traceparent property injected by the plugin
         String traceparent = received.getStringProperty("traceparent");
         assertNotNull("traceparent property should be set", traceparent);
         assertTrue("traceparent should follow W3C format", traceparent.startsWith("00-"));
@@ -154,15 +151,14 @@ public class OpenTelemetryBrokerPluginTest {
         assertNotNull("Should receive message", received);
         consumer.close();
 
-        // Allow time for postProcessDispatch
-        Thread.sleep(500);
+        assertTrue("Expected deliver span", Wait.waitFor(() -> findSpan(spanExporter.getFinishedSpanItems(), queueName + " deliver") != null));
 
         List<SpanData> spans = spanExporter.getFinishedSpanItems();
         SpanData deliverSpan = findSpan(spans, queueName + " deliver");
         assertNotNull("Deliver span should exist", deliverSpan);
         assertEquals(SpanKind.CONSUMER, deliverSpan.getKind());
-        assertEquals("activemq", deliverSpan.getAttributes().get(io.opentelemetry.api.common.AttributeKey.stringKey("messaging.system")));
-        assertEquals("deliver", deliverSpan.getAttributes().get(io.opentelemetry.api.common.AttributeKey.stringKey("messaging.operation")));
+        assertEquals("activemq", deliverSpan.getAttributes().get(io.opentelemetry.api.common.AttributeKey.stringKey("messaging.system.name")));
+        assertEquals("deliver", deliverSpan.getAttributes().get(io.opentelemetry.api.common.AttributeKey.stringKey("messaging.operation.type")));
     }
 
     @Test
@@ -178,20 +174,18 @@ public class OpenTelemetryBrokerPluginTest {
         assertNotNull("Should receive message", received);
         consumer.close();
 
-        // Allow time for ack processing
-        Thread.sleep(500);
+        assertTrue("Expected ack span", Wait.waitFor(() -> findSpan(spanExporter.getFinishedSpanItems(), queueName + " ack") != null));
 
         List<SpanData> spans = spanExporter.getFinishedSpanItems();
         SpanData ackSpan = findSpan(spans, queueName + " ack");
         assertNotNull("Ack span should exist", ackSpan);
         assertEquals(SpanKind.INTERNAL, ackSpan.getKind());
-        assertEquals("activemq", ackSpan.getAttributes().get(io.opentelemetry.api.common.AttributeKey.stringKey("messaging.system")));
-        assertEquals("ack", ackSpan.getAttributes().get(io.opentelemetry.api.common.AttributeKey.stringKey("messaging.operation")));
+        assertEquals("activemq", ackSpan.getAttributes().get(io.opentelemetry.api.common.AttributeKey.stringKey("messaging.system.name")));
+        assertEquals("ack", ackSpan.getAttributes().get(io.opentelemetry.api.common.AttributeKey.stringKey("messaging.operation.type")));
     }
 
     @Test
     public void testDisabledProducerTracing() throws Exception {
-        // Stop and reconfigure with tracing disabled
         connection.close();
         broker.stop();
         broker.waitUntilStopped();
@@ -224,7 +218,8 @@ public class OpenTelemetryBrokerPluginTest {
         consumer.receive(5000);
         consumer.close();
 
-        Thread.sleep(500);
+        // Brief wait then assert nothing was traced
+        Wait.waitFor(() -> false, 500, 100);
 
         List<SpanData> spans = spanExporter.getFinishedSpanItems();
         assertFalse("Should have no publish spans when tracing disabled",

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -138,6 +138,10 @@
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
+      <artifactId>activemq-opentelemetry</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
       <artifactId>activemq-spring</artifactId>
     </dependency>
     <dependency>

--- a/assembly/src/release/conf/activemq.xml
+++ b/assembly/src/release/conf/activemq.xml
@@ -161,6 +161,15 @@
         </systemUsage>
 
         <!--
+            The plugins element can be used to configure broker plugins.
+            For example, to enable OpenTelemetry distributed tracing, uncomment the following:
+
+        <plugins>
+            <openTelemetryPlugin traceProducer="true" traceConsumer="true" traceAcknowledge="true"/>
+        </plugins>
+        -->
+
+        <!--
             The transport connectors expose ActiveMQ over a given protocol to
             clients and other brokers. For more information, see:
 

--- a/assembly/src/release/examples/conf/activemq-opentelemetry.xml
+++ b/assembly/src/release/examples/conf/activemq-opentelemetry.xml
@@ -1,0 +1,120 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<!--
+    ActiveMQ with OpenTelemetry distributed tracing
+
+    This configuration enables OpenTelemetry tracing for the broker.
+    The plugin traces message send, dispatch, and acknowledge operations
+    using the OpenTelemetry API with W3C TraceContext propagation.
+
+    To use this, you need to provide an OpenTelemetry SDK implementation
+    and exporter at runtime (e.g., opentelemetry-sdk, opentelemetry-exporter-otlp).
+
+    You can configure the OpenTelemetry SDK via environment variables:
+      OTEL_SERVICE_NAME=activemq
+      OTEL_TRACES_EXPORTER=otlp
+      OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
+
+    Or via the Java agent:
+      ACTIVEMQ_OPTS="-javaagent:/path/to/opentelemetry-javaagent.jar"
+
+    To run ActiveMQ with this configuration:
+      $ bin/activemq console xbean:examples/conf/activemq-opentelemetry.xml
+-->
+<beans
+  xmlns="http://www.springframework.org/schema/beans"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+  http://activemq.apache.org/schema/core http://activemq.apache.org/schema/core/activemq-core.xsd">
+
+    <!-- Allows us to use system properties as variables in this configuration file -->
+    <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
+        <property name="locations">
+            <value>file:${activemq.conf}/credentials.properties</value>
+        </property>
+    </bean>
+
+    <broker xmlns="http://activemq.apache.org/schema/core" brokerName="localhost" dataDirectory="${activemq.data}">
+
+        <destinationPolicy>
+            <policyMap>
+              <policyEntries>
+                <policyEntry topic=">" >
+                  <pendingMessageLimitStrategy>
+                    <constantPendingMessageLimitStrategy limit="1000"/>
+                  </pendingMessageLimitStrategy>
+                </policyEntry>
+              </policyEntries>
+            </policyMap>
+        </destinationPolicy>
+
+        <!--
+            OpenTelemetry tracing plugin.
+
+            Attributes:
+              traceProducer    - trace message send operations (default: true)
+              traceConsumer    - trace message dispatch/deliver operations (default: true)
+              traceAcknowledge - trace message acknowledgment operations (default: true)
+
+            Span details:
+              send()               -> "{destination} publish"  (PRODUCER span)
+              preProcessDispatch() -> "{destination} deliver"  (CONSUMER span)
+              acknowledge()        -> "{destination} ack"      (INTERNAL span)
+
+            Each span includes standard OTel messaging attributes:
+              messaging.system, messaging.destination.name, messaging.operation,
+              messaging.message.id, messaging.client_id
+        -->
+        <plugins>
+            <openTelemetryPlugin traceProducer="true" traceConsumer="true" traceAcknowledge="true"/>
+        </plugins>
+
+        <persistenceAdapter>
+            <kahaDB directory="${activemq.data}/kahadb"/>
+        </persistenceAdapter>
+
+        <systemUsage>
+            <systemUsage>
+                <memoryUsage>
+                    <memoryUsage percentOfJvmHeap="70" />
+                </memoryUsage>
+                <storeUsage>
+                    <storeUsage limit="100 gb"/>
+                </storeUsage>
+                <tempUsage>
+                    <tempUsage limit="50 gb"/>
+                </tempUsage>
+            </systemUsage>
+        </systemUsage>
+
+        <transportConnectors>
+            <transportConnector name="openwire" uri="tcp://0.0.0.0:61616?maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/>
+            <transportConnector name="amqp" uri="amqp://0.0.0.0:5672?maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/>
+            <transportConnector name="stomp" uri="stomp://0.0.0.0:61613?maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/>
+            <transportConnector name="mqtt" uri="mqtt://0.0.0.0:1883?maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/>
+            <transportConnector name="ws" uri="ws://0.0.0.0:61614?maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/>
+        </transportConnectors>
+
+        <shutdownHooks>
+            <bean xmlns="http://www.springframework.org/schema/beans" class="org.apache.activemq.hooks.SpringContextHook" />
+        </shutdownHooks>
+
+    </broker>
+
+    <import resource="jetty.xml"/>
+
+</beans>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -149,6 +149,11 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.activemq</groupId>
+                <artifactId>activemq-opentelemetry</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
                 <artifactId>activemq-spring</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,7 @@
     <netty-version>4.2.16.Final</netty-version>
     <rome-version>2.1.0</rome-version>
     <shiro-version>2.2.1</shiro-version>
+    <opentelemetry-version>1.43.0</opentelemetry-version>
     <slf4j-version>2.0.18</slf4j-version>
     <spring-version>6.2.19</spring-version>
     <spring-version-range>[6,7)</spring-version-range>
@@ -209,6 +210,7 @@
     <module>activemq-rar</module>
     <module>activemq-run</module>
     <module>activemq-shiro</module>
+    <module>activemq-opentelemetry</module>
     <module>activemq-spring</module>
     <module>activemq-runtime-config</module>
     <module>activemq-tooling</module>
@@ -339,6 +341,11 @@
       <dependency>
         <groupId>org.apache.activemq</groupId>
         <artifactId>activemq-shiro</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.activemq</groupId>
+        <artifactId>activemq-opentelemetry</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>
@@ -652,6 +659,15 @@
         <artifactId>shiro-spring</artifactId>
         <version>${shiro-version}</version>
         <optional>true</optional>
+      </dependency>
+
+      <!-- Optional OpenTelemetry Support -->
+      <dependency>
+        <groupId>io.opentelemetry</groupId>
+        <artifactId>opentelemetry-bom</artifactId>
+        <version>${opentelemetry-version}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
 
       <!-- Optional Spring Support -->


### PR DESCRIPTION
New activemq-opentelemetry module that instruments the broker using the OpenTelemetry API. The plugin traces send (PRODUCER), dispatch (CONSUMER), and acknowledge (INTERNAL) operations with W3C TraceContext propagation and standard OTel messaging semantic conventions.

Depends on opentelemetry-api only; users bring their own SDK and exporter at runtime. Included in the distribution with example configuration. Maybe we should add a default SDK/exporter in the ActiveMQ distribution, just wondering 😄 