### PR TITLE
(test/fix) race condition in network bridge advisory subscription initialization in AMQ6366Test

### DIFF
--- a/activemq-unit-tests/src/test/java/org/apache/activemq/usecases/AMQ6366Test.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/usecases/AMQ6366Test.java
@@ -69,6 +69,7 @@ public class AMQ6366Test extends JmsMultipleBrokersTestSupport {
 
         startAllBrokers();
         waitForBridgeFormation();
+        waitForMinTopicRegionConsumerCount(conBroker, 1);
 
         final MessageConsumer client = createDurableSubscriber(conBroker, dest, "sub1");
         client.close();


### PR DESCRIPTION
### Description
This PR fixes a race condition in the network bridge setup that cause missed advisory messages and prevent durable demand subscriptions from being created.

`waitForBridgeFormation()` returned as soon as `remoteBrokerName` was set during `collectBrokerInfos()` and this occurs before `startRemoteBridge()` registers the advisory consumer on `conBroker`.

In some cases following sequence occur:
1. `waitForBridgeFormation()` returns early
2. `sub1` is created
3. Its advisory message is fired
4. The bridge advisory consumer is not yet registered on `conBroker
5. The advisory is missed
6. Durable demand subscription is never created on `pubBroker`

The fix ensures proper synchronization by waiting until the bridge’s advisory consumer is fully registered before proceeding. Now, it wait for at least one topic-region subscription on 1conBroker1

### Error
```
AMQ6366Test>CombinationTestSupport.runBare:113->CombinationTestSupport.runBare:107->testDuplexDurableSubRestarted:54->testNonDurableReceiveThrougRestart:109 Network durable subscription should be active on BrokerA
```
ref - https://github.com/apache/activemq/actions/runs/23763076486/job/69370689090

### Test
Ran test locally over 50 times with 100% success rate. Previously, test was failing consistently 5 out of 50 times (10% failure rate). 
