### PR TITLE
Enforce provider-only JMSX properties under strictCompliance

### DIFF
--- a/activemq-client/src/main/java/org/apache/activemq/command/ActiveMQMessage.java
+++ b/activemq-client/src/main/java/org/apache/activemq/command/ActiveMQMessage.java
@@ -18,7 +18,16 @@ package org.apache.activemq.command;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
-import java.util.*;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.Vector;
 
 import jakarta.jms.DeliveryMode;
 import jakarta.jms.Destination;

--- a/activemq-client/src/main/java/org/apache/activemq/command/ActiveMQMessage.java
+++ b/activemq-client/src/main/java/org/apache/activemq/command/ActiveMQMessage.java
@@ -510,7 +510,7 @@ public class ActiveMQMessage extends Message implements org.apache.activemq.Mess
                     "JMSXState".equals(name) ||
                     "JMSXProducerTXID".equals(name) ||
                     "JMSXConsumerTXID".equals(name)) {
-                throw new MessageNotWriteableException("Provider-set JMSX property '" + name + "' cannot be set by a client under strict compliance.");
+                throw new JMSException("Provider-set JMSX property '" + name + "' cannot be set by a client under strict compliance.");
             }
         }
 

--- a/activemq-client/src/main/java/org/apache/activemq/command/ActiveMQMessage.java
+++ b/activemq-client/src/main/java/org/apache/activemq/command/ActiveMQMessage.java
@@ -501,6 +501,19 @@ public class ActiveMQMessage extends Message implements org.apache.activemq.Mess
 
         checkValidObject(value);
         value = convertScheduled(name, value);
