### PR TITLE
Harden default broker and web console configuration

### DIFF
--- a/assembly/src/release/conf/activemq.xml
+++ b/assembly/src/release/conf/activemq.xml
@@ -55,6 +55,50 @@
 
 
         <!--
+            Security hardening (disabled by default so the sample broker starts
+            out-of-the-box). Uncomment the <plugins> block below to enforce:
+              * JAAS authentication using the 'activemq' realm in conf/login.config
+              * Destination-level authorization based on conf/groups.properties
+              * Broker-side audit logging of connections, producers and consumers
+
+            BEFORE ENABLING IN PRODUCTION:
+              1. ROTATE the credentials in conf/users.properties. The default
+                 'admin=admin' user is well-known and MUST NOT be used as-is.
+              2. Tighten the authorizationMap below to match the destinations
+                 you actually use; the defaults grant access only to 'admins'.
+              3. Confirm every enabled transport requires credentials and that
+                 clients are configured to send them.
+              4. To also restrict ObjectMessage deserialization, set
+                   ACTIVEMQ_OPTS="-Dorg.apache.activemq.SERIALIZABLE_PACKAGES=<csv>"
+                 in bin/env (an empty value blocks ObjectMessage deserialization
+                 entirely; specify only packages you explicitly trust).
+
+            For more information, see:
+              https://activemq.apache.org/security
+        -->
+        <!--
+        <plugins>
+            <jaasAuthenticationPlugin configuration="activemq" />
+
+            <authorizationPlugin>
+                <map>
+                    <authorizationMap>
+                        <authorizationEntries>
+                            <authorizationEntry queue=">" read="admins" write="admins" admin="admins" />
+                            <authorizationEntry topic=">" read="admins" write="admins" admin="admins" />
+                            <authorizationEntry topic="ActiveMQ.Advisory.>" read="admins,users" write="admins,users" admin="admins,users" />
+                        </authorizationEntries>
+                    </authorizationMap>
+                </map>
+            </authorizationPlugin>
+
+            <loggingBrokerPlugin logConnectionEvents="true"
+                                 logProducerEvents="true"
+                                 logConsumerEvents="true" />
+        </plugins>
+        -->
+
+        <!--
             The managementContext is used to configure how ActiveMQ is exposed in
             JMX. By default, ActiveMQ uses the MBean server that is started by
             the JVM. For more information, see:
@@ -105,10 +149,15 @@
         <transportConnectors>
             <!-- DOS protection, limit concurrent connections to 1000 and frame size to 100MB -->
             <transportConnector name="openwire" uri="tcp://0.0.0.0:61616?maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/>
-            <transportConnector name="amqp" uri="amqp://0.0.0.0:5672?maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/>
-            <transportConnector name="stomp" uri="stomp://0.0.0.0:61613?maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/>
-            <transportConnector name="mqtt" uri="mqtt://0.0.0.0:1883?maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/>
-            <transportConnector name="ws" uri="ws://0.0.0.0:61614?maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/>
+            <!--
+                Additional transports are disabled by default to reduce the exposed attack surface.
+                Uncomment only the protocols you actually need, and prefer the secured variants
+                (amqp+ssl, stomp+ssl, mqtt+nio+ssl, wss) in production deployments.
+            -->
+            <!-- <transportConnector name="amqp" uri="amqp://0.0.0.0:5672?maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/> -->
+            <!-- <transportConnector name="stomp" uri="stomp://0.0.0.0:61613?maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/> -->
+            <!-- <transportConnector name="mqtt" uri="mqtt://0.0.0.0:1883?maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/> -->
+            <!-- <transportConnector name="ws" uri="ws://0.0.0.0:61614?maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/> -->
         </transportConnectors>
 
         <!-- destroy the spring context on shutdown to stop jetty -->

--- a/assembly/src/release/conf/activemq.xml
+++ b/assembly/src/release/conf/activemq.xml
@@ -147,12 +147,19 @@
             http://activemq.apache.org/configuring-transports.html
         -->
         <transportConnectors>
