### PR TITLE
Bump dependencies for CVE fixes on 6.2.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <annogen-version>0.1.0</annogen-version>
     <ant-version>1.10.15</ant-version>
     <aries-version>1.1.0</aries-version>
-    <camel-version>4.14.4</camel-version>
+    <camel-version>4.14.7</camel-version>
     <commons-beanutils-version>1.11.0</commons-beanutils-version>
     <commons-collections-version>3.2.2</commons-collections-version>
     <commons-dbcp2-version>2.14.0</commons-dbcp2-version>
@@ -73,7 +73,7 @@
     <javassist-version>3.30.2-GA</javassist-version>
     <jettison-version>1.5.4</jettison-version>
     <jmock-version>2.13.1</jmock-version>
-    <jolokia-version>2.5.0</jolokia-version>
+    <jolokia-version>2.6.0</jolokia-version>
     <junit-version>4.13.2</junit-version>
     <hamcrest-version>1.3</hamcrest-version>
     <karaf-version>4.4.9</karaf-version>
@@ -89,8 +89,8 @@
     <rome-version>2.1.0</rome-version>
     <shiro-version>2.1.0</shiro-version>
     <slf4j-version>2.0.17</slf4j-version>
-    <snappy-version>1.1.2</snappy-version>
-    <spring-version>6.2.16</spring-version>
+    <snappy-version>1.1.10.7</snappy-version>
+    <spring-version>6.2.18</spring-version>
     <spring-version-range>[6,7)</spring-version-range>
     <taglibs-version>1.2.5</taglibs-version>
     <xpp3-version>1.1.4c</xpp3-version>


### PR DESCRIPTION
Bumps four dependency properties in the parent `pom.xml` to pick up published CVE fixes / patch releases for the 6.2.x line:

| Dependency | From | To | Notes |
|---|---|---|---|
| `camel-version` | 4.14.4 | 4.14.7 | CVE-2026-47323 (CXF/Knative header injection -> RCE), CVE-2026-27172 (ConsulRegistry deserialization), CVE-2026-28367 (request smuggling). Latest 4.14.x LTS patch. |
| `jolokia-version` | 2.5.0 | 2.6.0 | Routine patch bump. |
| `snappy-version` | 1.1.2 | 1.1.10.7 | CVE-2023-34455, CVE-2023-43642 (DoS via unchecked chunk length). Property is currently dead (no `${snappy-version}` reference) but kept for hygiene. |
| `spring-version` | 6.2.16 | 6.2.18 | Pulls March/April 2026 Spring Framework fixes. |

Jetty was evaluated but `11.0.26` is already the latest 11.0.x on Maven Central, so no bump.
