### PR TITLE
Fix flaky NetworkAdvancedStatisticsTest race condition

### DIFF
--- a/activemq-unit-tests/src/test/java/org/apache/activemq/network/NetworkAdvancedStatisticsTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/network/NetworkAdvancedStatisticsTest.java
@@ -165,8 +165,15 @@ public class NetworkAdvancedStatisticsTest extends BaseNetworkTest {
         assertTrue(Wait.waitFor(new Condition() {
             @Override
             public boolean isSatisified() throws Exception {
-                // The number of message that remain is due to the exclude queue
-                return receivedMessages.size() == MESSAGE_COUNT;
+                // Check if messages arrived at the consumer
+                boolean messagesReceived = receivedMessages.size() == MESSAGE_COUNT;
+
+                // Check if the asynchronous broker statistics have settled
+                long localDequeues = localBroker.getDestination(includedDestination).getDestinationStatistics().getDequeues().getCount();
+                long remoteEnqueues = remoteBroker.getDestination(includedDestination).getDestinationStatistics().getEnqueues().getCount();
+
+                // The test can only proceed when BOTH the messages are received and the stats match
+                return messagesReceived && localDequeues == MESSAGE_COUNT && remoteEnqueues == MESSAGE_COUNT;
             }
         }, 30000, 500));
 


### PR DESCRIPTION
This was originally included in PR #1853, but I have split it out into this separate PR per @mattrpav review so it can be merged quickly.

updated the Wait.waitFor block so the test now waits for both the messages to arrive and the statistics to finish updating before running the final assertions.