### PR TITLE
fix(webconsole): the webconsole now redirect to the slave.jsp when required

### DIFF
--- a/activemq-web-console/src/main/java/org/apache/activemq/web/filter/ApplicationContextFilter.java
+++ b/activemq-web-console/src/main/java/org/apache/activemq/web/filter/ApplicationContextFilter.java
@@ -66,6 +66,7 @@ public class ApplicationContextFilter implements Filter {
     private String applicationContextName = "applicationContext";
     private String requestContextName = "requestContext";
     private String requestName = "request";
+    private String slavePage = "slave.jsp";
 
     public void init(FilterConfig config) throws ServletException {
         this.servletContext = config.getServletContext();
@@ -84,19 +85,22 @@ public class ApplicationContextFilter implements Filter {
         Map requestContextWrapper = createRequestContextWrapper(request);
         String path = ((HttpServletRequest)request).getRequestURI();
         // handle slave brokers
-//        try {
-//            if ( !(path.endsWith("css") || path.endsWith("png") || path.endsWith("ico") || path.endsWith(slavePage))
-//                    && ((BrokerFacade)requestContextWrapper.get("brokerQuery")).isSlave()) {
-//                ((HttpServletResponse)response).sendRedirect(slavePage);
-//                return;
-//            }
-//        } catch (Exception e) {
-//            LOG.warn(path + ", failed to access BrokerFacade: reason: " + e.getLocalizedMessage());
-//            if (LOG.isDebugEnabled()) {
-//                LOG.debug(request.toString(), e);
-//            }
-//            throw new IOException(e);
-//        }
+        try {
+            boolean isSlave = ((BrokerFacade) requestContextWrapper.get("brokerQuery")).getBrokerAdmin().isSlave();
+            if (isSlave && !(path.endsWith("css") || path.endsWith("png") || path.endsWith("ico") || path.endsWith(slavePage))) {
+                ((HttpServletResponse) response).sendRedirect(slavePage);
+                return;
+            } else if (!isSlave && path.endsWith(slavePage)) {
+                ((HttpServletResponse) response).sendRedirect(((HttpServletRequest) request).getContextPath() + "/index.jsp");
+                return;
+            }
+        } catch (Exception e) {
+            LOG.warn(path + ", failed to access BrokerFacade: reason: " + e.getLocalizedMessage());
+            if (LOG.isDebugEnabled()) {
+                LOG.debug(request.toString(), e);
+            }
+            throw new IOException(e);
+        }
         request.setAttribute(requestContextName, requestContextWrapper);
         request.setAttribute(requestName, request);
         chain.doFilter(request, response);

--- a/assembly/src/release/conf/activemq.xml
+++ b/assembly/src/release/conf/activemq.xml
@@ -31,7 +31,7 @@
     <!--
         The <broker> element is used to configure the ActiveMQ broker.
     -->
-    <broker xmlns="http://activemq.apache.org/schema/core" brokerName="localhost" dataDirectory="${activemq.data}">
+    <broker xmlns="http://activemq.apache.org/schema/core" brokerName="localhost" dataDirectory="${activemq.data}" id="broker">
 
         <destinationPolicy>
             <policyMap>

--- a/assembly/src/release/conf/jetty.xml
+++ b/assembly/src/release/conf/jetty.xml
@@ -209,7 +209,7 @@
     </bean>
     
     <bean id="invokeStart" class="org.springframework.beans.factory.config.MethodInvokingFactoryBean" 
-        depends-on="configureJetty, invokeConnectors">
+        depends-on="broker, configureJetty, invokeConnectors">
         <property name="targetObject" ref="Server" />
         <property name="targetMethod" value="start" />      
     </bean>

--- a/assembly/src/release/examples/conf/activemq-demo.xml
+++ b/assembly/src/release/examples/conf/activemq-demo.xml
@@ -47,7 +47,7 @@
           - Change the brokerName attribute to something unique
     -->
 
-    <broker xmlns="http://activemq.apache.org/schema/core" brokerName="amq-broker" useJmx="true">
+    <broker xmlns="http://activemq.apache.org/schema/core" brokerName="amq-broker" useJmx="true" id="broker">
 
         <!--
             Examples of destination-specific policies using destination

--- a/assembly/src/release/examples/conf/activemq-security.xml
+++ b/assembly/src/release/examples/conf/activemq-security.xml
@@ -63,7 +63,7 @@
   </bean> 
   -->
 
-  <broker useJmx="true" persistent="false" xmlns="http://activemq.apache.org/schema/core" >
+  <broker useJmx="true" persistent="false" xmlns="http://activemq.apache.org/schema/core" id="broker">
 
     <managementContext>
         <managementContext createConnector="true">

--- a/assembly/src/release/examples/conf/activemq-stomp.xml
+++ b/assembly/src/release/examples/conf/activemq-stomp.xml
@@ -44,7 +44,7 @@
     <!--
         The <broker> element is used to configure the ActiveMQ broker.
     -->
-    <broker xmlns="http://activemq.apache.org/schema/core" brokerName="localhost" dataDirectory="${activemq.data}">
+    <broker xmlns="http://activemq.apache.org/schema/core" brokerName="localhost" dataDirectory="${activemq.data}" id="broker">
 
         <!--
             For better performances use VM cursor and small memory limit.


### PR DESCRIPTION
When using `<broker ... startAsync="true">` in master/slave mode, the Jetty server can be started on slave.

In that case, the broker is not a "full active" broker yet, and the Web Console is poorly failing with an exception (and long stack trace in the log).

This PR fixes the Web Console, now dealing with slave broker and redirecting cleanly to `slave.jsp`.

NB: no impact on standalone/master broker, same behavior as today.