### PR TITLE
[5.19.x] Minor bug fix for BrokerView#validateAllowedUri (#1900)

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/broker/jmx/BrokerView.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/jmx/BrokerView.java
@@ -570,7 +570,8 @@ public class BrokerView implements BrokerViewMBean {
     // Validate the URI does not contain VM transport
     private static void validateAllowedUri(URI uri, int depth) throws URISyntaxException {
         // Don't allow more than 5 nested URIs to prevent blowing the stack
-        if (depth > 5) {
+        // If we are greater than 4 then this is the 5th level of composite
+        if (depth > 4) {
             throw new IllegalArgumentException("URI can't contain more than 5 nested composite URIs");
         }
 
@@ -585,10 +586,10 @@ public class BrokerView implements BrokerViewMBean {
                 // Each URI could be a nested composite URI so call validateAllowedUri()
                 // to validate it. This check if composite first so we don't add to
                 // the recursive stack depth if there's a lot of URIs that are not composite
-                if (URISupport.isCompositeURI(uri)) {
+                if (URISupport.isCompositeURI(component)) {
                     validateAllowedUri(component, depth);
                 } else {
-                    validateAllowedScheme(uri.getScheme());
+                    validateAllowedScheme(component.getScheme());
                 }
             }
         }

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/jmx/JmxCreateNCTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/jmx/JmxCreateNCTest.java
@@ -116,11 +116,16 @@ public class JmxCreateNCTest {
 
     @Test
     public void testAddNetworkConnectorMaxComposite() throws Exception {
+        // Should allow 5 nested (excludes first wrapper) so no exception thrown
+        assertNotNull(proxy.addNetworkConnector(
+                "static:(static:(static:(static:(static:(bad://localhost)))))"));
+
         try {
-            // verify nested composite URI with more than 5 levels is blocked
+            // verify nested composite URI with more than 5 levels is blocked. This has 6 nested
+            // (not including first wrapper url
             proxy.addNetworkConnector(
                     "static:(failover:(failover:(failover:(failover:(failover:(tcp://localhost:0))))))");
-            fail("Should have failed trying to add vm connector bridge");
+            fail("Should have failed trying to add more than 5 connector bridges");
         } catch (IllegalArgumentException e) {
             assertEquals("URI can't contain more than 5 nested composite URIs", e.getMessage());
         }


### PR DESCRIPTION
The wrong variable is being referenced in the nested loop. This does not cause the validation to actually break due to other checks done during the recursive call, but is incorrect either way. With this fix the counter needed tweaking for limiting the number of nested components as well.

Follow on to #1847

(cherry picked from commit b787b0ed11cf1b7444b0a3904398fea5dc16179b)