### PR TITLE
Add remote file filtering for XBeanBrokerFactory

### DIFF
--- a/activemq-spring/src/main/java/org/apache/activemq/spring/Utils.java
+++ b/activemq-spring/src/main/java/org/apache/activemq/spring/Utils.java
@@ -32,6 +32,9 @@ public class Utils {
 
     public static final String FILE_PROTOCOL = "file";
     public static final String CLASSPATH_PROTOCOL = "classpath";
+    // Special marker to indicate we want to allow remote files such as
+    // Windows UNC, etc
+    public static final String REMOTE_FILE_PROTOCOL = "remote-" + FILE_PROTOCOL;
 
     public static Resource resourceFromString(String uri) throws MalformedURLException {
         // default allows all
@@ -49,7 +52,7 @@ public class Utils {
         // First, just try and load a local file (if it exists) and if "file"
         // as part of the allow list. This preserves previous behavior of
         // always optimistically trying a local file first.
-        if (isAllowFile(allowedProtocols) && new File(uri).exists()) {
+        if (isAllowFile(allowedProtocols, uri) && new File(uri).exists()) {
             resource = new FileSystemResource(uri);
         // If file isn't allowed, or if the file can't be found then check
         // if the string is a valid URL. If it's valid, then we need
@@ -77,22 +80,51 @@ public class Utils {
         return resource;
     }
 
-    static boolean isAllowFile(Set<String> allowedProtocols) {
-        return allowedProtocols == null || allowedProtocols.contains(FILE_PROTOCOL);
+    // These method treats local files and remote files (that are pre-fixed
+    // with two forward/backward slashes) differently
+    static boolean isAllowFile(Set<String> allowedProtocols, String uri) {
+        if (allowedProtocols == null) {
+            return true;
+        }
+        return isUnqualifiedRemoteFile(uri) ? allowedProtocols.contains(REMOTE_FILE_PROTOCOL) :
+                allowedProtocols.contains(FILE_PROTOCOL);
     }
 
     static boolean isAllowClasspath(Set<String> allowedProtocols) {
         return allowedProtocols == null || allowedProtocols.contains(CLASSPATH_PROTOCOL);
     }
 
-    private static void validateUrlAllowed(String uriString, Set<String> allowedProtocols)
+    static void validateUrlAllowed(String uriString, Set<String> allowedProtocols)
             throws URISyntaxException {
         // Use new URI() to get the scheme
         // This is important because ResourceUtils.getURL() actually searches
         // the classpath which we don't want to do if not allowed
-        if (allowedProtocols != null && !allowedProtocols.contains(new URI(uriString).getScheme())) {
-            throw new IllegalArgumentException("URL [" + uriString +
-                    "] does not use an allowed protocol for loading URL resources");
+        if (allowedProtocols != null) {
+            final String detectedProtocol = getProtocolFromScheme(uriString);
+            if (detectedProtocol == null) {
+                throw new IllegalArgumentException("Could not detect protocol in given URI [" + uriString + "]");
+            }
+            if (!allowedProtocols.contains(detectedProtocol)){
+                throw new IllegalArgumentException("URL [" + uriString +
+                        "] uses protocol '" + detectedProtocol + "' which is not allowed "
+                        + "for loading URL resources");
+            }
         }
+    }
+
+    // If this is a qualified remote file then we return a special marker
+    // so that we know this is trying to access a remote resource as that will be
+    // validated differently
+    private static String getProtocolFromScheme(String uriString) throws URISyntaxException {
+        return isQualifiedRemoteFile(uriString) ? REMOTE_FILE_PROTOCOL :
+                new URI(uriString).getScheme();
+    }
+
+    private static boolean isUnqualifiedRemoteFile(String uri) {
+        return uri.startsWith("//") || uri.startsWith("\\\\");
+    }
+
+    private static boolean isQualifiedRemoteFile(String uri) {
+        return uri.startsWith(FILE_PROTOCOL + "://") ||  uri.startsWith(FILE_PROTOCOL + ":\\\\");
     }
 }

--- a/activemq-spring/src/main/java/org/apache/activemq/spring/Utils.java
+++ b/activemq-spring/src/main/java/org/apache/activemq/spring/Utils.java
@@ -74,8 +74,8 @@ public class Utils {
         // Catch all fail-safe if nothing else matches. This could happen if file is allowed
         // but not classpath but the file doesn't exist
         } else {
-            throw new IllegalArgumentException("URL [" + uri + "] can't be found or is not allowed"
-                    + " for loading resources");
+            throw new IllegalArgumentException("URL [" + uri + "] can't be found or the protocol"
+                    + " is not allowed for loading resources");
         }
         return resource;
     }

--- a/activemq-spring/src/test/java/org/apache/activemq/spring/UtilsTest.java
+++ b/activemq-spring/src/test/java/org/apache/activemq/spring/UtilsTest.java
@@ -18,8 +18,10 @@ package org.apache.activemq.spring;
 
 import static org.apache.activemq.spring.Utils.CLASSPATH_PROTOCOL;
 import static org.apache.activemq.spring.Utils.FILE_PROTOCOL;
+import static org.apache.activemq.spring.Utils.REMOTE_FILE_PROTOCOL;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -36,13 +38,44 @@ import org.springframework.core.io.UrlResource;
 public class UtilsTest {
 
     @Test
-    public void testIsAllowFile() {
-        assertTrue(Utils.isAllowFile(null));
-        assertTrue(Utils.isAllowFile(Set.of(FILE_PROTOCOL)));
-        assertTrue(Utils.isAllowFile(Set.of(FILE_PROTOCOL, "ftp", "ssl")));
-        assertFalse(Utils.isAllowFile(Set.of(CLASSPATH_PROTOCOL, "ftp", "ssl")));
-        assertFalse(Utils.isAllowFile(Set.of()));
-        assertFalse(Utils.isAllowFile(Set.of("")));
+    public void testIsAllowLocalFile() {
+        Set<String> localFileExamples = Set.of("/some/absolute/file", "relative/file", "file.txt");
+        for (String localFile : localFileExamples) {
+            assertTrue(Utils.isAllowFile(null, localFile));
+            assertTrue(Utils.isAllowFile(Set.of(FILE_PROTOCOL), localFile));
+            assertTrue(Utils.isAllowFile(Set.of(FILE_PROTOCOL, "ftp", "ssl"), localFile));
+
+            assertFalse(Utils.isAllowFile(Set.of(CLASSPATH_PROTOCOL, "ftp", "ssl"), localFile));
+            assertFalse(Utils.isAllowFile(Set.of(), localFile));
+            assertFalse(Utils.isAllowFile(Set.of(""), localFile));   
+        }
+
+        // Test a remote file isn't allowed with only local
+        // Check windows backward slashes as well
+        Set<String> remoteFileExamples = Set.of("//some/remote/file", "\\\\remote\\file");
+        for (String remoteFileName : remoteFileExamples) {
+            assertTrue(Utils.isAllowFile(null, remoteFileName));
+            // None of these should be allowed as remote-file isn't included with FILE
+            assertFalse(Utils.isAllowFile(Set.of(FILE_PROTOCOL), remoteFileName));
+            assertFalse(Utils.isAllowFile(Set.of(FILE_PROTOCOL, "ftp", "ssl"), remoteFileName));
+        }
+
+    }
+
+    @Test
+    public void testIsAllowRemoteFile() {
+
+        // Test a remote file
+        Set<String> remoteFileExamples = Set.of("//some/remote/file", "\\\\remote\\file");
+        for (String remoteFileName : remoteFileExamples) {
+            assertTrue(Utils.isAllowFile(null, remoteFileName));
+            assertTrue(Utils.isAllowFile(Set.of(REMOTE_FILE_PROTOCOL), remoteFileName));
+            assertTrue(Utils.isAllowFile(Set.of(REMOTE_FILE_PROTOCOL, "ftp", "ssl"), remoteFileName));
+            assertFalse(Utils.isAllowFile(Set.of(CLASSPATH_PROTOCOL, "ftp", "ssl"), remoteFileName));
+            assertFalse(Utils.isAllowFile(Set.of(), remoteFileName));
+            assertFalse(Utils.isAllowFile(Set.of(""), remoteFileName));
+        }
+
     }
 
     @Test
@@ -55,53 +88,120 @@ public class UtilsTest {
         assertFalse(Utils.isAllowClasspath(Set.of("")));
     }
 
-    // Test 1: Check file is NOT allowed to load, and does NOT exist
     @Test
-    public void tesResourceFromStringFile1() throws Exception {
+    public void testValidateUrlAllowed() throws URISyntaxException {
+        // not a qualified url so this throws an exception
+        assertValidateUrlAllowedThrows("somefile.txt", Set.of(FILE_PROTOCOL));
+
+        // Test File - Allowed
+        Utils.validateUrlAllowed("file:/somefile.txt", Set.of(FILE_PROTOCOL));
+        Utils.validateUrlAllowed("file:/somefile.txt", Set.of(FILE_PROTOCOL, CLASSPATH_PROTOCOL));
+        Utils.validateUrlAllowed("file:some/other/file.txt", null);
+
+        // Test File - Blocked
+        assertValidateUrlAllowedThrows("file:somefile.txt", Set.of());
+        assertValidateUrlAllowedThrows("file:some/other/file.txt", Set.of(""));
+        assertValidateUrlAllowedThrows("file:some/other/file.txt", Set.of(CLASSPATH_PROTOCOL));
+
+        // Test Remote File - Allowed
+        Utils.validateUrlAllowed("file://somefile.txt", Set.of(REMOTE_FILE_PROTOCOL));
+        Utils.validateUrlAllowed("file://somefile.txt", Set.of(FILE_PROTOCOL, REMOTE_FILE_PROTOCOL));
+        Utils.validateUrlAllowed("file://some/other/file.txt", null);
+
+        // Test File - Blocked
+        assertValidateUrlAllowedThrows("file://somefile.txt", Set.of());
+        assertValidateUrlAllowedThrows("file://some/other/file.txt", Set.of(""));
+        assertValidateUrlAllowedThrows("file://some/other/file.txt", Set.of(FILE_PROTOCOL));
+
+        // Test http - Allowed
+        Utils.validateUrlAllowed("http://somefile.txt", Set.of("http"));
+        Utils.validateUrlAllowed("http://somefile.txt", Set.of(FILE_PROTOCOL, "http"));
+        Utils.validateUrlAllowed("http://some/other/file.txt", null);
+
+        // Test http - Blocked
+        assertValidateUrlAllowedThrows("http://somefile.txt", Set.of());
+        assertValidateUrlAllowedThrows("http://some/other/file.txt", Set.of(""));
+        assertValidateUrlAllowedThrows("http://some/other/file.txt", Set.of("ftp"));
+    }
+
+    private void assertValidateUrlAllowedThrows(String uriString, Set<String> allowedProtocols)
+            throws URISyntaxException {
+        try {
+            Utils.validateUrlAllowed(uriString, allowedProtocols);
+            fail("Should have failed with an exception");
+        } catch (IllegalArgumentException ignored) {
+            // expected
+        }
+    }
+
+    // Test 1: Check file and remote file is NOT allowed to load, and does NOT exist
+    @Test
+    public void testResourceFromStringFile1() throws Exception {
+        testResourceFromStringFile1(FILE_PROTOCOL, "doesNotExist", "file:doesNotExist");
+    }
+
+    @Test
+    public void testResourceFromStringRemoteFile1() throws Exception {
+        testResourceFromStringFile1(REMOTE_FILE_PROTOCOL, "//doesNotExist", "file://doesNotExist");
+    }
+
+    protected void testResourceFromStringFile1(String protocol, String url, String fqUrl) throws Exception {
         Resource resource;
 
         // file not allowed, only jar
-        assertNotAllowed("URL [doesNotExist] can't be found or is not allowed for loading resources",
-                () -> Utils.resourceFromString("doesNotExist", Set.of("jar")));
+        assertNotAllowed("URL [" + url + "] can't be found or is not allowed for loading resources",
+                () -> Utils.resourceFromString(url, Set.of("jar")));
         // if classpath is allowed and not fully qualified, it will not find the file and fallback
-        resource = Utils.resourceFromString("doesNotExist", Set.of(CLASSPATH_PROTOCOL));
+        resource = Utils.resourceFromString(url, Set.of(CLASSPATH_PROTOCOL));
         assertTrue(resource instanceof ClassPathResource);
         assertFalse(resource.exists());
         // fully qualified fails regardless
-        assertNotAllowed("URL [file:doesNotExist] does not use an allowed protocol for loading URL resources",
-                () -> Utils.resourceFromString("file:doesNotExist", Set.of(CLASSPATH_PROTOCOL)));
+        assertNotAllowed("URL [" + fqUrl + "] uses protocol '" + protocol + "' which is not allowed for loading URL resources",
+                () -> Utils.resourceFromString(fqUrl, Set.of(CLASSPATH_PROTOCOL)));
         // Test Uri format, empty set not allowed
         assertNotAllowed("No protocols are allowed for loading resources.",
-                () -> Utils.resourceFromString("file:doesNotExist", Set.of()));
+                () -> Utils.resourceFromString(fqUrl, Set.of()));
 
     }
 
-    // Test 2: Check file is allowed to load, but it does not exist
+    // Test 2: Check file and remote file is allowed to load, but it does not exist
     // This will throw an exception if classpath is not allowed or fully qualified uri,
     // otherwise it will fallback to try classpath if classpath is allowed
     @Test
-    public void tesResourceFromStringFile2() throws Exception {
+    public void testResourceFromStringFile2() throws Exception {
+        testResourceFromStringFile2(FILE_PROTOCOL, "doesNotExist", "file:doesNotExist");
+    }
+
+    @Test
+    public void testResourceFromStringRemoteFile2() throws Exception {
+        testResourceFromStringFile2(REMOTE_FILE_PROTOCOL, "//doesNotExist", "file://doesNotExist");
+    }
+
+    protected void testResourceFromStringFile2(String protocol, String url, String fqUrl) throws Exception {
         Resource resource;
 
         //classpath allowed so it will fallback
-        resource = Utils.resourceFromString("doesNotExist", Set.of(FILE_PROTOCOL, CLASSPATH_PROTOCOL));
+        resource = Utils.resourceFromString(url, Set.of(protocol, CLASSPATH_PROTOCOL));
         assertTrue(resource instanceof ClassPathResource);
         assertFalse(resource.exists());
-        resource = Utils.resourceFromString("doesNotExist", null);
+        resource = Utils.resourceFromString(url, null);
         assertTrue(resource instanceof ClassPathResource);
         assertFalse(resource.exists());
         // single argument - default is null for allowed protocols so all are allowed
-        resource = Utils.resourceFromString("doesNotExist");
+        resource = Utils.resourceFromString(url);
         assertTrue(resource instanceof ClassPathResource);
         assertFalse(resource.exists());
         // classpath not allowed so we get an exception as we can't find it
-        assertNotAllowed("URL [doesNotExist] can't be found or is not allowed for loading resources",
-                () -> Utils.resourceFromString("doesNotExist", Set.of(FILE_PROTOCOL)));
+        assertNotAllowed("URL [" + url + "] can't be found or is not allowed for loading resources",
+                () -> Utils.resourceFromString(url, Set.of(protocol)));
+        resource = Utils.resourceFromString(fqUrl, Set.of(protocol));
+        assertNotNull(resource);
+        assertFalse(resource.exists());
     }
 
     // Test 3: Check file is NOT allowed to load, but it does exist
     @Test
-    public void tesResourceFromStringFile3() throws Exception {
+    public void tetsResourceFromStringFile3() throws Exception {
         Resource resource;
 
         // Test using "jar" as allowed so we don't fallback
@@ -115,13 +215,13 @@ public class UtilsTest {
         assertNotAllowed("No protocols are allowed for loading resources.",
                 () -> Utils.resourceFromString("src/test/resources/activemq.xml", Set.of()));
         // Test Uri format - only classpath allowed
-        assertNotAllowed("URL [file:src/test/resources/activemq.xml] does not use an allowed protocol for loading URL resources",
+        assertNotAllowed("URL [file:src/test/resources/activemq.xml] uses protocol 'file' which is not allowed for loading URL resources",
                 () -> Utils.resourceFromString("file:src/test/resources/activemq.xml", Set.of(CLASSPATH_PROTOCOL)));
     }
 
     // Test 4: Check file is both allowed and exists
     @Test
-    public void tesResourceFromStringFile4() throws Exception {
+    public void testResourceFromStringFile4() throws Exception {
         Resource resource;
 
         resource = Utils.resourceFromString("src/test/resources/activemq.xml", Set.of(FILE_PROTOCOL));
@@ -136,11 +236,11 @@ public class UtilsTest {
 
     // Test 1: Check classpath is NOT allowed to load, and does NOT exist
     @Test
-    public void tesResourceFromStringClasspath1() {
+    public void tetsResourceFromStringClasspath1() {
         // Check classpath is NOT allowed to load, and does NOT exist
         assertNotAllowed("URL [doesNotExist] can't be found or is not allowed for loading resources",
                 () -> Utils.resourceFromString("doesNotExist", Set.of(FILE_PROTOCOL)));
-        assertNotAllowed("URL [classpath:doesNotExist] does not use an allowed protocol for loading URL resources",
+        assertNotAllowed("URL [classpath:doesNotExist] uses protocol 'classpath' which is not allowed for loading URL resources",
                 () -> Utils.resourceFromString("classpath:doesNotExist", Set.of(FILE_PROTOCOL)));
         // Test Uri format, empty set not allowed
         assertNotAllowed("No protocols are allowed for loading resources.",
@@ -151,7 +251,7 @@ public class UtilsTest {
     // This will return a classpath resource because file is tried first
     // but won't be found so it eventually returns a classpath resource
     @Test
-    public void tesResourceFromStringClasspath2() throws Exception {
+    public void testResourceFromStringClasspath2() throws Exception {
         Resource resource;
 
         resource = Utils.resourceFromString("doesNotExist", Set.of(FILE_PROTOCOL, CLASSPATH_PROTOCOL));
@@ -171,7 +271,7 @@ public class UtilsTest {
 
     // Test 3: Check classpath is NOT allowed to load, but it does exist
     @Test
-    public void tesResourceFromStringClasspath3() {
+    public void testResourceFromStringClasspath3() {
         // This exists on the classpath but not allowed, only file is allowed
         assertNotAllowed("URL [activemq.xml] can't be found or is not allowed for loading resources",
                 () -> Utils.resourceFromString("activemq.xml", Set.of(FILE_PROTOCOL)));
@@ -179,12 +279,12 @@ public class UtilsTest {
         assertNotAllowed("No protocols are allowed for loading resources.",
                 () -> Utils.resourceFromString("activemq.xml", Set.of()));
         // Test Uri format - only file allowed
-        assertNotAllowed("URL [classpath:activemq.xml] does not use an allowed protocol for loading URL resources",
+        assertNotAllowed("URL [classpath:activemq.xml] uses protocol 'classpath' which is not allowed for loading URL resources",
                 () -> Utils.resourceFromString("classpath:activemq.xml", Set.of(FILE_PROTOCOL)));
     }
 
     @Test
-    public void tesResourceFromStringClasspath4() throws Exception {
+    public void testResourceFromStringClasspath4() throws Exception {
         Resource resource;
 
         // Test 4: Check classpath is both allowed and exists
@@ -199,15 +299,19 @@ public class UtilsTest {
 
     // Test URIs not allowed
     @Test
-    public void tesResourceFromStringUri1() throws Exception {
+    public void testResourceFromStringUri1() throws Exception {
         Resource resource;
 
         // none of these protocols are allowed
-        assertNotAllowed("URL [http://invalid] does not use an allowed protocol for loading URL resources",
+        assertNotAllowed("URL [file://invalid] uses protocol 'remote-file' which is not allowed for loading URL resources",
+                () -> Utils.resourceFromString("file://invalid", Set.of(FILE_PROTOCOL,CLASSPATH_PROTOCOL)));
+        assertNotAllowed("URL [file:\\\\invalid] uses protocol 'remote-file' which is not allowed for loading URL resources",
+                () -> Utils.resourceFromString("file:\\\\invalid", Set.of(FILE_PROTOCOL,CLASSPATH_PROTOCOL)));
+        assertNotAllowed("URL [http://invalid] uses protocol 'http' which is not allowed for loading URL resources",
                 () -> Utils.resourceFromString("http://invalid", Set.of(FILE_PROTOCOL,CLASSPATH_PROTOCOL)));
-        assertNotAllowed("URL [ftp://invalid] does not use an allowed protocol for loading URL resources",
+        assertNotAllowed("URL [ftp://invalid] uses protocol 'ftp' which is not allowed for loading URL resources",
                 () -> Utils.resourceFromString("ftp://invalid", Set.of(FILE_PROTOCOL,CLASSPATH_PROTOCOL)));
-        assertNotAllowed("URL [jar:file:invalid.jar!/] does not use an allowed protocol for loading URL resources",
+        assertNotAllowed("URL [jar:file:invalid.jar!/] uses protocol 'jar' which is not allowed for loading URL resources",
                 () -> Utils.resourceFromString("jar:file:invalid.jar!/", Set.of(FILE_PROTOCOL,CLASSPATH_PROTOCOL)));
         assertNotAllowed("No protocols are allowed for loading resources.",
                 () -> Utils.resourceFromString("http://invalid", Set.of()));
@@ -237,7 +341,7 @@ public class UtilsTest {
 
     // check urls that are allowed
     @Test
-    public void tesResourceFromStringUri2() throws Exception {
+    public void testResourceFromStringUri2() throws Exception {
         Resource resource;
 
         // we should be able to build the resources now that they allowed even if they don't exist

--- a/activemq-spring/src/test/java/org/apache/activemq/spring/UtilsTest.java
+++ b/activemq-spring/src/test/java/org/apache/activemq/spring/UtilsTest.java
@@ -59,12 +59,10 @@ public class UtilsTest {
             assertFalse(Utils.isAllowFile(Set.of(FILE_PROTOCOL), remoteFileName));
             assertFalse(Utils.isAllowFile(Set.of(FILE_PROTOCOL, "ftp", "ssl"), remoteFileName));
         }
-
     }
 
     @Test
     public void testIsAllowRemoteFile() {
-
         // Test a remote file
         Set<String> remoteFileExamples = Set.of("//some/remote/file", "\\\\remote\\file");
         for (String remoteFileName : remoteFileExamples) {
@@ -75,7 +73,6 @@ public class UtilsTest {
             assertFalse(Utils.isAllowFile(Set.of(), remoteFileName));
             assertFalse(Utils.isAllowFile(Set.of(""), remoteFileName));
         }
-
     }
 
     @Test
@@ -112,6 +109,8 @@ public class UtilsTest {
         assertValidateUrlAllowedThrows("file://somefile.txt", Set.of());
         assertValidateUrlAllowedThrows("file://some/other/file.txt", Set.of(""));
         assertValidateUrlAllowedThrows("file://some/other/file.txt", Set.of(FILE_PROTOCOL));
+        // Test extra slash, we consider everything with more than one slash to be remote to simplify
+        assertValidateUrlAllowedThrows("file:///some/other/file.txt", Set.of(FILE_PROTOCOL));
 
         // Test http - Allowed
         Utils.validateUrlAllowed("http://somefile.txt", Set.of("http"));
@@ -149,7 +148,7 @@ public class UtilsTest {
         Resource resource;
 
         // file not allowed, only jar
-        assertNotAllowed("URL [" + url + "] can't be found or is not allowed for loading resources",
+        assertNotAllowed("URL [" + url + "] can't be found or the protocol is not allowed for loading resources",
                 () -> Utils.resourceFromString(url, Set.of("jar")));
         // if classpath is allowed and not fully qualified, it will not find the file and fallback
         resource = Utils.resourceFromString(url, Set.of(CLASSPATH_PROTOCOL));
@@ -192,7 +191,7 @@ public class UtilsTest {
         assertTrue(resource instanceof ClassPathResource);
         assertFalse(resource.exists());
         // classpath not allowed so we get an exception as we can't find it
-        assertNotAllowed("URL [" + url + "] can't be found or is not allowed for loading resources",
+        assertNotAllowed("URL [" + url + "] can't be found or the protocol is not allowed for loading resources",
                 () -> Utils.resourceFromString(url, Set.of(protocol)));
         resource = Utils.resourceFromString(fqUrl, Set.of(protocol));
         assertNotNull(resource);
@@ -205,7 +204,7 @@ public class UtilsTest {
         Resource resource;
 
         // Test using "jar" as allowed so we don't fallback
-        assertNotAllowed("URL [src/test/resources/activemq.xml] can't be found or is not allowed for loading resources",
+        assertNotAllowed("URL [src/test/resources/activemq.xml] can't be found or the protocol is not allowed for loading resources",
                 () -> Utils.resourceFromString("src/test/resources/activemq.xml", Set.of("jar")));
         // classpath is allowed so it won't find the file and fallback to classpath
         resource = Utils.resourceFromString("src/test/resources/activemq.xml", Set.of(CLASSPATH_PROTOCOL));
@@ -238,7 +237,7 @@ public class UtilsTest {
     @Test
     public void tetsResourceFromStringClasspath1() {
         // Check classpath is NOT allowed to load, and does NOT exist
-        assertNotAllowed("URL [doesNotExist] can't be found or is not allowed for loading resources",
+        assertNotAllowed("URL [doesNotExist] can't be found or the protocol is not allowed for loading resources",
                 () -> Utils.resourceFromString("doesNotExist", Set.of(FILE_PROTOCOL)));
         assertNotAllowed("URL [classpath:doesNotExist] uses protocol 'classpath' which is not allowed for loading URL resources",
                 () -> Utils.resourceFromString("classpath:doesNotExist", Set.of(FILE_PROTOCOL)));
@@ -273,7 +272,7 @@ public class UtilsTest {
     @Test
     public void testResourceFromStringClasspath3() {
         // This exists on the classpath but not allowed, only file is allowed
-        assertNotAllowed("URL [activemq.xml] can't be found or is not allowed for loading resources",
+        assertNotAllowed("URL [activemq.xml] can't be found or the protocol is not allowed for loading resources",
                 () -> Utils.resourceFromString("activemq.xml", Set.of(FILE_PROTOCOL)));
         // empty allow list
         assertNotAllowed("No protocols are allowed for loading resources.",
@@ -335,7 +334,7 @@ public class UtilsTest {
         assertFalse(resource.exists());
 
         // classpath is now not allowed either so it fails
-        assertNotAllowed("URL [bad://invalid] can't be found or is not allowed for loading resources",
+        assertNotAllowed("URL [bad://invalid] can't be found or the protocol is not allowed for loading resources",
                 () -> Utils.resourceFromString("bad://invalid", Set.of(FILE_PROTOCOL)));
     }
 

--- a/activemq-spring/src/test/java/org/apache/activemq/xbean/XBeanBrokerFactoryTest.java
+++ b/activemq-spring/src/test/java/org/apache/activemq/xbean/XBeanBrokerFactoryTest.java
@@ -99,6 +99,8 @@ public class XBeanBrokerFactoryTest {
         startBrokerNotAllowedError("xbean:ftp:bad/xbean-test.xml");
         // should get illegal state exception, we are not allowed to use the jar protocol
         startBrokerNotAllowedError("xbean:jar:file:invalid.jar!/");
+        // remote file is blocked
+        startBrokerNotAllowedError("xbean:file://remote/xbean-test.xml");
 
         // custom is not a known protocol so this is detected as invalid protocol
         // and not a URI, so it fallsback and tries classpath which is allowed
@@ -120,7 +122,11 @@ public class XBeanBrokerFactoryTest {
                 "No protocols are allowed for loading resources");
         startBrokerNotAllowedError("xbean:src/test/resources/spring/xbean-test.xml",
                 "No protocols are allowed for loading resources");
+        startBrokerNotAllowedError("xbean://src/test/resources/spring/xbean-test.xml",
+                "No protocols are allowed for loading resources");
         startBrokerNotAllowedError("xbean:file:src/test/resources/spring/xbean-test.xml",
+                "No protocols are allowed for loading resources");
+        startBrokerNotAllowedError("xbean:file://src/test/resources/spring/xbean-test.xml",
                 "No protocols are allowed for loading resources");
         startBrokerNotAllowedError("xbean:classpath:src/test/resources/spring/xbean-test.xml",
                 "No protocols are allowed for loading resources");
@@ -141,6 +147,8 @@ public class XBeanBrokerFactoryTest {
         startBrokerBeanError("xbean:jar:file:invalid.jar!/", NoSuchFileException.class);
         startBrokerBeanError("xbean:ftp://invalid", UnknownHostException.class);
         startBrokerBeanError("xbean:http://invalid", UnknownHostException.class);
+        // check remote file too
+        startBrokerBeanError("xbean:file://invalid", UnknownHostException.class);
     }
 
     @Test
@@ -156,10 +164,13 @@ public class XBeanBrokerFactoryTest {
         startBrokerBeanError("xbean:ftp://invalid", UnknownHostException.class);
         startBrokerBeanError("xbean:http://invalid", UnknownHostException.class);
 
-        // file and classpath are all blocked
+        // file, remote file and classpath are all blocked
         startBrokerNotAllowedError("xbean:src/test/resources/spring/xbean-test.xml",
                 "can't be found or is not allowed");
+        startBrokerNotAllowedError("xbean://remote/spring/xbean-test.xml",
+                "can't be found or is not allowed");
         startBrokerNotAllowedError("xbean:file:src/test/resources/spring/xbean-test.xml");
+        startBrokerNotAllowedError("xbean:file://remote/spring/xbean-test.xml");
         startBrokerNotAllowedError("xbean:spring/xbean-test.xml",
                 "can't be found or is not allowed");
         startBrokerNotAllowedError("xbean:classpath:spring/xbean-test.xml");
@@ -207,7 +218,7 @@ public class XBeanBrokerFactoryTest {
     }
 
     private void startBrokerNotAllowedError(String url) throws Exception {
-        startBrokerNotAllowedError(url, "does not use an allowed protocol for loading URL resources");
+        startBrokerNotAllowedError(url, "which is not allowed for loading URL resources");
     }
 
     private void startBrokerNotAllowedError(String url, String expected) throws Exception {

--- a/activemq-spring/src/test/java/org/apache/activemq/xbean/XBeanBrokerFactoryTest.java
+++ b/activemq-spring/src/test/java/org/apache/activemq/xbean/XBeanBrokerFactoryTest.java
@@ -166,13 +166,13 @@ public class XBeanBrokerFactoryTest {
 
         // file, remote file and classpath are all blocked
         startBrokerNotAllowedError("xbean:src/test/resources/spring/xbean-test.xml",
-                "can't be found or is not allowed");
+                "can't be found or the protocol is not allowed");
         startBrokerNotAllowedError("xbean://remote/spring/xbean-test.xml",
-                "can't be found or is not allowed");
+                "can't be found or the protocol is not allowed");
         startBrokerNotAllowedError("xbean:file:src/test/resources/spring/xbean-test.xml");
         startBrokerNotAllowedError("xbean:file://remote/spring/xbean-test.xml");
         startBrokerNotAllowedError("xbean:spring/xbean-test.xml",
-                "can't be found or is not allowed");
+                "can't be found or the protocol is not allowed");
         startBrokerNotAllowedError("xbean:classpath:spring/xbean-test.xml");
     }
 
@@ -187,7 +187,7 @@ public class XBeanBrokerFactoryTest {
 
         // Classpath entries won't work
         // not a URI and classpath isn't allowed so errors out
-        startBrokerNotAllowedError("xbean:spring/xbean-test.xml", "can't be found or is not allowed");
+        startBrokerNotAllowedError("xbean:spring/xbean-test.xml", "can't be found or the protocol is not allowed");
         startBrokerNotAllowedError("xbean:classpath:spring/xbean-test.xml");
 
         // block files, allow classpath

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/spring/ActiveMQConnectionFactoryXBeanTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/spring/ActiveMQConnectionFactoryXBeanTest.java
@@ -61,6 +61,12 @@ public class ActiveMQConnectionFactoryXBeanTest {
         assertBrokerCreated("vm://localhost?brokerConfig=xbean:activemq.xml");
         assertBrokerCreated("vm://localhost?brokerConfig=xbean:classpath:activemq.xml");
 
+        // Remote file not allowed by default, falls back to classpath as it isn't fully qualified
+        assertBrokerStartError("vm://localhost?brokerConfig=xbean://activemq.xml",
+                FileNotFoundException.class);
+        // Remote file not allowed by default
+        assertUrlNotAllowed("vm://localhost?brokerConfig=xbean:file://activemq.xml");
+
         // other URL types blocked
         assertUrlNotAllowed("vm://localhost?brokerConfig=xbean:http://activemq.xml");
         assertUrlNotAllowed("vm://localhost?brokerConfig=xbean:ftp://activemq.xml");
@@ -82,6 +88,12 @@ public class ActiveMQConnectionFactoryXBeanTest {
         assertUrlNotAllowed("vm://localhost?brokerConfig=xbean:src/test/resources/activemq.xml",
                 "No protocols are allowed for loading resources");
         assertUrlNotAllowed("vm://localhost?brokerConfig=xbean:file:src/test/resources/activemq.xml",
+                "No protocols are allowed for loading resources");
+
+        // Remote file resources blocked
+        assertUrlNotAllowed("vm://localhost?brokerConfig=xbean://remote/resources/activemq.xml",
+                "No protocols are allowed for loading resources");
+        assertUrlNotAllowed("vm://localhost?brokerConfig=xbean:file://remote/resources/activemq.xml",
                 "No protocols are allowed for loading resources");
 
         // Classpath resources blocked
@@ -129,6 +141,11 @@ public class ActiveMQConnectionFactoryXBeanTest {
         assertBrokerCreated("vm://localhost?brokerConfig=xbean:src/test/resources/activemq.xml");
         assertBrokerCreated("vm://localhost?brokerConfig=xbean:file:src/test/resources/activemq.xml");
 
+        // Remote file resources - not allowed
+        assertUrlNotAllowed("vm://localhost?brokerConfig=xbean://activemq.xml",
+                "can't be found or is not allowed");
+        assertUrlNotAllowed("vm://localhost?brokerConfig=xbean:file://activemq.xml");
+
         // Classpath resources - not allowed
         assertUrlNotAllowed("vm://localhost?brokerConfig=xbean:activemq.xml",
                 "can't be found or is not allowed");
@@ -143,6 +160,11 @@ public class ActiveMQConnectionFactoryXBeanTest {
 
         // jar is now allowed but file doesn't exist
         assertBrokerStartError("vm://localhost?brokerConfig=xbean:jar:file:invalid.jar!/", NoSuchFileException.class);
+
+        System.setProperty(XBeanBrokerFactory.XBEAN_BROKER_FACTORY_PROTOCOLS_PROP, "remote-file,jar,ftp");
+        // remote file is now allowed, but can't be found with bad host
+        assertBrokerStartError("vm://localhost?brokerConfig=xbean:file://invalid",
+                UnknownHostException.class);
     }
 
     private void assertBrokerCreated(String url) throws JMSException {
@@ -153,7 +175,7 @@ public class ActiveMQConnectionFactoryXBeanTest {
     }
 
     private void assertUrlNotAllowed(String url) {
-        assertUrlNotAllowed(url, "does not use an allowed protocol for loading URL resources");
+        assertUrlNotAllowed(url, " which is not allowed for loading URL resources");
     }
 
     private void assertUrlNotAllowed(String url, String error) {

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/spring/ActiveMQConnectionFactoryXBeanTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/spring/ActiveMQConnectionFactoryXBeanTest.java
@@ -143,12 +143,12 @@ public class ActiveMQConnectionFactoryXBeanTest {
 
         // Remote file resources - not allowed
         assertUrlNotAllowed("vm://localhost?brokerConfig=xbean://activemq.xml",
-                "can't be found or is not allowed");
+                "can't be found or the protocol is not allowed");
         assertUrlNotAllowed("vm://localhost?brokerConfig=xbean:file://activemq.xml");
 
         // Classpath resources - not allowed
         assertUrlNotAllowed("vm://localhost?brokerConfig=xbean:activemq.xml",
-                "can't be found or is not allowed");
+                "can't be found or the protocol is not allowed");
         assertUrlNotAllowed("vm://localhost?brokerConfig=xbean:classpath:activemq.xml");
 
         // http not allowed


### PR DESCRIPTION
This expands on the previous work in #1910 to add treat remote files as a separate protocol category that can be controlled independently of regular files when loading resources. By default remote files will be disabled.

Follow on to #1910