### PR TITLE
fix(broker): allow link stealing when old connection is stopping

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/broker/region/RegionBroker.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/region/RegionBroker.java
@@ -260,11 +260,18 @@ public class RegionBroker extends EmptyBroker {
         synchronized (clientIdSet) {
             oldContext = clientIdSet.get(clientId);
             if (oldContext != null) {
-                if (context.isAllowLinkStealing()) {
+                Connection oldConnection = oldContext.getConnection();
+                // Allow the new connection if link-stealing is enabled OR if the old
+                // connection is already in the process of stopping (race condition where
+                // the client reconnects before the broker has finished cleaning up the
+                // previous disconnected connection from clientIdSet).
+                boolean oldConnectionStopping = oldConnection instanceof TransportConnection
+                        && ((TransportConnection) oldConnection).isStopping();
+                if (context.isAllowLinkStealing() || oldConnectionStopping) {
                     clientIdSet.put(clientId, context);
                 } else {
                     throw new InvalidClientIDException("Broker: " + getBrokerName() + " - Client: " + clientId + " already connected from "
-                        + oldContext.getConnection().getRemoteAddress());
+                        + oldConnection.getRemoteAddress());
                 }
             } else {
                 clientIdSet.put(clientId, context);
@@ -274,7 +281,11 @@ public class RegionBroker extends EmptyBroker {
         if (oldContext != null) {
             if (oldContext.getConnection() != null) {
                 Connection connection = oldContext.getConnection();
-                LOG.warn("Stealing link for clientId {} From Connection {}", clientId, oldContext.getConnection());
+                if (connection instanceof TransportConnection && ((TransportConnection) connection).isStopping()) {
+                    LOG.debug("Reconnect for clientId {} allowed; old connection {} is already stopping", clientId, connection);
+                } else {
+                    LOG.warn("Stealing link for clientId {} From Connection {}", clientId, connection);
+                }
                 if (connection instanceof TransportConnection) {
                     TransportConnection transportConnection = (TransportConnection) connection;
                     transportConnection.stopAsync(new IOException("Stealing link for clientId " + clientId + " From Connection " + oldContext.getConnection().getConnectionId()));


### PR DESCRIPTION
### **Proposed PR Description**

**Title:** Fix race condition causing `InvalidClientIDException` on rapid client reconnects

**Summary**
This PR resolves a Time-of-Check to Time-of-Use (TOCTOU) race condition in `RegionBroker.addConnection()` that occurs when a client rapidly reconnects after a network drop. Previously, this race condition resulted in an unwarranted `InvalidClientIDException`.

**The Problem & Root Cause**
When a client connection drops and immediately reconnects, the following sequence occurs:
1. The network drops, triggering `TransportConnection.stopAsync()` on the old connection. This immediately sets `stopping = true`.
2. The actual cleanup task (`processRemoveConnection`, which calls `broker.removeConnection()`) is scheduled to run asynchronously on a separate thread.
3. If the client reconnects before that asynchronous cleanup completes, `RegionBroker.addConnection()` finds a stale entry for the client in the `clientIdSet`.
4. Because `isAllowLinkStealing()` defaults to `false` for TCP/OpenWire, the broker rejects the perfectly valid reconnect attempt and throws an `InvalidClientIDException`. 

**The Fix**
Modified `RegionBroker.addConnection()` to inspect the state of the existing connection before throwing the exception. 

Inside the `synchronized (clientIdSet)` block, we now check if the existing connection has `isStopping() == true`. If it is already in the process of stopping, we allow the new connection to proceed—effectively treating it the same as link-stealing, since the old connection is already dead and just awaiting garbage collection.

**Safety & Side-Effect Analysis**
This change is clean and introduces no regression risks for the following reasons:
* **Idempotency:** The subsequent `stopAsync()` call on the old connection is completely harmless. It uses `compareAndSet(false, true)`, meaning calling it on an already-stopping connection is a safe no-op.
* **Cleanup Thread Safety:** The asynchronous `removeConnection()` cleanup relies on a guard (`oldValue == context`). When the delayed task finally executes, it will not accidentally remove the newly registered connection context. 

---
*Fixes #[Insert Issue Number]*