### PR TITLE
[#1826] fix(test): Fix flakiness in AMQ4930Test

### DIFF
--- a/activemq-unit-tests/src/test/java/org/apache/activemq/bugs/AMQ4930Test.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/bugs/AMQ4930Test.java
@@ -109,18 +109,14 @@ public class AMQ4930Test extends TestCase {
         browsed = underTest.browse();
         LOG.info("Browsed: " + browsed.length);
         assertEquals("maxBrowsePageSize", maxBrowsePageSize, browsed.length);
-        Runtime.getRuntime().gc();
-        long free = Runtime.getRuntime().freeMemory()/1024;
-        LOG.info("free at start of check: " + free);
+        long memoryUsageAtStart = underTest.getMemoryUsage().getUsage();
+        LOG.info("Memory usage at start of check: " + memoryUsageAtStart);
         // check for memory growth
         for (int i=0; i<10; i++) {
-            LOG.info("free: " + Runtime.getRuntime().freeMemory()/1024);
             browsed = underTest.browse();
             LOG.info("Browsed: " + browsed.length);
             assertEquals("maxBrowsePageSize", maxBrowsePageSize, browsed.length);
-            Runtime.getRuntime().gc();
-            Runtime.getRuntime().gc();
-            assertTrue("No growth: " + Runtime.getRuntime().freeMemory()/1024 + " >= " + (free - (free * 0.2)), Runtime.getRuntime().freeMemory()/1024 >= (free - (free * 0.2)));
+            assertTrue("Memory usage is ballooning: " + underTest.getMemoryUsage().getUsage() + " > " + (memoryUsageAtStart * 1.1), underTest.getMemoryUsage().getUsage() <= (memoryUsageAtStart * 1.1));
         }
     }
 


### PR DESCRIPTION
fixes #1826 
This PR addresses the flakiness in AMQ4930Test.

Existing test relies on Runtime.freeMemory() and explicit gc() calls, which makes the test flaky due to JVM heap resizing and GC timing variability.