### PR TITLE
[6.2.x] Bump jackson-version from 2.21.0 to 2.21.1 (#1709)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
     <httpclient-version>4.5.14</httpclient-version>
     <httpcore-version>4.4.16</httpcore-version>
     <insight-version>1.2.0.Beta4</insight-version>
-    <jackson-version>2.21.0</jackson-version>
+    <jackson-version>2.21.1</jackson-version>
     <jackson-annotations-version>2.21</jackson-annotations-version>
     <jakarta-jms-api-version>3.1.0</jakarta-jms-api-version>
     <jasypt-version>1.9.3</jasypt-version>


### PR DESCRIPTION
Bumps `jackson-version` from 2.21.0 to 2.21.1.

Updates `com.fasterxml.jackson.core:jackson-core` from 2.21.0 to 2.21.1
- [Commits](https://github.com/FasterXML/jackson-core/compare/jackson-core-2.21.0...jackson-core-2.21.1)

Updates `com.fasterxml.jackson.core:jackson-databind` from 2.21.0 to 2.21.1
- [Commits](https://github.com/FasterXML/jackson/commits)

Updates `com.fasterxml.jackson.dataformat:jackson-dataformat-xml` from 2.21.0 to 2.21.1
- [Commits](https://github.com/FasterXML/jackson-dataformat-xml/compare/jackson-dataformat-xml-2.21.0...jackson-dataformat-xml-2.21.1)

---
updated-dependencies:
- dependency-name: com.fasterxml.jackson.core:jackson-core dependency-version: 2.21.1 dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: com.fasterxml.jackson.core:jackson-databind dependency-version: 2.21.1 dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: com.fasterxml.jackson.dataformat:jackson-dataformat-xml dependency-version: 2.21.1 dependency-type: direct:production update-type: version-update:semver-patch ...