### PR TITLE
Docker image update to JDK 25 and README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To help you get started, try the following links:
 Getting Started
 - You need JDK17+ to run Apache ActiveMQ
 - After having extracted ActiveMQ binary distribution, you can start ActiveMQ with `./bin/activemq console` (foreground) or `./bin/activemq start`
-- Docker images are also available on Docker Hub (https://hub.docker.com/r/apache/activemq-classic)
+- Docker images are also available on Docker Hub (https://hub.docker.com/r/apache/activemq)
 
 Building
 - You can build (fast) using Apache Maven: `mvn clean install -DskipTests`

--- a/assembly/src/docker/README.md
+++ b/assembly/src/docker/README.md
@@ -32,7 +32,7 @@ On macOS, an easy way to install `buildx` is to install [Docker Desktop Edge](ht
 
 ## Build
 
-Images are based on the Docker official [Eclipse Temurin 17 JRE](https://hub.docker.com/_/eclipse-temurin/tags?page=1&name=17-jre) image. If you want to
+Images are based on the Docker official [Eclipse Temurin 25 JRE](https://hub.docker.com/_/eclipse-temurin/tags?page=1&name=25-jre) image. If you want to
 build the ActiveMQ image you have the following choices:
 
 1. Create the docker image from a local distribution package
@@ -50,7 +50,7 @@ Usage:
 
   If the --image-name flag is not used the built image name will be 'activemq'.
   Check the supported build platforms; you can verify with this command: docker buildx ls
-  The supported platforms (OS/Arch) depend on the build's base image, in this case [eclipse-temurin:17-jre](https://hub.docker.com/_/eclipse-temurin).
+  The supported platforms (OS/Arch) depend on the build's base image, in this case [eclipse-temurin:25-jre](https://hub.docker.com/_/eclipse-temurin).
 ```
 
 To create the docker image from local distribution) you can execute the command

--- a/helm/activemq/README.md
+++ b/helm/activemq/README.md
@@ -65,7 +65,7 @@ helm uninstall my-activemq
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `replicaCount` | Number of broker replicas | `1` |
-| `image.repository` | Container image repository | `apache/activemq-classic` |
+| `image.repository` | Container image repository | `apache/activemq` |
 | `image.tag` | Image tag (defaults to chart `appVersion`) | `""` |
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `imagePullSecrets` | Image pull secrets for private registries | `[]` |

--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
     <tools-maven-plugin-version>1.4</tools-maven-plugin-version>
     <depends-maven-plugin-version>1.5.0</depends-maven-plugin-version>
     <docker-maven-plugin-version>0.48.1</docker-maven-plugin-version>
-    <docker-java-version>17</docker-java-version>
+    <docker-java-version>25</docker-java-version>
     <maven-project-info-reports-plugin-version>3.9.0</maven-project-info-reports-plugin-version>
     <maven-core-version>3.9.16</maven-core-version>
     <maven-surefire-plugin-version>3.5.3</maven-surefire-plugin-version>


### PR DESCRIPTION
We now use JDK 21 and we have some custom code that we add to the base activemq classic image that is currently compiling against jdk17. We want to move everything to jdk21.

I don't see any down side here...