### PR TITLE
fix(dependabot): catch all dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,14 +23,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
   - package-ecosystem: "maven"
     directory: "/"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 50
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
dependabot was ignoring a bunch of dependency updates due to the `ignore` section.

This change fixes that.