+
+        // Strict Compliance Check For Provider-Set JMSX Properties
+        ActiveMQConnection conn = getConnection();
+        if (conn != null && conn.isStrictCompliance()) {
+            if ("JMSXDeliveryCount".equals(name) ||
+                    "JMSXRcvTimestamp".equals(name) ||
+                    "JMSXState".equals(name) ||
+                    "JMSXProducerTXID".equals(name) ||
+                    "JMSXConsumerTXID".equals(name)) {
+                throw new MessageNotWriteableException("Provider-set JMSX property '" + name + "' cannot be set by a client under strict compliance.");
+            }
+        }
+
         PropertySetter setter = JMS_PROPERTY_SETERS.get(name);
 
         if (setter != null && value != null) {

--- a/activemq-client/src/main/java/org/apache/activemq/command/ActiveMQMessage.java
+++ b/activemq-client/src/main/java/org/apache/activemq/command/ActiveMQMessage.java
@@ -18,11 +18,7 @@ package org.apache.activemq.command;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Vector;
+import java.util.*;
 
 import jakarta.jms.DeliveryMode;
 import jakarta.jms.Destination;
@@ -50,6 +46,15 @@ public class ActiveMQMessage extends Message implements org.apache.activemq.Mess
     public static final String BROKER_PATH_PROPERTY = "JMSActiveMQBrokerPath";
 
     private static final Map<String, PropertySetter> JMS_PROPERTY_SETERS = new HashMap<String, PropertySetter>();
+
+    public static final Set<String> STRICT_PROVIDER_JMSX_PROPERTIES =
+            Collections.unmodifiableSet(new HashSet<String>(Arrays.asList(
+                    "JMSXDeliveryCount",
+                    "JMSXRcvTimestamp",
+                    "JMSXState",
+                    "JMSXProducerTXID",
+                    "JMSXConsumerTXID"
+            )));
 
     protected transient Callback acknowledgeCallback;
 
@@ -505,11 +510,7 @@ public class ActiveMQMessage extends Message implements org.apache.activemq.Mess
         // Strict Compliance Check For Provider-Set JMSX Properties
         ActiveMQConnection conn = getConnection();
         if (conn != null && conn.isStrictCompliance()) {
-            if ("JMSXDeliveryCount".equals(name) ||
-                    "JMSXRcvTimestamp".equals(name) ||
-                    "JMSXState".equals(name) ||
-                    "JMSXProducerTXID".equals(name) ||
-                    "JMSXConsumerTXID".equals(name)) {
+            if (STRICT_PROVIDER_JMSX_PROPERTIES.contains(name)) {
                 throw new JMSException("Provider-set JMSX property '" + name + "' cannot be set by a client under strict compliance.");
             }
         }

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/StrictComplianceProviderJMSXPropertyTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/StrictComplianceProviderJMSXPropertyTest.java
@@ -17,7 +17,8 @@
 package org.apache.activemq;
 
 import jakarta.jms.Connection;
-import jakarta.jms.MessageNotWriteableException;
+import jakarta.jms.JMSException;
+import jakarta.jms.Message;
 import jakarta.jms.Session;
 import org.apache.activemq.ActiveMQConnectionFactory;
 import org.apache.activemq.broker.BrokerService;
@@ -27,7 +28,6 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
-
 public class StrictComplianceProviderJMSXPropertyTest {
 
     private BrokerService broker;
@@ -63,7 +63,7 @@ public class StrictComplianceProviderJMSXPropertyTest {
              Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE)) {
 
             connection.start();
-            Message message = (Message) session.createMessage();
+            Message message = session.createMessage();
 
             try {
                 // ActiveMQ allows clients to overwrite the delivery count
@@ -87,7 +87,7 @@ public class StrictComplianceProviderJMSXPropertyTest {
              Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE)) {
 
             connection.start();
-            Message message = (Message) session.createMessage();
+            Message message = session.createMessage();
 
             String[] providerOnlyProperties = {
                     "JMSXDeliveryCount",
@@ -102,7 +102,7 @@ public class StrictComplianceProviderJMSXPropertyTest {
                     // Attempting to set these should fail
                     message.setObjectProperty(property, 1);
                     fail("Strict mode must reject client attempt to set provider-only property: " + property);
-                } catch (MessageNotWriteableException e) {
+                } catch (JMSException e) {
                     // PASS: Expected Jakarta Messaging 3.1 behavior
                 }
             }
@@ -120,7 +120,7 @@ public class StrictComplianceProviderJMSXPropertyTest {
              Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE)) {
 
             connection.start();
-            Message message = (Message) session.createMessage();
+            Message message = session.createMessage();
 
             try {
                 // The spec explicitly allows clients to set these specific JMSX properties
@@ -130,7 +130,7 @@ public class StrictComplianceProviderJMSXPropertyTest {
                 assertEquals("Group-A", message.getStringProperty("JMSXGroupID"));
                 assertEquals(1, message.getIntProperty("JMSXGroupSeq"));
                 // PASS: Valid client-set properties succeeded
-            } catch (MessageNotWriteableException e) {
+            } catch (JMSException e) {
                 fail("Strict mode incorrectly rejected a valid client-set JMSX property");
             }
         }

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/StrictComplianceProviderJMSXPropertyTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/StrictComplianceProviderJMSXPropertyTest.java
@@ -1,0 +1,138 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq;
+
+import jakarta.jms.Connection;
+import jakarta.jms.MessageNotWriteableException;
+import jakarta.jms.Session;
+import org.apache.activemq.ActiveMQConnectionFactory;
+import org.apache.activemq.broker.BrokerService;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class StrictComplianceProviderJMSXPropertyTest {
+
+    private BrokerService broker;
+    private String connectionUri;
+
+    @Before
+    public void setUp() throws Exception {
+        broker = new BrokerService();
+        broker.setPersistent(false);
+        broker.setUseJmx(false);
+        broker.addConnector("vm://localhost");
+        broker.start();
+        broker.waitUntilStarted();
+        connectionUri = broker.getTransportConnectors().get(0).getPublishableConnectString();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (broker != null) {
+            broker.stop();
+            broker.waitUntilStopped();
+        }
+    }
+
+    @Test
+    public void testLegacyModeAllowsProviderSetJMSXProperties() throws Exception {
+        ActiveMQConnectionFactory factory = new ActiveMQConnectionFactory(connectionUri);
+
+        // Legacy mode (default)
+        factory.setStrictCompliance(false);
+
+        try (Connection connection = factory.createConnection();
+             Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE)) {
+
+            connection.start();
+            Message message = (Message) session.createMessage();
+
+            try {
+                // ActiveMQ allows clients to overwrite the delivery count
+                message.setIntProperty("JMSXDeliveryCount", 5);
+                assertEquals(5, message.getIntProperty("JMSXDeliveryCount"));
+                // PASS: Should not throw an exception in legacy mode
+            } catch (Exception e) {
+                fail("Legacy mode should not restrict setting provider-only JMSX properties");
+            }
+        }
+    }
+
+    @Test
+    public void testStrictModeRejectsProviderSetJMSXProperties() throws Exception {
+        ActiveMQConnectionFactory factory = new ActiveMQConnectionFactory(connectionUri);
+
+        // Enforce Jakarta 3.1 compliance
+        factory.setStrictCompliance(true);
+
+        try (Connection connection = factory.createConnection();
+             Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE)) {
+
+            connection.start();
+            Message message = (Message) session.createMessage();
+
+            String[] providerOnlyProperties = {
+                    "JMSXDeliveryCount",
+                    "JMSXRcvTimestamp",
+                    "JMSXState",
+                    "JMSXProducerTXID",
+                    "JMSXConsumerTXID"
+            };
+
+            for (String property : providerOnlyProperties) {
+                try {
+                    // Attempting to set these should fail
+                    message.setObjectProperty(property, 1);
+                    fail("Strict mode must reject client attempt to set provider-only property: " + property);
+                } catch (MessageNotWriteableException e) {
+                    // PASS: Expected Jakarta Messaging 3.1 behavior
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testStrictModeAllowsClientSetJMSXProperties() throws Exception {
+        ActiveMQConnectionFactory factory = new ActiveMQConnectionFactory(connectionUri);
+
+        // Enforce Jakarta 3.1 compliance
+        factory.setStrictCompliance(true);
+
+        try (Connection connection = factory.createConnection();
+             Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE)) {
+
+            connection.start();
+            Message message = (Message) session.createMessage();
+
+            try {
+                // The spec explicitly allows clients to set these specific JMSX properties
+                message.setStringProperty("JMSXGroupID", "Group-A");
+                message.setIntProperty("JMSXGroupSeq", 1);
+
+                assertEquals("Group-A", message.getStringProperty("JMSXGroupID"));
+                assertEquals(1, message.getIntProperty("JMSXGroupSeq"));
+                // PASS: Valid client-set properties succeeded
+            } catch (MessageNotWriteableException e) {
+                fail("Strict mode incorrectly rejected a valid client-set JMSX property");
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Throws a MessageNotWriteableException if a client attempts to set JMSXDeliveryCount, JMSXRcvTimestamp, JMSXState, JMSXProducerTXID, or JMSXConsumerTXID.
- Client-set properties (like JMSXGroupID and JMSXGroupSeq) are completely bypassed and function normally.
- Added StrictComplianceProviderJMSXPropertyTest using an embedded BrokerService to explicitly verify both strict and legacy behaviors.