### PR TITLE
build(deps): bump shiro-version from 2.1.0 to 2.2.0 (6.2.x backport)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
     <qpid-jms-version>2.10.0</qpid-jms-version>
     <netty-version>4.2.10.Final</netty-version>
     <rome-version>2.1.0</rome-version>
-    <shiro-version>2.1.0</shiro-version>
+    <shiro-version>2.2.0</shiro-version>
     <slf4j-version>2.0.17</slf4j-version>
     <snappy-version>1.1.10.7</snappy-version>
     <spring-version>6.2.18</spring-version>


### PR DESCRIPTION
## Summary
- Backport of #2023 to `activemq-6.2.x`: bumps `shiro-version` from 2.1.0 to 2.2.0.

## Test plan
- [ ] CI build passes on `activemq-6.2.x`