### PR TITLE
build(deps): bump log4j-version from 2.25.3 to 2.25.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
     <junit-version>4.13.2</junit-version>
     <hamcrest-version>1.3</hamcrest-version>
     <karaf-version>4.4.9</karaf-version>
-    <log4j-version>2.25.3</log4j-version>
+    <log4j-version>2.25.4</log4j-version>
     <mockito-version>4.8.1</mockito-version>
     <owasp-dependency-check-version>12.2.0</owasp-dependency-check-version>
     <mqtt-client-version>1.16</mqtt-client-version>


### PR DESCRIPTION
Mitigation of CVE: https://www.cve.org/CVERecord?id=CVE-2026-34480

Ref: https://github.com/apache/activemq/pull/1854 