### PR TITLE
feat(#1828): Expose NetworkConnector URI and local URI in JMX MBean

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/broker/jmx/NetworkConnectorView.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/jmx/NetworkConnectorView.java
@@ -16,6 +16,8 @@
  */
 package org.apache.activemq.broker.jmx;
 
+import java.net.URISyntaxException;
+
 import org.apache.activemq.network.NetworkConnector;
 
 public class NetworkConnectorView implements NetworkConnectorViewMBean {
@@ -35,6 +37,20 @@ public class NetworkConnectorView implements NetworkConnectorViewMBean {
     @Override
     public void stop() throws Exception {
         connector.stop();
+    }
+
+    @Override
+    public String getUri() {
+        return connector.getUri() != null ? connector.getUri().toString() : "";
+    }
+
+    @Override
+    public String getLocalUri() {
+        try {
+            return connector.getLocalUri() != null ? connector.getLocalUri().toString() : "";
+        } catch (URISyntaxException e) {
+            return "";
+        }
     }
 
     @Override

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/jmx/NetworkConnectorViewMBean.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/jmx/NetworkConnectorViewMBean.java
@@ -20,6 +20,10 @@ import org.apache.activemq.Service;
 
 public interface NetworkConnectorViewMBean extends Service {
 
+    String getUri();
+
+    String getLocalUri();
+
     String getName();
 
     int getMessageTTL();

--- a/activemq-broker/src/main/java/org/apache/activemq/network/MulticastNetworkConnector.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/network/MulticastNetworkConnector.java
@@ -77,6 +77,11 @@ public class MulticastNetworkConnector extends NetworkConnector {
         this.remoteTransport = remoteTransport;
     }
 
+    @Override
+    public URI getUri() {
+        return remoteURI;
+    }
+
     public URI getRemoteURI() {
         return remoteURI;
     }

--- a/activemq-broker/src/main/java/org/apache/activemq/network/MulticastNetworkConnector.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/network/MulticastNetworkConnector.java
@@ -77,9 +77,10 @@ public class MulticastNetworkConnector extends NetworkConnector {
         this.remoteTransport = remoteTransport;
     }
 
+    // Satisfies the abstract getUri() contract from NetworkConnector; delegates to getRemoteURI()
     @Override
     public URI getUri() {
-        return remoteURI;
+        return getRemoteURI();
     }
 
     public URI getRemoteURI() {

--- a/activemq-broker/src/main/java/org/apache/activemq/network/NetworkConnector.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/network/NetworkConnector.java
@@ -77,6 +77,8 @@ public abstract class NetworkConnector extends NetworkBridgeConfiguration implem
         this.localURI = localURI;
     }
 
+    public abstract URI getUri();
+
     public URI getLocalUri() throws URISyntaxException {
         return localURI;
     }

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/jmx/JmxCreateNCTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/jmx/JmxCreateNCTest.java
@@ -80,6 +80,8 @@ public class JmxCreateNCTest {
 
         assertNotNull(nc);
         assertEquals("NC", nc.getName());
+        assertEquals("static:(tcp://localhost:61617)", nc.getUri());
+        assertNotNull(nc.getLocalUri());
     }
 
     @Test


### PR DESCRIPTION
Add getUri() and getLocalUri() attributes to NetworkConnectorViewMBean so that the network connector URI is visible via JMX. Add abstract getUri() to NetworkConnector base class and implement it in MulticastNetworkConnector.