### PR TITLE
fix(assembly): add missing jolokia-core to assembly descriptor

### DIFF
--- a/assembly/src/main/descriptors/common-bin.xml
+++ b/assembly/src/main/descriptors/common-bin.xml
@@ -309,6 +309,7 @@
         <include>org.jdom:jdom2</include>
 
         <!-- REST API -->
+        <include>org.jolokia:jolokia-core</include>
         <include>org.jolokia:jolokia-server-core</include>
         <include>org.jolokia:jolokia-json</include>
         <include>org.jolokia:jolokia-service-jmx</include>


### PR DESCRIPTION
The jolokia-core artifact (containing org.jolokia.core.api.LogHandler) is a transitive dependency of jolokia-server-core in Jolokia 2.x but was not listed in the assembly descriptor's explicit includes, causing a NoClassDefFoundError at runtime.