-            <!-- DOS protection, limit concurrent connections to 1000 and frame size to 100MB -->
+            <!--
+                DOS protection, limit concurrent connections to 1000 and frame size to 100MB.
+
+                WARNING: this openwire connector uses plain TCP and traffic is unencrypted. It is
+                intended for initial testing only. For production deployments it is strongly
+                recommended to use the SSL variant (ssl://) so that credentials and message
+                payloads are not transmitted in cleartext.
+            -->
             <transportConnector name="openwire" uri="tcp://0.0.0.0:61616?maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/>
             <!--
                 Additional transports are disabled by default to reduce the exposed attack surface.
                 Uncomment only the protocols you actually need, and prefer the secured variants
-                (amqp+ssl, stomp+ssl, mqtt+nio+ssl, wss) in production deployments.
+                (openwire+ssl, amqp+ssl, stomp+ssl, mqtt+nio+ssl, wss) in production deployments.
             -->
             <!-- <transportConnector name="amqp" uri="amqp://0.0.0.0:5672?maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/> -->
             <!-- <transportConnector name="stomp" uri="stomp://0.0.0.0:61613?maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/> -->

--- a/assembly/src/release/conf/jetty.xml
+++ b/assembly/src/release/conf/jetty.xml
@@ -21,6 +21,8 @@
 
     <bean id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
         <property name="sendServerVersion" value="false"/>
+        <property name="sendXPoweredBy" value="false"/>
+        <property name="sendDateHeader" value="false"/>
         <!--
             When the web console sits behind a reverse proxy or load balancer,
             uncomment the customizer below so Jetty honors X-Forwarded-* (or
@@ -112,6 +114,26 @@
                     <property name="pattern" value="*"/>
                     <property name="name" value="Content-Security-Policy"/>
                     <property name="value" value="style-src-elem 'self'; style-src 'self'; img-src 'self'; script-src-elem 'self'; default-src 'none'; object-src 'none'; frame-ancestors 'none'; base-uri 'none';" />
+                </bean>
+                <bean id="header" class="org.eclipse.jetty.rewrite.handler.HeaderPatternRule">
+                    <property name="pattern" value="*"/>
+                    <property name="name" value="Referrer-Policy"/>
+                    <property name="value" value="no-referrer"/>
+                </bean>
+                <bean id="header" class="org.eclipse.jetty.rewrite.handler.HeaderPatternRule">
+                    <property name="pattern" value="*"/>
+                    <property name="name" value="Permissions-Policy"/>
+                    <property name="value" value="accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()"/>
+                </bean>
+                <bean id="header" class="org.eclipse.jetty.rewrite.handler.HeaderPatternRule">
+                    <property name="pattern" value="*"/>
+                    <property name="name" value="Cross-Origin-Opener-Policy"/>
+                    <property name="value" value="same-origin"/>
+                </bean>
+                <bean id="header" class="org.eclipse.jetty.rewrite.handler.HeaderPatternRule">
+                    <property name="pattern" value="*"/>
+                    <property name="name" value="Cross-Origin-Resource-Policy"/>
+                    <property name="value" value="same-origin"/>
                 </bean>
                 <!-- More relaxed rules to allow browsers to properly render XML -->
                 <bean id="header" class="org.eclipse.jetty.rewrite.handler.HeaderPatternRule">


### PR DESCRIPTION
Reduce the attack surface of the sample broker shipped in the binary assembly:

* activemq.xml: enable only the openwire TCP transportConnector by default; amqp, stomp, mqtt and ws are commented out with a note pointing to the SSL-secured variants.
* activemq.xml: add a commented <plugins> block wiring JAAS authentication, destination-level authorization and broker-side audit logging, with a prominent reminder to rotate the default admin=admin credentials and an ACTIVEMQ_OPTS hint for restricting ObjectMessage deserialization.
* jetty.xml: suppress X-Powered-By and Date response headers in addition to the already-disabled Server header.
* jetty.xml: add Referrer-Policy, Permissions-Policy, Cross-Origin-Opener-Policy and Cross-Origin-Resource-Policy response headers alongside the existing CSP/XFO/XSS rules.