### PR TITLE
Fix 'occured' -> 'occurred' typos in 3 files

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/network/jms/JmsConnector.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/network/jms/JmsConnector.java
@@ -484,7 +484,7 @@ public abstract class JmsConnector implements Service {
      * during normal bridging operations.
      *
      * @param connection
-     * 		The connection that was in use when the failure occured.
+     * 		The connection that was in use when the failure occurred.
      */
     void handleConnectionFailure(Connection connection) {
 

--- a/activemq-client/src/main/java/org/apache/activemq/transport/TransportListener.java
+++ b/activemq-client/src/main/java/org/apache/activemq/transport/TransportListener.java
@@ -32,7 +32,7 @@ public interface TransportListener {
      */
     void onCommand(Object command);
     /**
-     * An unrecoverable exception has occured on the transport
+     * An unrecoverable exception has occurred on the transport
      * @param error
      */
     void onException(IOException error);

--- a/activemq-ra/src/main/java/org/apache/activemq/ra/SimpleConnectionManager.java
+++ b/activemq-ra/src/main/java/org/apache/activemq/ra/SimpleConnectionManager.java
@@ -58,12 +58,12 @@ public class SimpleConnectionManager implements ConnectionManager, ConnectionEve
         try {
             ((ManagedConnection)event.getSource()).cleanup();
         } catch (ResourceException e) {
-            LOG.warn("Error occured during the cleanup of a managed connection: ", e);
+            LOG.warn("Error occurred during the cleanup of a managed connection: ", e);
         }
         try {
             ((ManagedConnection)event.getSource()).destroy();
         } catch (ResourceException e) {
-            LOG.warn("Error occured during the destruction of a managed connection: ", e);
+            LOG.warn("Error occurred during the destruction of a managed connection: ", e);
         }
     }
 
@@ -93,12 +93,12 @@ public class SimpleConnectionManager implements ConnectionManager, ConnectionEve
         try {
             ((ManagedConnection)event.getSource()).cleanup();
         } catch (ResourceException e) {
-            LOG.warn("Error occured during the cleanup of a managed connection: ", e);
+            LOG.warn("Error occurred during the cleanup of a managed connection: ", e);
         }
         try {
             ((ManagedConnection)event.getSource()).destroy();
         } catch (ResourceException e) {
-            LOG.warn("Error occured during the destruction of a managed connection: ", e);
+            LOG.warn("Error occurred during the destruction of a managed connection: ", e);
         }
     }
 


### PR DESCRIPTION
Trivial spelling fix in three source files — `occured` → `occurred`.

Four of the fixes are in user-visible `LOG.warn` messages:

- `activemq-ra/.../SimpleConnectionManager.java` — four `LOG.warn("Error occurred during the cleanup/destruction of a managed connection: ", e)` calls emitted from `connectionClosed` / `connectionErrorOccurred`.

The other two are Javadoc:

- `activemq-client/.../TransportListener.java` — doc on `onException()`
- `activemq-broker/.../JmsConnector.java` — `@param` on `handleConnectionFailure()`

No functional changes.