### PR TITLE
Bump default JVM heap and add OOM diagnostics

### DIFF
--- a/assembly/src/release/bin/activemq
+++ b/assembly/src/release/bin/activemq
@@ -198,8 +198,14 @@ if [ "$CONFIG_LOAD" != "yes" ];then
       echo
 fi
 
+if [ -z "$ACTIVEMQ_OOM_OPTS" ] ; then
+    ACTIVEMQ_OOM_OPTS="-XX:+ExitOnOutOfMemoryError"
+    #ACTIVEMQ_OOM_DUMP_OPTS="-XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=\"$ACTIVEMQ_DATA\" -XX:HeapDumpGzipLevel=6"
+    #ACTIVEMQ_OOM_OPTS="$ACTIVEMQ_OOM_OPTS $ACTIVEMQ_OOM_DUMP_OPTS"
+fi
+
 if [ -z "$ACTIVEMQ_OPTS" ] ; then
-    ACTIVEMQ_OPTS="$ACTIVEMQ_OPTS_MEMORY -Djava.util.logging.config.file=logging.properties -Djava.security.auth.login.config=\"$ACTIVEMQ_CONF\"/login.config"
+    ACTIVEMQ_OPTS="$ACTIVEMQ_OPTS_MEMORY $ACTIVEMQ_OOM_OPTS -Djava.util.logging.config.file=logging.properties -Djava.security.auth.login.config=\"$ACTIVEMQ_CONF\"/login.config"
 fi
 
 

--- a/assembly/src/release/bin/setenv
+++ b/assembly/src/release/bin/setenv
@@ -31,7 +31,7 @@
 
 # Set jvm memory configuration (minimal/maximum amount of memory)
 if [ -z "$ACTIVEMQ_OPTS_MEMORY" ] ; then
-    ACTIVEMQ_OPTS_MEMORY="-Xms512M -Xmx2G"
+    ACTIVEMQ_OPTS_MEMORY="-Xms64M -Xmx2G"
 fi
 
 # Terminate the JVM on OutOfMemoryError so the broker is not left running in a degraded state.

--- a/assembly/src/release/bin/setenv
+++ b/assembly/src/release/bin/setenv
@@ -31,10 +31,21 @@
 
 # Set jvm memory configuration (minimal/maximum amount of memory)
 if [ -z "$ACTIVEMQ_OPTS_MEMORY" ] ; then
-    ACTIVEMQ_OPTS_MEMORY="-Xms64M -Xmx1G"
+    ACTIVEMQ_OPTS_MEMORY="-Xms512M -Xmx2G"
 fi
+
+# Terminate the JVM on OutOfMemoryError so the broker is not left running in a degraded state.
+# Heap dump on OOM is disabled by default to avoid unexpected disk usage (especially with large
+# heap sizes). Uncomment ACTIVEMQ_OOM_DUMP_OPTS to enable heap dumps; -XX:HeapDumpGzipLevel=6
+# requires JDK 17+.
+if [ -z "$ACTIVEMQ_OOM_OPTS" ] ; then
+    ACTIVEMQ_OOM_OPTS="-XX:+ExitOnOutOfMemoryError"
+    #ACTIVEMQ_OOM_DUMP_OPTS="-XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=$ACTIVEMQ_DATA -XX:HeapDumpGzipLevel=6"
+    #ACTIVEMQ_OOM_OPTS="$ACTIVEMQ_OOM_OPTS $ACTIVEMQ_OOM_DUMP_OPTS"
+fi
+
 if [ -z "$ACTIVEMQ_OPTS" ] ; then
-    ACTIVEMQ_OPTS="$ACTIVEMQ_OPTS_MEMORY -Djava.util.logging.config.file=logging.properties -Djava.security.auth.login.config=$ACTIVEMQ_CONF/login.config"
+    ACTIVEMQ_OPTS="$ACTIVEMQ_OPTS_MEMORY $ACTIVEMQ_OOM_OPTS -Djava.util.logging.config.file=logging.properties -Djava.security.auth.login.config=$ACTIVEMQ_CONF/login.config"
 fi
 
 if [ -z "$ACTIVEMQ_OUT" ]; then


### PR DESCRIPTION
- Raise the shipped default heap from `-Xms64M -Xmx1G` to `-Xms512M -Xmx2G` in `assembly/src/release/bin/setenv`. The previous default is undersized for a production broker; the new value is still modest and remains overridable via `ACTIVEMQ_OPTS_MEMORY`.
- Add a new `ACTIVEMQ_OOM_OPTS` variable defaulting to `-XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=$ACTIVEMQ_DATA -XX:+ExitOnOutOfMemoryError` so that an `OutOfMemoryError` produces a heap dump under the broker data directory and the JVM terminates rather than continuing in a degraded state.
- Mirror the same `ACTIVEMQ_OOM_OPTS` fallback inside `assembly/src/release/bin/activemq` so the diagnostics still apply if `setenv` is absent.

Both new variables remain overridable from the environment or from any of the higher-priority configuration files (`/etc/default/activemq`, `~/.activemqrc`, `bin/setenv`).