### PR TITLE
(Fix/ci) remove surefire rerun flag when tests are skipped

### DIFF
--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -54,7 +54,7 @@ jobs:
           distribution: temurin
           cache: 'maven'
       - name: Build
-        run: mvn -U -B -e clean install -DskipTests -Dsurefire.rerunFailingTestsCount=3
+        run: mvn -U -B -e clean install -DskipTests
       - name: Verify
         run: mvn apache-rat:check
 

--- a/.github/workflows/ci-weekly.yml
+++ b/.github/workflows/ci-weekly.yml
@@ -52,7 +52,7 @@ jobs:
           distribution: temurin
           cache: 'maven'
       - name: Build
-        run: mvn -U -B -e clean install -DskipTests -Dsurefire.rerunFailingTestsCount=3
+        run: mvn -U -B -e clean install -DskipTests
       - name: Verify
         run: mvn apache-rat:check
 


### PR DESCRIPTION
## Description
This PR fixes a build failure in the GitHub Actions workflow caused by Maven flag. 
The rerun flag is only applicable when tests are executed. Since build step of workflow explicitly skips tests, the flag was unnecessary here and caused Maven to fail.