### PR TITLE
fix(spring/jetty): add depends-on for Jetty to start only when the broker is available

### DIFF
--- a/assembly/src/release/conf/activemq.xml
+++ b/assembly/src/release/conf/activemq.xml
@@ -31,7 +31,7 @@
     <!--
         The <broker> element is used to configure the ActiveMQ broker.
     -->
-    <broker xmlns="http://activemq.apache.org/schema/core" brokerName="localhost" dataDirectory="${activemq.data}">
+    <broker id="broker" xmlns="http://activemq.apache.org/schema/core" brokerName="localhost" dataDirectory="${activemq.data}">
 
         <destinationPolicy>
             <policyMap>

--- a/assembly/src/release/conf/jetty.xml
+++ b/assembly/src/release/conf/jetty.xml
@@ -15,6 +15,10 @@
         An embedded servlet engine for serving up the Admin consoles, REST and Ajax APIs and
         some demos Include this file in your configuration to enable ActiveMQ web components
         e.g. <import resource="jetty.xml"/>
+
+        Note: the broker element in your configuration must have id="broker" set so that
+        the Jetty server starts only after the broker is fully available.
+        e.g. <broker id="broker" xmlns="http://activemq.apache.org/schema/core" ...>
     -->
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
@@ -208,8 +212,8 @@
         </property>
     </bean>
     
-    <bean id="invokeStart" class="org.springframework.beans.factory.config.MethodInvokingFactoryBean" 
-        depends-on="configureJetty, invokeConnectors">
+    <bean id="invokeStart" class="org.springframework.beans.factory.config.MethodInvokingFactoryBean"
+        depends-on="configureJetty, invokeConnectors, broker">
         <property name="targetObject" ref="Server" />
         <property name="targetMethod" value="start" />      
     </bean>

--- a/assembly/src/release/examples/conf/activemq-demo.xml
+++ b/assembly/src/release/examples/conf/activemq-demo.xml
@@ -47,7 +47,7 @@
           - Change the brokerName attribute to something unique
     -->
 
-    <broker xmlns="http://activemq.apache.org/schema/core" brokerName="amq-broker" useJmx="true">
+    <broker id="broker" xmlns="http://activemq.apache.org/schema/core" brokerName="amq-broker" useJmx="true">
 
         <!--
             Examples of destination-specific policies using destination

--- a/assembly/src/release/examples/conf/activemq-security.xml
+++ b/assembly/src/release/examples/conf/activemq-security.xml
@@ -63,7 +63,7 @@
   </bean> 
   -->
 
-  <broker useJmx="true" persistent="false" xmlns="http://activemq.apache.org/schema/core" >
+  <broker id="broker" useJmx="true" persistent="false" xmlns="http://activemq.apache.org/schema/core" >
 
     <managementContext>
         <managementContext createConnector="true">

--- a/assembly/src/release/examples/conf/activemq-stomp.xml
+++ b/assembly/src/release/examples/conf/activemq-stomp.xml
@@ -44,7 +44,7 @@
     <!--
         The <broker> element is used to configure the ActiveMQ broker.
     -->
-    <broker xmlns="http://activemq.apache.org/schema/core" brokerName="localhost" dataDirectory="${activemq.data}">
+    <broker id="broker" xmlns="http://activemq.apache.org/schema/core" brokerName="localhost" dataDirectory="${activemq.data}">
 
         <!--
             For better performances use VM cursor and small memory limit.


### PR DESCRIPTION
This is a fix required by Spring 6.2.x, in order to avoid starting Jetty when the broker is a master.