### PR TITLE
Fix flakiness in AdvisoryViaNetworkTest by verifying peer broker info on both sides of duplex network

### DIFF
--- a/activemq-unit-tests/src/test/java/org/apache/activemq/usecases/AdvisoryViaNetworkTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/usecases/AdvisoryViaNetworkTest.java
@@ -105,6 +105,7 @@ public class AdvisoryViaNetworkTest extends JmsMultipleBrokersTestSupport {
 
         startAllBrokers();
         verifyPeerBrokerInfo(brokers.get("A"), 1);
+        verifyPeerBrokerInfo(brokers.get("B"), 1);
 
         createConsumer("A", topic1);
         createConsumer("A", new ActiveMQTopic("A.FOO2"));
@@ -142,6 +143,7 @@ public class AdvisoryViaNetworkTest extends JmsMultipleBrokersTestSupport {
 
         startAllBrokers();
         verifyPeerBrokerInfo(brokers.get("A"), 1);
+        verifyPeerBrokerInfo(brokers.get("B"), 1);
 
         createConsumer("A", topic1);
         createConsumer("A", new ActiveMQTopic("A.FOO2"));
@@ -177,6 +179,7 @@ public class AdvisoryViaNetworkTest extends JmsMultipleBrokersTestSupport {
 
         startAllBrokers();
         verifyPeerBrokerInfo(brokers.get("A"), 1);
+        verifyPeerBrokerInfo(brokers.get("B"), 1);
 
         createConsumer("A", topic1);
         createConsumer("A", new ActiveMQTopic("A.FOO2"));
@@ -211,6 +214,7 @@ public class AdvisoryViaNetworkTest extends JmsMultipleBrokersTestSupport {
 
         startAllBrokers();
         verifyPeerBrokerInfo(brokers.get("A"), 1);
+        verifyPeerBrokerInfo(brokers.get("B"), 1);
 
         createConsumer("A", topic1);
         createConsumer("A", new ActiveMQTopic("A.FOO2"));
@@ -243,6 +247,7 @@ public class AdvisoryViaNetworkTest extends JmsMultipleBrokersTestSupport {
 
         startAllBrokers();
         verifyPeerBrokerInfo(brokers.get("A"), 1);
+        verifyPeerBrokerInfo(brokers.get("B"), 1);
 
         for (int i = 0; i < 10; i++) {
             createConsumer("A", new ActiveMQTopic("A.FOO"));
@@ -270,6 +275,7 @@ public class AdvisoryViaNetworkTest extends JmsMultipleBrokersTestSupport {
 
         startAllBrokers();
         verifyPeerBrokerInfo(brokers.get("A"), 1);
+        verifyPeerBrokerInfo(brokers.get("B"), 1);
 
         for (int i = 0; i < 10; i++) {
             createConsumer("A", new ActiveMQTopic("A.FOO"));


### PR DESCRIPTION
### Problem
AdvisoryViaNetworkTest was intermittently failing with errors like:

```
Consumer on B for topic://A.FOO
```
ref- https://github.com/apache/activemq/actions/runs/23815739249/job/69531878381?pr=1863

The failure occurs in `waitForConsumerOnBroker`, indicating that broker B has not yet fully received advisory information about consumers from broker A.

### Root Cause
The tests only verified peer broker discovery on broker A. In a duplex network, advisory propagation and peer discovery are bidirectional, but the test did not ensure that broker B had completed initialization and discovered its peer. As a result tests could proceed before broker B was fully ready or leading to race conditions and intermittent failures.

### Fix
Added verification of peer broker info on both brokers after startup for duplex network of brokers. This ensures both sides of the duplex network are fully established before test actions begin.

### Testing

Ran `AdvisoryViaNetworkTest` 30 times locally; 100% pass rate after the fix.
