### PR TITLE
feat(#1797): add message delivery tracking to QueueMessageReference

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/broker/region/IndirectMessageReference.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/region/IndirectMessageReference.java
@@ -35,6 +35,8 @@ public class IndirectMessageReference implements QueueMessageReference {
     private boolean dropped;
     /** Has the message been acked? */
     private boolean acked;
+    /** Has the message been acked? */
+    private boolean delivered;
     /** Direct reference to the message */
     private final Message message;
     private final MessageId messageId;
@@ -197,16 +199,25 @@ public class IndirectMessageReference implements QueueMessageReference {
 
     @Override
     public synchronized int getSize() {
-       return message.getSize();
+        return message.getSize();
     }
 
     @Override
     public boolean isAdvisory() {
-       return message.isAdvisory();
+        return message.isAdvisory();
     }
 
     @Override
     public boolean canProcessAsExpired() {
         return message.canProcessAsExpired();
+    }
+
+    @Override
+    public boolean isDelivered() {
+        return delivered;
+    }
+
+    public void setDelivered(final boolean delivered) {
+        this.delivered = delivered;
     }
 }

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/region/IndirectMessageReference.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/region/IndirectMessageReference.java
@@ -35,7 +35,7 @@ public class IndirectMessageReference implements QueueMessageReference {
     private boolean dropped;
     /** Has the message been acked? */
     private boolean acked;
-    /** Has the message been acked? */
+    /** Has the message been delivered? */
     private boolean delivered;
     /** Direct reference to the message */
     private final Message message;
@@ -213,11 +213,12 @@ public class IndirectMessageReference implements QueueMessageReference {
     }
 
     @Override
-    public boolean isDelivered() {
+    public synchronized boolean isDelivered() {
         return delivered;
     }
 
-    public void setDelivered(final boolean delivered) {
+    @Override
+    public synchronized void setDelivered(final boolean delivered) {
         this.delivered = delivered;
     }
 }

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/region/NullMessageReference.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/region/NullMessageReference.java
@@ -159,4 +159,13 @@ public final class NullMessageReference implements QueueMessageReference {
         return false;
     }
 
+    @Override
+    public boolean isDelivered() {
+        return false;
+    }
+
+    @Override
+    public void setDelivered(boolean delivered) {
+
+    }
 }

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/region/PrefetchSubscription.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/region/PrefetchSubscription.java
@@ -271,33 +271,14 @@ public abstract class PrefetchSubscription extends AbstractSubscription {
                 // Message was delivered but not acknowledged: update pre-fetch
                 // counters.
 
-                boolean inAckRange = false;
                 for (final MessageReference node : dispatched) {
-                    MessageId messageId = node.getMessageId();
-                    if (ack.getFirstMessageId() == null
-                            || ack.getFirstMessageId().equals(messageId)) {
-                        inAckRange = true;
+                    final MessageId messageId = node.getMessageId();
+                    if (node instanceof QueueMessageReference) {
+                        ((QueueMessageReference) node).setDelivered(true);
                     }
-                    if (inAckRange) {
-                        if (node instanceof QueueMessageReference) {
-                            ((QueueMessageReference) node).setDelivered(true);
-                        }
-
-                        if (ack.getLastMessageId().equals(messageId)) {
-                            destination = (Destination) node.getRegionDestination();
-                            callDispatchMatched = true;
-                            break;
-                        }
-                    }
-                }
-
-                int index = 0;
-                for (Iterator<MessageReference> iter = dispatched.iterator(); iter.hasNext(); index++) {
-                    final MessageReference node = iter.next();
-                    Destination nodeDest = (Destination) node.getRegionDestination();
-                    if (ack.getLastMessageId().equals(node.getMessageId())) {
+                    if (ack.getLastMessageId().equals(messageId)) {
                         expandPrefetchExtension(ack.getMessageCount());
-                        destination = nodeDest;
+                        destination = (Destination) node.getRegionDestination();
                         callDispatchMatched = true;
                         break;
                     }

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/region/PrefetchSubscription.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/region/PrefetchSubscription.java
@@ -270,6 +270,27 @@ public abstract class PrefetchSubscription extends AbstractSubscription {
             } else if (ack.isDeliveredAck()) {
                 // Message was delivered but not acknowledged: update pre-fetch
                 // counters.
+
+                boolean inAckRange = false;
+                for (final MessageReference node : dispatched) {
+                    MessageId messageId = node.getMessageId();
+                    if (ack.getFirstMessageId() == null
+                            || ack.getFirstMessageId().equals(messageId)) {
+                        inAckRange = true;
+                    }
+                    if (inAckRange) {
+                        if (node instanceof QueueMessageReference) {
+                            ((QueueMessageReference) node).setDelivered(true);
+                        }
+
+                        if (ack.getLastMessageId().equals(messageId)) {
+                            destination = (Destination) node.getRegionDestination();
+                            callDispatchMatched = true;
+                            break;
+                        }
+                    }
+                }
+
                 int index = 0;
                 for (Iterator<MessageReference> iter = dispatched.iterator(); iter.hasNext(); index++) {
                     final MessageReference node = iter.next();
@@ -396,7 +417,7 @@ public abstract class PrefetchSubscription extends AbstractSubscription {
     }
 
     protected void processExpiredAck(final ConnectionContext context, final Destination dest,
-        final MessageReference node) {
+                                     final MessageReference node) {
         dest.messageExpired(context, this, node);
     }
 

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/region/QueueMessageReference.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/region/QueueMessageReference.java
@@ -42,4 +42,8 @@ public interface QueueMessageReference extends MessageReference {
     boolean unlock();
 
     LockOwner getLockOwner();
+
+    boolean isDelivered();
+
+    void setDelivered(boolean delivered);
 }


### PR DESCRIPTION
Add isDelivered()/setDelivered() to QueueMessageReference interface with implementations in IndirectMessageReference (boolean field) and NullMessageReference (no-op). PrefetchSubscription.acknowledge() now marks messages as delivered=true when processing DeliveredAck, enabling downstream consumers to distinguish delivered-but-unacked messages.