### PR TITLE
[6.2.x] Add more transport types to the denied list for JMX part 2 (#1972)

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/broker/jmx/BrokerView.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/jmx/BrokerView.java
@@ -46,7 +46,7 @@ public class BrokerView implements BrokerViewMBean {
 
     public static final Set<String> DENIED_TRANSPORT_SCHEMES = Set.of("vm", "http",
             "multicast", "zeroconf", "discovery", "fanout", "mock", "peer", "failover",
-            "proxy", "reliable", "simple", "udp");
+            "proxy", "reliable", "simple", "udp", "masterslave");
 
     ManagedRegionBroker broker;
 


### PR DESCRIPTION
Follow on to #1949

(cherry picked from commit 1f2a2571524c56b3b103a9d3a625ceda3430f6e9)