### PR TITLE
build(deps): bump log4j-version from 2.25.3 to 2.25.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
     <junit-version>4.13.2</junit-version>
     <hamcrest-version>1.3</hamcrest-version>
     <karaf-version>4.4.9</karaf-version>
-    <log4j-version>2.25.3</log4j-version>
+    <log4j-version>2.25.4</log4j-version>
     <mockito-version>4.8.1</mockito-version>
     <owasp-dependency-check-version>12.2.0</owasp-dependency-check-version>
     <mqtt-client-version>1.16</mqtt-client-version>


### PR DESCRIPTION
Bumps `log4j-version` from 2.25.3 to 2.25.4.

Updates `org.apache.logging.log4j:log4j-api` from 2.25.3 to 2.25.4

Updates `org.apache.logging.log4j:log4j-core` from 2.25.3 to 2.25.4

Updates `org.apache.logging.log4j:log4j-slf4j2-impl` from 2.25.3 to 2.25.4

---
updated-dependencies:
- dependency-name: org.apache.logging.log4j:log4j-api dependency-version: 2.25.4 dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: org.apache.logging.log4j:log4j-core dependency-version: 2.25.4 dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: org.apache.logging.log4j:log4j-slf4j2-impl dependency-version: 2.25.4 dependency-type: direct:production update-type: version-update:semver-patch ...

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

(cherry picked from commit 66d5d749b10654dabc1872cf96983bd9809e8380)