### PR TITLE
[6.2.x] Restrict URL protocol types loaded by XBeanBrokerFactory (#1910)

### DIFF
--- a/activemq-spring/src/main/java/org/apache/activemq/spring/Utils.java
+++ b/activemq-spring/src/main/java/org/apache/activemq/spring/Utils.java
@@ -19,6 +19,9 @@ package org.apache.activemq.spring;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Set;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
@@ -27,22 +30,69 @@ import org.springframework.util.ResourceUtils;
 
 public class Utils {
 
+    public static final String FILE_PROTOCOL = "file";
+    public static final String CLASSPATH_PROTOCOL = "classpath";
+
     public static Resource resourceFromString(String uri) throws MalformedURLException {
-        Resource resource;
-        File file = new File(uri);
-        if (file.exists()) {
+        // default allows all
+        return resourceFromString(uri, null);
+    }
+
+    public static Resource resourceFromString(String uri, Set<String> allowedProtocols) throws MalformedURLException {
+        // Empty set means nothing is allowed
+        if (allowedProtocols != null && allowedProtocols.isEmpty()) {
+            throw new IllegalArgumentException("No protocols are allowed for loading resources.");
+        }
+
+        final Resource resource;
+
+        // First, just try and load a local file (if it exists) and if "file"
+        // as part of the allow list. This preserves previous behavior of
+        // always optimistically trying a local file first.
+        if (isAllowFile(allowedProtocols) && new File(uri).exists()) {
             resource = new FileSystemResource(uri);
+        // If file isn't allowed, or if the file can't be found then check
+        // if the string is a valid URL. If it's valid, then we need
+        // to validate if it's allowed before loading the URL.
+        // isUrl() uses URI internally so it won't actually load anything
         } else if (ResourceUtils.isUrl(uri)) {
             try {
+                validateUrlAllowed(uri, allowedProtocols);
                 resource = new UrlResource(ResourceUtils.getURL(uri));
-            } catch (FileNotFoundException e) {
+            } catch (FileNotFoundException | URISyntaxException e) {
                 MalformedURLException malformedURLException = new MalformedURLException(uri);
                 malformedURLException.initCause(e);
-                throw  malformedURLException;
+                throw malformedURLException;
             }
-        } else {
+        // Fallback to trying on the classpath if not a valid Url, and we allow it which
+        // also preserves the previous behavior (if classpath is allowed)
+        } else if (isAllowClasspath(allowedProtocols)){
             resource = new ClassPathResource(uri);
+        // Catch all fail-safe if nothing else matches. This could happen if file is allowed
+        // but not classpath but the file doesn't exist
+        } else {
+            throw new IllegalArgumentException("URL [" + uri + "] can't be found or is not allowed"
+                    + " for loading resources");
         }
         return resource;
+    }
+
+    static boolean isAllowFile(Set<String> allowedProtocols) {
+        return allowedProtocols == null || allowedProtocols.contains(FILE_PROTOCOL);
+    }
+
+    static boolean isAllowClasspath(Set<String> allowedProtocols) {
+        return allowedProtocols == null || allowedProtocols.contains(CLASSPATH_PROTOCOL);
+    }
+
+    private static void validateUrlAllowed(String uriString, Set<String> allowedProtocols)
+            throws URISyntaxException {
+        // Use new URI() to get the scheme
+        // This is important because ResourceUtils.getURL() actually searches
+        // the classpath which we don't want to do if not allowed
+        if (allowedProtocols != null && !allowedProtocols.contains(new URI(uriString).getScheme())) {
+            throw new IllegalArgumentException("URL [" + uriString +
+                    "] does not use an allowed protocol for loading URL resources");
+        }
     }
 }

--- a/activemq-spring/src/main/java/org/apache/activemq/xbean/XBeanBrokerFactory.java
+++ b/activemq-spring/src/main/java/org/apache/activemq/xbean/XBeanBrokerFactory.java
@@ -20,7 +20,9 @@ import java.beans.PropertyEditorManager;
 import java.net.MalformedURLException;
 import java.net.URI;
 
-import org.apache.activemq.broker.BrokerContextAware;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.activemq.broker.BrokerFactoryHandler;
 import org.apache.activemq.broker.BrokerService;
 import org.apache.activemq.spring.SpringBrokerContext;
@@ -35,20 +37,38 @@ import org.springframework.beans.BeansException;
 import org.springframework.beans.FatalBeanException;
 import org.springframework.beans.factory.xml.XmlBeanDefinitionReader;
 import org.springframework.context.ApplicationContext;
-import org.springframework.context.ApplicationContextAware;
 import org.springframework.core.io.Resource;
 
 /**
  * 
  */
 public class XBeanBrokerFactory implements BrokerFactoryHandler {
-    private static final transient Logger LOG = LoggerFactory.getLogger(XBeanBrokerFactory.class);
+    private static final Logger LOG = LoggerFactory.getLogger(XBeanBrokerFactory.class);
+
+    public static final String XBEAN_BROKER_FACTORY_PROTOCOLS_PROP =
+            "org.apache.activemq.xbean.XBEAN_BROKER_FACTORY_PROTOCOLS";
+    public static final String DEFAULT_ALLOWED_PROTOCOLS = Utils.FILE_PROTOCOL + "," + Utils.CLASSPATH_PROTOCOL;
+
+    private final Set<String> allowedProtocols;
 
     static {
         PropertyEditorManager.registerEditor(URI.class, URIEditor.class);
     }
 
+    public XBeanBrokerFactory() {
+        final String allowedProtocols = System.getProperty(XBEAN_BROKER_FACTORY_PROTOCOLS_PROP,
+                DEFAULT_ALLOWED_PROTOCOLS);
+
+        // Asterisk will map to null which will allow all and skip checking
+        // Empty string will map to an empty set and will deny all
+        this.allowedProtocols = !allowedProtocols.equals("*") ?
+                Arrays.stream(allowedProtocols.split("\\s*,\\s*"))
+                .filter(s -> !s.isBlank())
+                .collect(Collectors.toUnmodifiableSet()) : null;
+    }
+
     private boolean validate = true;
+
     public boolean isValidate() {
         return validate;
     }
@@ -75,12 +95,10 @@ public class XBeanBrokerFactory implements BrokerFactoryHandler {
         if (broker == null) {
             // lets try find by type
             String[] names = context.getBeanNamesForType(BrokerService.class);
-            for (int i = 0; i < names.length; i++) {
-                String name = names[i];
-                broker = (BrokerService)context.getBean(name);
-                if (broker != null) {
-                    break;
-                }
+            for (String name : names) {
+                // No need to check for null, this will throw an exception if not found
+                broker = (BrokerService) context.getBean(name);
+                break;
             }
         }
         if (broker == null) {
@@ -98,8 +116,8 @@ public class XBeanBrokerFactory implements BrokerFactoryHandler {
     }
 
     protected ApplicationContext createApplicationContext(String uri) throws MalformedURLException {
-        Resource resource = Utils.resourceFromString(uri);
-        LOG.debug("Using " + resource + " from " + uri);
+        Resource resource = Utils.resourceFromString(uri, allowedProtocols);
+        LOG.debug("Using {} from {}", resource, uri);
         try {
             return new ResourceXmlApplicationContext(resource) {
                 @Override
@@ -108,9 +126,14 @@ public class XBeanBrokerFactory implements BrokerFactoryHandler {
                 }
             };
         } catch (FatalBeanException errorToLog) {
-            LOG.error("Failed to load: " + resource + ", reason: " + errorToLog.getLocalizedMessage(), errorToLog);
+            LOG.error("Failed to load: {}, reason: {}", resource, errorToLog.getLocalizedMessage(),
+                    errorToLog);
             throw errorToLog;
         }
     }
 
+    // Package scope for testing
+    Set<String> getAllowedProtocols() {
+        return allowedProtocols;
+    }
 }

--- a/activemq-spring/src/test/java/org/apache/activemq/spring/UtilsTest.java
+++ b/activemq-spring/src/test/java/org/apache/activemq/spring/UtilsTest.java
@@ -1,0 +1,270 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.spring;
+
+import static org.apache.activemq.spring.Utils.CLASSPATH_PROTOCOL;
+import static org.apache.activemq.spring.Utils.FILE_PROTOCOL;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import org.junit.Test;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.UrlResource;
+
+public class UtilsTest {
+
+    @Test
+    public void testIsAllowFile() {
+        assertTrue(Utils.isAllowFile(null));
+        assertTrue(Utils.isAllowFile(Set.of(FILE_PROTOCOL)));
+        assertTrue(Utils.isAllowFile(Set.of(FILE_PROTOCOL, "ftp", "ssl")));
+        assertFalse(Utils.isAllowFile(Set.of(CLASSPATH_PROTOCOL, "ftp", "ssl")));
+        assertFalse(Utils.isAllowFile(Set.of()));
+        assertFalse(Utils.isAllowFile(Set.of("")));
+    }
+
+    @Test
+    public void testIsAllowClasspath() {
+        assertTrue(Utils.isAllowClasspath(null));
+        assertTrue(Utils.isAllowClasspath(Set.of(CLASSPATH_PROTOCOL)));
+        assertTrue(Utils.isAllowClasspath(Set.of(CLASSPATH_PROTOCOL, "ftp", "ssl")));
+        assertFalse(Utils.isAllowClasspath(Set.of(FILE_PROTOCOL, "ftp", "ssl")));
+        assertFalse(Utils.isAllowClasspath(Set.of()));
+        assertFalse(Utils.isAllowClasspath(Set.of("")));
+    }
+
+    // Test 1: Check file is NOT allowed to load, and does NOT exist
+    @Test
+    public void tesResourceFromStringFile1() throws Exception {
+        Resource resource;
+
+        // file not allowed, only jar
+        assertNotAllowed("URL [doesNotExist] can't be found or is not allowed for loading resources",
+                () -> Utils.resourceFromString("doesNotExist", Set.of("jar")));
+        // if classpath is allowed and not fully qualified, it will not find the file and fallback
+        resource = Utils.resourceFromString("doesNotExist", Set.of(CLASSPATH_PROTOCOL));
+        assertTrue(resource instanceof ClassPathResource);
+        assertFalse(resource.exists());
+        // fully qualified fails regardless
+        assertNotAllowed("URL [file:doesNotExist] does not use an allowed protocol for loading URL resources",
+                () -> Utils.resourceFromString("file:doesNotExist", Set.of(CLASSPATH_PROTOCOL)));
+        // Test Uri format, empty set not allowed
+        assertNotAllowed("No protocols are allowed for loading resources.",
+                () -> Utils.resourceFromString("file:doesNotExist", Set.of()));
+
+    }
+
+    // Test 2: Check file is allowed to load, but it does not exist
+    // This will throw an exception if classpath is not allowed or fully qualified uri,
+    // otherwise it will fallback to try classpath if classpath is allowed
+    @Test
+    public void tesResourceFromStringFile2() throws Exception {
+        Resource resource;
+
+        //classpath allowed so it will fallback
+        resource = Utils.resourceFromString("doesNotExist", Set.of(FILE_PROTOCOL, CLASSPATH_PROTOCOL));
+        assertTrue(resource instanceof ClassPathResource);
+        assertFalse(resource.exists());
+        resource = Utils.resourceFromString("doesNotExist", null);
+        assertTrue(resource instanceof ClassPathResource);
+        assertFalse(resource.exists());
+        // single argument - default is null for allowed protocols so all are allowed
+        resource = Utils.resourceFromString("doesNotExist");
+        assertTrue(resource instanceof ClassPathResource);
+        assertFalse(resource.exists());
+        // classpath not allowed so we get an exception as we can't find it
+        assertNotAllowed("URL [doesNotExist] can't be found or is not allowed for loading resources",
+                () -> Utils.resourceFromString("doesNotExist", Set.of(FILE_PROTOCOL)));
+    }
+
+    // Test 3: Check file is NOT allowed to load, but it does exist
+    @Test
+    public void tesResourceFromStringFile3() throws Exception {
+        Resource resource;
+
+        // Test using "jar" as allowed so we don't fallback
+        assertNotAllowed("URL [src/test/resources/activemq.xml] can't be found or is not allowed for loading resources",
+                () -> Utils.resourceFromString("src/test/resources/activemq.xml", Set.of("jar")));
+        // classpath is allowed so it won't find the file and fallback to classpath
+        resource = Utils.resourceFromString("src/test/resources/activemq.xml", Set.of(CLASSPATH_PROTOCOL));
+        assertTrue(resource instanceof ClassPathResource);
+        assertFalse(resource.exists());
+        // empty allow list
+        assertNotAllowed("No protocols are allowed for loading resources.",
+                () -> Utils.resourceFromString("src/test/resources/activemq.xml", Set.of()));
+        // Test Uri format - only classpath allowed
+        assertNotAllowed("URL [file:src/test/resources/activemq.xml] does not use an allowed protocol for loading URL resources",
+                () -> Utils.resourceFromString("file:src/test/resources/activemq.xml", Set.of(CLASSPATH_PROTOCOL)));
+    }
+
+    // Test 4: Check file is both allowed and exists
+    @Test
+    public void tesResourceFromStringFile4() throws Exception {
+        Resource resource;
+
+        resource = Utils.resourceFromString("src/test/resources/activemq.xml", Set.of(FILE_PROTOCOL));
+        assertTrue(resource instanceof FileSystemResource);
+        assertTrue(resource.exists());
+
+        // Retry with file allowed using uri format
+        resource = Utils.resourceFromString("file:src/test/resources/activemq.xml", Set.of(FILE_PROTOCOL));
+        assertTrue(resource instanceof UrlResource);
+        assertTrue(resource.exists());
+    }
+
+    // Test 1: Check classpath is NOT allowed to load, and does NOT exist
+    @Test
+    public void tesResourceFromStringClasspath1() {
+        // Check classpath is NOT allowed to load, and does NOT exist
+        assertNotAllowed("URL [doesNotExist] can't be found or is not allowed for loading resources",
+                () -> Utils.resourceFromString("doesNotExist", Set.of(FILE_PROTOCOL)));
+        assertNotAllowed("URL [classpath:doesNotExist] does not use an allowed protocol for loading URL resources",
+                () -> Utils.resourceFromString("classpath:doesNotExist", Set.of(FILE_PROTOCOL)));
+        // Test Uri format, empty set not allowed
+        assertNotAllowed("No protocols are allowed for loading resources.",
+                () -> Utils.resourceFromString("classpath:doesNotExist", Set.of()));
+    }
+
+    // Test 2: Check classpath is allowed to load, but it does not exist
+    // This will return a classpath resource because file is tried first
+    // but won't be found so it eventually returns a classpath resource
+    @Test
+    public void tesResourceFromStringClasspath2() throws Exception {
+        Resource resource;
+
+        resource = Utils.resourceFromString("doesNotExist", Set.of(FILE_PROTOCOL, CLASSPATH_PROTOCOL));
+        assertTrue(resource instanceof ClassPathResource);
+        assertFalse(resource.exists());
+        resource = Utils.resourceFromString("doesNotExist", Set.of(CLASSPATH_PROTOCOL));
+        assertTrue(resource instanceof ClassPathResource);
+        assertFalse(resource.exists());
+        resource = Utils.resourceFromString("doesNotExist", null);
+        assertTrue(resource instanceof ClassPathResource);
+        assertFalse(resource.exists());
+        // test single argument
+        resource = Utils.resourceFromString("doesNotExist");
+        assertTrue(resource instanceof ClassPathResource);
+        assertFalse(resource.exists());
+    }
+
+    // Test 3: Check classpath is NOT allowed to load, but it does exist
+    @Test
+    public void tesResourceFromStringClasspath3() {
+        // This exists on the classpath but not allowed, only file is allowed
+        assertNotAllowed("URL [activemq.xml] can't be found or is not allowed for loading resources",
+                () -> Utils.resourceFromString("activemq.xml", Set.of(FILE_PROTOCOL)));
+        // empty allow list
+        assertNotAllowed("No protocols are allowed for loading resources.",
+                () -> Utils.resourceFromString("activemq.xml", Set.of()));
+        // Test Uri format - only file allowed
+        assertNotAllowed("URL [classpath:activemq.xml] does not use an allowed protocol for loading URL resources",
+                () -> Utils.resourceFromString("classpath:activemq.xml", Set.of(FILE_PROTOCOL)));
+    }
+
+    @Test
+    public void tesResourceFromStringClasspath4() throws Exception {
+        Resource resource;
+
+        // Test 4: Check classpath is both allowed and exists
+        resource = Utils.resourceFromString("activemq.xml", Set.of(CLASSPATH_PROTOCOL));
+        assertTrue(resource instanceof ClassPathResource);
+        assertTrue(resource.exists());
+        // Retry with classpath allowed using uri format
+        resource = Utils.resourceFromString("classpath:activemq.xml", Set.of(CLASSPATH_PROTOCOL));
+        assertTrue(resource instanceof UrlResource);
+        assertTrue(resource.exists());
+    }
+
+    // Test URIs not allowed
+    @Test
+    public void tesResourceFromStringUri1() throws Exception {
+        Resource resource;
+
+        // none of these protocols are allowed
+        assertNotAllowed("URL [http://invalid] does not use an allowed protocol for loading URL resources",
+                () -> Utils.resourceFromString("http://invalid", Set.of(FILE_PROTOCOL,CLASSPATH_PROTOCOL)));
+        assertNotAllowed("URL [ftp://invalid] does not use an allowed protocol for loading URL resources",
+                () -> Utils.resourceFromString("ftp://invalid", Set.of(FILE_PROTOCOL,CLASSPATH_PROTOCOL)));
+        assertNotAllowed("URL [jar:file:invalid.jar!/] does not use an allowed protocol for loading URL resources",
+                () -> Utils.resourceFromString("jar:file:invalid.jar!/", Set.of(FILE_PROTOCOL,CLASSPATH_PROTOCOL)));
+        assertNotAllowed("No protocols are allowed for loading resources.",
+                () -> Utils.resourceFromString("http://invalid", Set.of()));
+        // malformed
+        try {
+            // not allowed but should have malformed error before it even checks
+            Utils.resourceFromString("http:", Set.of("http"));
+            fail("should have exception");
+        } catch (MalformedURLException e) {
+            assertTrue(e.getCause() instanceof URISyntaxException);
+        }
+
+        // special edge case - "bad" is not a valid protocol so it skips the URI loading
+        // and falls back to a classpath search, which is allowed. That will of course fail because
+        // it's not a valid classpath entry
+        resource = Utils.resourceFromString("bad://doesNotExist", Set.of(CLASSPATH_PROTOCOL));
+        assertTrue(resource instanceof ClassPathResource);
+        assertFalse(resource.exists());
+        resource = Utils.resourceFromString("bad:doesNotExist", Set.of(CLASSPATH_PROTOCOL));
+        assertTrue(resource instanceof ClassPathResource);
+        assertFalse(resource.exists());
+
+        // classpath is now not allowed either so it fails
+        assertNotAllowed("URL [bad://invalid] can't be found or is not allowed for loading resources",
+                () -> Utils.resourceFromString("bad://invalid", Set.of(FILE_PROTOCOL)));
+    }
+
+    // check urls that are allowed
+    @Test
+    public void tesResourceFromStringUri2() throws Exception {
+        Resource resource;
+
+        // we should be able to build the resources now that they allowed even if they don't exist
+        resource = Utils.resourceFromString("http://doesNotExist", Set.of("http"));
+        assertTrue(resource instanceof UrlResource);
+        assertFalse(resource.exists());
+
+        resource = Utils.resourceFromString("jar:file:invalid.jar!/", Set.of("jar"));
+        assertTrue(resource instanceof UrlResource);
+        assertFalse(resource.exists());
+
+        try {
+            // allowed but should have malformed error
+            Utils.resourceFromString("http:", Set.of("http"));
+            fail("should have exception");
+        } catch (MalformedURLException e) {
+            assertTrue(e.getCause() instanceof URISyntaxException);
+        }
+    }
+
+    private static void assertNotAllowed(String expected, Callable<?> callable) {
+        try {
+            callable.call();
+            fail("Should have failed with Exception");
+        } catch (Exception e) {
+            assertTrue(e instanceof IllegalArgumentException);
+            assertEquals(expected, e.getMessage());
+        }
+    }
+}

--- a/activemq-spring/src/test/java/org/apache/activemq/xbean/XBeanBrokerFactoryTest.java
+++ b/activemq-spring/src/test/java/org/apache/activemq/xbean/XBeanBrokerFactoryTest.java
@@ -1,0 +1,235 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.xbean;
+
+import static org.apache.activemq.xbean.XBeanBrokerFactory.DEFAULT_ALLOWED_PROTOCOLS;
+import static org.apache.activemq.xbean.XBeanBrokerFactory.XBEAN_BROKER_FACTORY_PROTOCOLS_PROP;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.FileNotFoundException;
+import java.net.UnknownHostException;
+import java.nio.file.NoSuchFileException;
+import java.util.Set;
+import org.apache.activemq.broker.BrokerFactory;
+import org.apache.activemq.broker.BrokerService;
+import org.apache.activemq.spring.Utils;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.FatalBeanException;
+
+public class XBeanBrokerFactoryTest {
+
+    @Before
+    public void setUp() throws Exception {
+        // reset before each test
+        System.setProperty(XBEAN_BROKER_FACTORY_PROTOCOLS_PROP, DEFAULT_ALLOWED_PROTOCOLS);
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        System.setProperty(XBEAN_BROKER_FACTORY_PROTOCOLS_PROP, DEFAULT_ALLOWED_PROTOCOLS);
+    }
+
+    @Test
+    public void testXBeanAllowedProtocolParsing() throws Exception {
+        // new instance will read the current property protocol prop and build set
+        XBeanBrokerFactory factory = new XBeanBrokerFactory();
+        assertEquals(Set.of(Utils.FILE_PROTOCOL, Utils.CLASSPATH_PROTOCOL), factory.getAllowedProtocols());
+
+        // set property
+        System.setProperty(XBEAN_BROKER_FACTORY_PROTOCOLS_PROP, "file,jar");
+        factory = new XBeanBrokerFactory();
+        assertEquals(Set.of("jar","file"), factory.getAllowedProtocols());
+        System.setProperty(XBEAN_BROKER_FACTORY_PROTOCOLS_PROP, "http");
+        factory = new XBeanBrokerFactory();
+        assertEquals(Set.of("http"), factory.getAllowedProtocols());
+
+        // check allow all
+        System.setProperty(XBEAN_BROKER_FACTORY_PROTOCOLS_PROP, "*");
+        factory = new XBeanBrokerFactory();
+        assertNull(factory.getAllowedProtocols());
+
+        // check allow none
+        System.setProperty(XBEAN_BROKER_FACTORY_PROTOCOLS_PROP, "");
+        factory = new XBeanBrokerFactory();
+        assertTrue(factory.getAllowedProtocols().isEmpty());
+
+        // test empty and white space only
+        System.setProperty(XBEAN_BROKER_FACTORY_PROTOCOLS_PROP, "jar  , ftp,   http");
+        factory = new XBeanBrokerFactory();
+        assertEquals(Set.of("jar","ftp", "http"), factory.getAllowedProtocols());
+        System.setProperty(XBEAN_BROKER_FACTORY_PROTOCOLS_PROP, "   ");
+        factory = new XBeanBrokerFactory();
+        assertTrue(factory.getAllowedProtocols().isEmpty());
+    }
+
+
+    // Test default protocols
+    @Test
+    public void testDefaultXBeanProtocols() throws Exception {
+        // file works
+        startBroker("xbean:src/test/resources/spring/xbean-test.xml");
+        startBroker("xbean:file:src/test/resources/spring/xbean-test.xml");
+
+        // classpath works
+        startBroker("xbean:spring/xbean-test.xml");
+        startBroker("xbean:classpath:spring/xbean-test.xml");
+
+        // http/fttp blocked by default
+        startBrokerNotAllowedError("xbean:http://bad/xbean-test.xml");
+        startBrokerNotAllowedError("xbean:ftp:bad/xbean-test.xml");
+        // should get illegal state exception, we are not allowed to use the jar protocol
+        startBrokerNotAllowedError("xbean:jar:file:invalid.jar!/");
+
+        // custom is not a known protocol so this is detected as invalid protocol
+        // and not a URI, so it fallsback and tries classpath which is allowed
+        // but won't be found
+        startBrokerBeanError("xbean:custom://invalid", FileNotFoundException.class);
+    }
+
+    @Test
+    public void testXBeanAllowNone() throws Exception {
+        // Allow nothing
+        System.setProperty(XBEAN_BROKER_FACTORY_PROTOCOLS_PROP, "");
+
+        // everything is not allowed
+        startBrokerNotAllowedError("xbean:http://bad/xbean-test.xml",
+                "No protocols are allowed for loading resources");
+        startBrokerNotAllowedError("xbean:ftp:bad/xbean-test.xml",
+                "No protocols are allowed for loading resources");
+        startBrokerNotAllowedError("xbean:jar:file:invalid.jar!/",
+                "No protocols are allowed for loading resources");
+        startBrokerNotAllowedError("xbean:src/test/resources/spring/xbean-test.xml",
+                "No protocols are allowed for loading resources");
+        startBrokerNotAllowedError("xbean:file:src/test/resources/spring/xbean-test.xml",
+                "No protocols are allowed for loading resources");
+        startBrokerNotAllowedError("xbean:classpath:src/test/resources/spring/xbean-test.xml",
+                "No protocols are allowed for loading resources");
+    }
+
+    @Test
+    public void testXBeanAllowAll() throws Exception {
+        // set to asterisk to allow all
+        System.setProperty(XBEAN_BROKER_FACTORY_PROTOCOLS_PROP, "*");
+
+        // file works
+        startBroker("xbean:src/test/resources/spring/xbean-test.xml");
+        startBroker("xbean:file:src/test/resources/spring/xbean-test.xml");
+        // classpath works
+        startBroker("xbean:spring/xbean-test.xml");
+        startBroker("xbean:classpath:spring/xbean-test.xml");
+        // jar, http, ftp are allowed so they just get bean errors as can't be found
+        startBrokerBeanError("xbean:jar:file:invalid.jar!/", NoSuchFileException.class);
+        startBrokerBeanError("xbean:ftp://invalid", UnknownHostException.class);
+        startBrokerBeanError("xbean:http://invalid", UnknownHostException.class);
+    }
+
+    @Test
+    public void testDefaultXBeanProtocolsCustom() throws Exception {
+        // update allowed list
+        System.setProperty(XBEAN_BROKER_FACTORY_PROTOCOLS_PROP, "jar,ftp,http");
+
+        // jar is allowed, but file is invalid so we get a different error
+        startBrokerBeanError("xbean:jar:file:invalid.jar!/", NoSuchFileException.class);
+
+        // ftp/http is allowed but url is invalid we get a different error
+        // because the host is unknown
+        startBrokerBeanError("xbean:ftp://invalid", UnknownHostException.class);
+        startBrokerBeanError("xbean:http://invalid", UnknownHostException.class);
+
+        // file and classpath are all blocked
+        startBrokerNotAllowedError("xbean:src/test/resources/spring/xbean-test.xml",
+                "can't be found or is not allowed");
+        startBrokerNotAllowedError("xbean:file:src/test/resources/spring/xbean-test.xml");
+        startBrokerNotAllowedError("xbean:spring/xbean-test.xml",
+                "can't be found or is not allowed");
+        startBrokerNotAllowedError("xbean:classpath:spring/xbean-test.xml");
+    }
+
+    @Test
+    public void testXBeanProtocolsOnlyFileOrClasspath() throws Exception {
+        // block classpath
+        System.setProperty(XBEAN_BROKER_FACTORY_PROTOCOLS_PROP, Utils.FILE_PROTOCOL);
+
+        // Files should work fine
+        startBroker("xbean:src/test/resources/spring/xbean-test.xml");
+        startBroker("xbean:file:src/test/resources/spring/xbean-test.xml");
+
+        // Classpath entries won't work
+        // not a URI and classpath isn't allowed so errors out
+        startBrokerNotAllowedError("xbean:spring/xbean-test.xml", "can't be found or is not allowed");
+        startBrokerNotAllowedError("xbean:classpath:spring/xbean-test.xml");
+
+        // block files, allow classpath
+        System.setProperty(XBEAN_BROKER_FACTORY_PROTOCOLS_PROP, Utils.CLASSPATH_PROTOCOL);
+
+        // Files should now break
+        // This will fallback to trying classpath because file isn't allowed and it isn't
+        // a qualified URI so it will just get a bean exception as won't be on the classpath
+        startBrokerBeanError("xbean:src/test/resources/spring/xbean-test.xml",
+                FileNotFoundException.class);
+        // qualified URI will try file no matter won't and will be blocked as file is not allowed
+        // so it won't fall back
+        startBrokerNotAllowedError("xbean:file:src/test/resources/spring/xbean-test.xml");
+
+        // classpath should work
+        startBroker("xbean:spring/xbean-test.xml");
+        startBroker("xbean:classpath:spring/xbean-test.xml");
+    }
+
+    private void startBrokerBeanError(String url, Class<? extends Exception> expected) throws Exception {
+        try {
+            startBroker(url);
+            fail("Should have failed with an exception");
+        } catch (FatalBeanException e) {
+            Throwable cause = e.getCause() != null ? e.getCause() : e;
+            assertTrue(expected.isAssignableFrom(cause.getClass()));
+        }
+    }
+
+    private void startBrokerNotAllowedError(String url) throws Exception {
+        startBrokerNotAllowedError(url, "does not use an allowed protocol for loading URL resources");
+    }
+
+    private void startBrokerNotAllowedError(String url, String expected) throws Exception {
+        try {
+            startBroker(url);
+            fail("Should have failed with an exception");
+        } catch (IllegalArgumentException e) {
+            assertTrue(e.getMessage().contains(expected));
+        }
+    }
+
+    private void startBroker(String url) throws Exception {
+        BrokerService broker = null;
+        try {
+            broker = BrokerFactory.createBroker(url);
+            assertNotNull(broker);
+            broker.stop();
+        } finally {
+            if (broker != null) {
+                broker.stop();
+                broker.waitUntilStopped();
+            }
+        }
+    }
+}

--- a/activemq-spring/src/test/resources/spring/xbean-test.xml
+++ b/activemq-spring/src/test/resources/spring/xbean-test.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+   
+    http://www.apache.org/licenses/LICENSE-2.0
+   
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<beans 
+  xmlns="http://www.springframework.org/schema/beans"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+  http://activemq.apache.org/schema/core http://activemq.apache.org/schema/core/activemq-core.xsd">
+
+  <broker useJmx="false"  xmlns="http://activemq.apache.org/schema/core" persistent="false">
+
+    <transportConnectors>
+      <transportConnector uri="tcp://localhost:0" />
+    </transportConnectors>
+        
+  </broker>
+  
+</beans>

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/spring/ActiveMQConnectionFactoryXBeanTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/spring/ActiveMQConnectionFactoryXBeanTest.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.spring;
+
+import static org.apache.activemq.xbean.XBeanBrokerFactory.DEFAULT_ALLOWED_PROTOCOLS;
+import static org.apache.activemq.xbean.XBeanBrokerFactory.XBEAN_BROKER_FACTORY_PROTOCOLS_PROP;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import jakarta.jms.Connection;
+import jakarta.jms.JMSException;
+import java.io.FileNotFoundException;
+import java.net.UnknownHostException;
+import java.nio.file.NoSuchFileException;
+import org.apache.activemq.ActiveMQConnectionFactory;
+import org.apache.activemq.test.annotations.ParallelTest;
+import org.apache.activemq.xbean.XBeanBrokerFactory;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.springframework.beans.FatalBeanException;
+
+@Category(ParallelTest.class)
+public class ActiveMQConnectionFactoryXBeanTest {
+
+    @Before
+    public void setUp() throws Exception {
+        // reset before each test
+        System.setProperty(XBEAN_BROKER_FACTORY_PROTOCOLS_PROP, DEFAULT_ALLOWED_PROTOCOLS);
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        System.setProperty(XBEAN_BROKER_FACTORY_PROTOCOLS_PROP, DEFAULT_ALLOWED_PROTOCOLS);
+    }
+
+    // File and classpath are allowed by default
+    @Test
+    public void testCreateBrokerDefaults() throws Exception {
+        // File resources
+        assertBrokerCreated("vm://localhost?brokerConfig=xbean:src/test/resources/activemq.xml");
+        assertBrokerCreated("vm://localhost?brokerConfig=xbean:file:src/test/resources/activemq.xml");
+
+        // Classpath resources
+        assertBrokerCreated("vm://localhost?brokerConfig=xbean:activemq.xml");
+        assertBrokerCreated("vm://localhost?brokerConfig=xbean:classpath:activemq.xml");
+
+        // other URL types blocked
+        assertUrlNotAllowed("vm://localhost?brokerConfig=xbean:http://activemq.xml");
+        assertUrlNotAllowed("vm://localhost?brokerConfig=xbean:ftp://activemq.xml");
+        assertUrlNotAllowed("vm://localhost?brokerConfig=xbean:jar:file:invalid.jar!/");
+
+        // Custom is not a valid protocol so this does not get processed as a URI
+        // so classpath is tried (as it is allowed and gets tried last with no uri
+        // prefix). Spring won't find the file on the classpath.
+        assertBrokerStartError("vm://localhost?brokerConfig=xbean:custom:activemq.xml",
+                FileNotFoundException.class);
+    }
+
+    @Test
+    public void testCreateBrokerAllowNone() {
+        // empty allows none
+        System.setProperty(XBeanBrokerFactory.XBEAN_BROKER_FACTORY_PROTOCOLS_PROP, "");
+
+        // File resources blocked
+        assertUrlNotAllowed("vm://localhost?brokerConfig=xbean:src/test/resources/activemq.xml",
+                "No protocols are allowed for loading resources");
+        assertUrlNotAllowed("vm://localhost?brokerConfig=xbean:file:src/test/resources/activemq.xml",
+                "No protocols are allowed for loading resources");
+
+        // Classpath resources blocked
+        assertUrlNotAllowed("vm://localhost?brokerConfig=xbean:activemq.xml",
+                "No protocols are allowed for loading resources");
+        assertUrlNotAllowed("vm://localhost?brokerConfig=xbean:classpath:activemq.xml",
+                "No protocols are allowed for loading resources");
+
+        //others blocked, we get IllegalArgumentException without trying to load
+        assertUrlNotAllowed("vm://localhost?brokerConfig=xbean:http://invalid",
+                "No protocols are allowed for loading resources");
+        assertUrlNotAllowed("vm://localhost?brokerConfig=xbean:ftp://invalid",
+                "No protocols are allowed for loading resources");
+        assertUrlNotAllowed("vm://localhost?brokerConfig=xbean:jar:file:invalid.jar!/",
+                "No protocols are allowed for loading resources");
+    }
+
+    // File and classpath are allowed by default
+    @Test
+    public void testCreateBrokerAllowAll() throws Exception {
+        // allow all with asterisk
+        System.setProperty(XBeanBrokerFactory.XBEAN_BROKER_FACTORY_PROTOCOLS_PROP, "*");
+
+        // File resources
+        assertBrokerCreated("vm://localhost?brokerConfig=xbean:src/test/resources/activemq.xml");
+        assertBrokerCreated("vm://localhost?brokerConfig=xbean:file:src/test/resources/activemq.xml");
+
+        // Classpath resources
+        assertBrokerCreated("vm://localhost?brokerConfig=xbean:activemq.xml");
+        assertBrokerCreated("vm://localhost?brokerConfig=xbean:classpath:activemq.xml");
+
+        // http/ftp allowed but unknown host
+        assertBrokerStartError("vm://localhost?brokerConfig=xbean:http://invalid",
+                UnknownHostException.class);
+        assertBrokerStartError("vm://localhost?brokerConfig=xbean:ftp://invalid",
+                UnknownHostException.class);
+    }
+
+    @Test
+    public void testCreateBrokerPropConfigured() throws Exception {
+        // allow only file and jar
+        System.setProperty(XBeanBrokerFactory.XBEAN_BROKER_FACTORY_PROTOCOLS_PROP, "file,jar,ftp");
+
+        // File resources - allowed
+        assertBrokerCreated("vm://localhost?brokerConfig=xbean:src/test/resources/activemq.xml");
+        assertBrokerCreated("vm://localhost?brokerConfig=xbean:file:src/test/resources/activemq.xml");
+
+        // Classpath resources - not allowed
+        assertUrlNotAllowed("vm://localhost?brokerConfig=xbean:activemq.xml",
+                "can't be found or is not allowed");
+        assertUrlNotAllowed("vm://localhost?brokerConfig=xbean:classpath:activemq.xml");
+
+        // http not allowed
+        assertUrlNotAllowed("vm://localhost?brokerConfig=xbean:http://invalid");
+
+        // ftp is allowed, but can't be found with bad host
+        assertBrokerStartError("vm://localhost?brokerConfig=xbean:ftp://invalid",
+                UnknownHostException.class);
+
+        // jar is now allowed but file doesn't exist
+        assertBrokerStartError("vm://localhost?brokerConfig=xbean:jar:file:invalid.jar!/", NoSuchFileException.class);
+    }
+
+    private void assertBrokerCreated(String url) throws JMSException {
+        final ActiveMQConnectionFactory factory = new ActiveMQConnectionFactory(url);
+        try (Connection connection = factory.createConnection()) {
+            assertNotNull(connection);
+        }
+    }
+
+    private void assertUrlNotAllowed(String url) {
+        assertUrlNotAllowed(url, "does not use an allowed protocol for loading URL resources");
+    }
+
+    private void assertUrlNotAllowed(String url, String error) {
+        final ActiveMQConnectionFactory factory = new ActiveMQConnectionFactory(url);
+        try (Connection ignored = factory.createConnection()) {
+            fail("Should of thrown exception");
+        } catch (JMSException e) {
+            assertTrue(e.getCause() instanceof IllegalArgumentException);
+            assertTrue(e.getMessage().contains(error));
+        }
+    }
+
+    private void assertBrokerStartError(String url, Class<? extends Exception> expected) {
+        final ActiveMQConnectionFactory factory = new ActiveMQConnectionFactory(url);
+        try (Connection ignored = factory.createConnection()) {
+            fail("Should have failed with an exception");
+        } catch (JMSException e) {
+            Throwable cause = e.getCause() != null ? e.getCause() : e;
+            assertTrue(cause instanceof FatalBeanException);
+            cause = cause.getCause() != null ? cause.getCause() : cause;
+            assertTrue(expected.isAssignableFrom(cause.getClass()));
+        }
+    }
+}


### PR DESCRIPTION
This adds a new system property to control which protocol types are valid for loading resources using the XBeanBrokerFactory. By default only file and classpath resources can be loaded.

The goal of this is to prevent possible future security issues by hardening what is allowed to be loaded by default.

(cherry picked from commit 85fa7bbf17be57107a624d7aa7161008fee7d488)