### PR TITLE
Fix flaky XACompletionTest by adding wait for async states

### DIFF
--- a/activemq-unit-tests/src/test/java/org/apache/activemq/store/jdbc/XACompletionTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/store/jdbc/XACompletionTest.java
@@ -249,7 +249,7 @@ public class XACompletionTest extends TestSupport {
         resource.recover(XAResource.TMSTARTRSCAN);
         resource.recover(XAResource.TMNOFLAGS);
 
-        Wait.waitFor(() -> proxy.getInFlightCount() == 0L && proxy.cursorSize() == 0);
+        assertTrue("Timed out waiting for queue state to stabilize", Wait.waitFor(() -> proxy.getInFlightCount() == 0L && proxy.getQueueSize() == 10L && proxy.cursorSize() == 0));
         assertEquals("prefetch 0", 0, proxy.getInFlightCount());
         assertEquals("size 0", 10, proxy.getQueueSize());
         assertEquals("size 0", 0, proxy.cursorSize());


### PR DESCRIPTION

XACompletionTest.testStatsAndBrowseAfterAckPreparedRolledback was failing intermittently:
```
Error:    XACompletionTest.testStatsAndBrowseAfterAckPreparedRolledback:254 size 0 expected:<0> but was:<10>
```
ref: https://github.com/apache/activemq/actions/runs/23623154131/job/68806975829

The test relied on immediate JMX state, which is asynchronous and can lead to flakiness.