### PR TITLE
Bump netty, snappy, karaf to address known CVEs on activemq-5.19.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
     <json-simple-version>1.1.1</json-simple-version>
     <junit-version>4.13.2</junit-version>
     <hamcrest-version>1.3</hamcrest-version>
-    <karaf-version>4.3.7</karaf-version>
+    <karaf-version>4.3.10</karaf-version>
     <log4j-version>2.25.3</log4j-version>
     <mockito-version>4.8.1</mockito-version>
     <owasp-dependency-check-version>12.1.0</owasp-dependency-check-version>
@@ -98,12 +98,12 @@
     <zookeeper-version>3.4.14</zookeeper-version>
     <qpid-proton-version>0.34.1</qpid-proton-version>
     <qpid-jms-version>1.9.0</qpid-jms-version>
-    <netty-version>4.1.94.Final</netty-version>
+    <netty-version>4.1.133.Final</netty-version>
     <regexp-version>1.4</regexp-version>
     <rome-version>2.1.0</rome-version>
     <shiro-version>1.13.0</shiro-version>
     <slf4j-version>2.0.17</slf4j-version>
-    <snappy-version>1.1.2</snappy-version>
+    <snappy-version>1.1.10.8</snappy-version>
     <spring-version>5.3.39</spring-version>
     <taglibs-version>1.2.5</taglibs-version>
     <velocity-version>2.4.1</velocity-version>


### PR DESCRIPTION
Dependency bumps in `pom.xml` to address known CVEs on `activemq-5.19.x`:

- **netty** `4.1.94.Final` → `4.1.133.Final`
  - CVE-2024-29025 (codec-http multipart decoder DoS)
  - SslHandler native crash, fixed in 4.1.118.Final
  - CVE-2025-58057 (BrotliDecoder / decompression DoS), fixed in 4.1.125.Final
- **snappy** `1.1.2` → `1.1.10.8`
  - CVE-2023-34453, CVE-2023-34454, CVE-2023-34455 (integer overflow / unchecked chunk length DoS)
  - CVE-2023-43642 (missing upper-bound check on chunk length)
- **karaf** `4.3.7` → `4.3.10`
  - CVE-2022-40145 (JNDI LDAP RCE via JDBC config)

Not bumped here (require separate evaluation):
- `zookeeper 3.4.14` — line is EOL; jumping to 3.9.x is a breaking-change risk for replicated leveldb paths
- `spring 5.3.39` — 5.3.x OSS EOL; April 2026 CVEs (CVE-2026-22740/22741/22745) have no OSS patch in Maven Central
- `jetty 9.4.58.v20250814` — already the latest 9.4.x published to Maven Central
