### PR TITLE
fix(console): fix NPE in AbstractJmxCommand.execute and AbstractCommand.handleException

### DIFF
--- a/activemq-console/src/main/java/org/apache/activemq/console/command/AbstractCommand.java
+++ b/activemq-console/src/main/java/org/apache/activemq/console/command/AbstractCommand.java
@@ -162,13 +162,9 @@ public abstract class AbstractCommand implements Command {
     }
 
     protected void handleException(Exception exception, String serviceUrl) throws Exception {
-        Throwable cause = exception.getCause();
-        while (true) {
-            Throwable next = cause.getCause();
-            if (next == null) {
-                break;
-            }
-            cause = next;
+        Throwable cause = exception;
+        while (cause.getCause() != null) {
+            cause = cause.getCause();
         }
         if (cause instanceof ConnectException) {
             context.printInfo("Broker not available at: " + serviceUrl);

--- a/activemq-console/src/main/java/org/apache/activemq/console/command/AbstractJmxCommand.java
+++ b/activemq-console/src/main/java/org/apache/activemq/console/command/AbstractJmxCommand.java
@@ -388,7 +388,7 @@ public abstract class AbstractJmxCommand extends AbstractCommand {
         try {
             super.execute(tokens);
         } catch (Exception exception) {
-            handleException(exception, jmxServiceUrl.toString());
+            handleException(exception, jmxServiceUrl != null ? jmxServiceUrl.toString() : "local");
             return;
         }finally {
             closeJmxConnection();


### PR DESCRIPTION
`AbstractJmxCommand.execute` called `jmxServiceUrl.toString()` without a null check. `jmxServiceUrl` is never set in local JMX mode (--jmxlocal), so any exception thrown in that mode produced a **NullPointerException** instead of the real error.

`AbstractCommand.handleException` started cause-chain traversal from `exception.getCause()`, which is null for exceptions thrown without a wrapped cause (e.g. IllegalArgumentException). This caused a **NullPointerException** that masked the original exception and swallowed the error message entirely.