### PR TITLE
build: make surefire enableProcessChecker overridable for Windows 11 compatibility.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,8 @@
          preventing CI from hanging indefinitely on Windows file-lock issues or
          any other test that never terminates. Override per-module if needed. -->
     <surefire.forkedProcessTimeout>300</surefire.forkedProcessTimeout>
+    <!-- Set to 'ping' on Windows 11+ where wmic is unavailable: -Dsurefire.enableProcessChecker=ping -->
+    <surefire.enableProcessChecker>all</surefire.enableProcessChecker>
 
     <siteId>activemq-${project.version}</siteId>
     <projectName>Apache ActiveMQ</projectName>
@@ -967,7 +969,7 @@
             <forkCount>1</forkCount>
             <reuseForks>false</reuseForks>
             <forkedProcessTimeoutInSeconds>${surefire.forkedProcessTimeout}</forkedProcessTimeoutInSeconds>
-            <enableProcessChecker>all</enableProcessChecker>
+            <enableProcessChecker>${surefire.enableProcessChecker}</enableProcessChecker>
             <failIfNoTests>false</failIfNoTests>
             <systemPropertyVariables>
                 <java.awt.headless>true</java.awt.headless>


### PR DESCRIPTION
**## Problem**
Surefire 3.x uses `wmic` to periodically check whether the parent Maven process is still alive. `wmic` was removed in Windows 11 22H2, so the check always fails — the forked test, JVM concludes the parent has died and calls System.exit(1) before any test runs.

  **Symptoms on Windows 11:**
      [ERROR] The forked VM terminated without properly saying goodbye.
      [ERROR] Process Exit Code: 1

 **## Change**
Extract `enableProcessChecker` into an overridable property with **default** `all` . Windows 11 developers can now run tests using: **`mvn test -Dsurefire.enableProcessChecker=ping`**.

No behaviour change for CI or any other environment.

**Note:**  `ping` uses the stdin pipe to detect parent-process death rather than `wmic`, and works correctly on all platforms.

