### PR TITLE
(fix/test) flaky testAdvisoryForwardingDuplexNC

### DIFF
--- a/activemq-unit-tests/src/test/java/org/apache/activemq/usecases/AdvisoryViaNetworkTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/usecases/AdvisoryViaNetworkTest.java
@@ -311,6 +311,7 @@ public class AdvisoryViaNetworkTest extends JmsMultipleBrokersTestSupport {
         networkBridge.setDuplex(true);
         startAllBrokers();
         verifyPeerBrokerInfo(brokers.get("A"), 1);
+        verifyPeerBrokerInfo(brokers.get("B"), 1);
 
 
         MessageConsumer consumerA = createConsumer("A", advisoryTopic);


### PR DESCRIPTION
### Description:
In a Duplex Network Connector configuration, Broker A initiates the connection, but Broker B must then initialize a sub-bridge for the reverse path. If messages are sent immediately after Broker A reports a connection, the reverse path on Broker B may not yet be fully established. Since Advisory messages are non-persistent and "fire-and-forget," they are dropped if the bridge demand/metadata exchange is incomplete.

Adding a verification step for Broker B ensures that both sides of the duplex transport have completed their BrokerInfo exchange and are ready to forward advisories before the test producer is started.

Error:
```
[ERROR] Failures: 
[ERROR]   AdvisoryViaNetworkTest>CombinationTestSupport.runBare:113->CombinationTestSupport.runBare:107->testAdvisoryForwardingDuplexNC:329 expected number of messages when received expected:<2> but was:<0>
```
### Testing:
Ran testAdvisoryForwardingDuplexNC 30 times locally; 100% pass rate after the fix (previously failed ~70% of the time).