### PR TITLE
 AMQ-9365 - use ephemeral port and disable JMX in tests to prevent parallel CI conflicts.

### DIFF
--- a/activemq-unit-tests/src/test/java/org/apache/activemq/broker/region/cursors/AbstractPendingMessageCursorTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/broker/region/cursors/AbstractPendingMessageCursorTest.java
@@ -94,6 +94,7 @@ public abstract class AbstractPendingMessageCursorTest extends AbstractStoreStat
     protected void setUpBroker(boolean clearDataDir) throws Exception {
 
         broker = new BrokerService();
+        broker.setUseJmx(false);
         this.initPersistence(broker);
         //set up a transport
         TransportConnector connector = broker

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/transport/tcp/TcpTransportServerTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/transport/tcp/TcpTransportServerTest.java
@@ -29,7 +29,7 @@ import java.util.HashMap;
 public class TcpTransportServerTest extends TestCase{
 
     public void testDefaultPropertiesSetOnTransport() throws Exception {
-        TcpTransportServer server = (TcpTransportServer) TransportFactory.bind(new URI("tcp://localhost:61616?trace=true"));
+        TcpTransportServer server = (TcpTransportServer) TransportFactory.bind(new URI("tcp://localhost:0?trace=true"));
         server.setTransportOption(new HashMap<String, Object>());
 
         server.setAcceptListener(new TransportAcceptListener() {
@@ -46,8 +46,8 @@ public class TcpTransportServerTest extends TestCase{
 
         server.start();
 
-
-        Socket socket = new Socket("localhost", 61616);
+        int port = server.getConnectURI().getPort();
+        Socket socket = new Socket("localhost", port);
         server.handleSocket(socket);
         server.stop();
 


### PR DESCRIPTION
Fixed two parallel CI test conflicts reported in AMQ-9365:

**TcpTransportServerTest**: replace hardcoded port `61616` with `tcp://localhost:0` and read the actual bound port via `server.getConnectURI().getPort()` to avoid `BindException: Address already in use`.

**AbstractPendingMessageCursorTest**: add `broker.setUseJmx(false)` to prevent `InstanceAlreadyExists` JMX errors.