### PR TITLE
 AMQ-9386: Remove legacy IBM JDK-specific test paths from MBeanTest and StompTest.

### DIFF
--- a/activemq-stomp/src/test/java/org/apache/activemq/transport/stomp/StompTest.java
+++ b/activemq-stomp/src/test/java/org/apache/activemq/transport/stomp/StompTest.java
@@ -116,27 +116,6 @@ public class StompTest extends StompTestSupport {
 
     @Override
     public void setUp() throws Exception {
-        // The order of the entries is different when using ibm jdk 5.
-        if (System.getProperty("java.vendor").equals("IBM Corporation")
-            && System.getProperty("java.version").startsWith("1.5")) {
-            xmlMap = "<map>\n"
-                + "  <entry>\n"
-                + "    <string>city</string>\n"
-                + "    <string>Belgrade</string>\n"
-                + "  </entry>\n"
-                + "  <entry>\n"
-                + "    <string>name</string>\n"
-                + "    <string>Dejan</string>\n"
-                + "  </entry>\n"
-                + "</map>\n";
-            jsonMap = "{\"map\":{"
-                + "\"entry\":["
-                + "{\"string\":[\"city\",\"Belgrade\"]},"
-                + "{\"string\":[\"name\",\"Dejan\"]}"
-                + "]"
-                + "}}";
-        }
-
         queue = new ActiveMQQueue(getQueueName());
         super.setUp();
 

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/broker/jmx/MBeanTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/broker/jmx/MBeanTest.java
@@ -664,10 +664,6 @@ public class MBeanTest extends EmbeddedBrokerTestSupport {
             assertComplexData(i, cdata, "JMSCorrelationID", "MyCorrId");
             assertComplexData(i, cdata, "JMSDeliveryMode", "NON-PERSISTENT");
             String expected = "{MyStringHeader=StringHeader" + i + ", MyHeader=" + i + "}";
-            // The order of the properties is different when using the ibm jdk.
-            if (System.getProperty("java.vendor").equals("IBM Corporation")) {
-                expected = "{MyHeader=" + i + ", MyStringHeader=StringHeader" + i + "}";
-            }
             assertComplexData(i, cdata, "PropertiesText", expected);
 
             if (allStrings) {


### PR DESCRIPTION
ActiveMQ 6.x targets Java 17+, and IBM Java now uses the same property ordering as other JVMs. Remove the IBM Corporation java.vendor checks and the IBM JDK 1.5-specific map ordering workaround in StompTest.setUp().