### PR TITLE
Replace deprecated StatsImpl.addStatistic with addStatistics(Set.of(..))

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/broker/region/ConnectionStatistics.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/region/ConnectionStatistics.java
@@ -17,6 +17,8 @@
 
 package org.apache.activemq.broker.region;
 
+import java.util.Set;
+
 import org.apache.activemq.management.CountStatisticImpl;
 import org.apache.activemq.management.StatsImpl;
 
@@ -35,8 +37,7 @@ public class ConnectionStatistics extends StatsImpl {
         enqueues = new CountStatisticImpl("enqueues", "The number of messages that have been sent to the connection");
         dequeues = new CountStatisticImpl("dequeues", "The number of messages that have been dispatched from the connection");
 
-        addStatistic("enqueues", enqueues);
-        addStatistic("dequeues", dequeues);
+        addStatistics(Set.of(enqueues, dequeues));
     }
 
     public CountStatisticImpl getEnqueues() {

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/region/ConnectorStatistics.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/region/ConnectorStatistics.java
@@ -17,6 +17,8 @@
 
 package org.apache.activemq.broker.region;
 
+import java.util.Set;
+
 import org.apache.activemq.management.CountStatisticImpl;
 import org.apache.activemq.management.PollCountStatisticImpl;
 import org.apache.activemq.management.StatsImpl;
@@ -42,11 +44,7 @@ public class ConnectorStatistics extends StatsImpl {
         messages = new CountStatisticImpl("messages", "The number of messages that that are being held by the destination");
         messagesCached = new PollCountStatisticImpl("messagesCached", "The number of messages that are held in the destination's memory cache");
 
-        addStatistic("enqueues", enqueues);
-        addStatistic("dequeues", dequeues);
-        addStatistic("consumers", consumers);
-        addStatistic("messages", messages);
-        addStatistic("messagesCached", messagesCached);
+        addStatistics(Set.of(enqueues, dequeues, consumers, messages, messagesCached));
     }
 
     public CountStatisticImpl getEnqueues() {

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/region/RegionStatistics.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/region/RegionStatistics.java
@@ -17,6 +17,8 @@
 
 package org.apache.activemq.broker.region;
 
+import java.util.Set;
+
 import org.apache.activemq.management.CountStatisticImpl;
 import org.apache.activemq.management.StatsImpl;
 
@@ -41,9 +43,7 @@ public class RegionStatistics extends StatsImpl {
         destinations = new CountStatisticImpl("destinations", "The number of regular (non-adivsory) destinations in the region");
         allDestinations = new CountStatisticImpl("allDestinations", "The total number of destinations, including advisory destinations, in the region");
 
-        addStatistic("advisoryDestinations", advisoryDestinations);
-        addStatistic("destinations", destinations);
-        addStatistic("allDestinations", allDestinations);
+        addStatistics(Set.of(advisoryDestinations, destinations, allDestinations));
 
         this.setEnabled(enabled);
     }

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/region/SubscriptionStatistics.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/region/SubscriptionStatistics.java
@@ -17,6 +17,8 @@
 
 package org.apache.activemq.broker.region;
 
+import java.util.Set;
+
 import org.apache.activemq.management.CountStatisticImpl;
 import org.apache.activemq.management.SizeStatisticImpl;
 import org.apache.activemq.management.StatsImpl;
@@ -45,11 +47,7 @@ public class SubscriptionStatistics extends StatsImpl {
         dequeues = new CountStatisticImpl("dequeues", "The number of messages that have been acknowledged from the subscription");
         inflightMessageSize = new SizeStatisticImpl("inflightMessageSize", "The size in bytes of messages dispatched but awaiting acknowledgement");
 
-        addStatistic("consumedCount", consumedCount);
-        addStatistic("enqueues", enqueues);
-        addStatistic("dispatched", dispatched);
-        addStatistic("dequeues", dequeues);
-        addStatistic("inflightMessageSize", inflightMessageSize);
+        addStatistics(Set.of(consumedCount, enqueues, dispatched, dequeues, inflightMessageSize));
 
         this.setEnabled(enabled);
     }

--- a/activemq-broker/src/main/java/org/apache/activemq/network/NetworkBridgeStatistics.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/network/NetworkBridgeStatistics.java
@@ -17,6 +17,8 @@
 
 package org.apache.activemq.network;
 
+import java.util.Set;
+
 import org.apache.activemq.management.CountStatisticImpl;
 import org.apache.activemq.management.StatsImpl;
 
@@ -34,9 +36,7 @@ public class NetworkBridgeStatistics extends StatsImpl {
         dequeues = new CountStatisticImpl("dequeues", "The current number of dequeues this bridge has, which is the number of messages received by the remote broker.");
         receivedCount = new CountStatisticImpl("receivedCount", "The number of messages that have been received by the NetworkBridge from the remote broker.  Only applies for Duplex bridges.");
 
-        addStatistic("enqueues", enqueues);
-        addStatistic("dequeues", dequeues);
-        addStatistic("receivedCount", receivedCount);
+        addStatistics(Set.of(enqueues, dequeues, receivedCount));
     }
 
     /**

--- a/activemq-broker/src/main/java/org/apache/activemq/store/AbstractMessageStoreStatistics.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/store/AbstractMessageStoreStatistics.java
@@ -17,6 +17,8 @@
 
 package org.apache.activemq.store;
 
+import java.util.Set;
+
 import org.apache.activemq.management.CountStatisticImpl;
 import org.apache.activemq.management.SizeStatisticImpl;
 import org.apache.activemq.management.StatsImpl;
@@ -37,8 +39,7 @@ public abstract class AbstractMessageStoreStatistics extends StatsImpl {
         messageCount = new CountStatisticImpl("messageCount", countDescription);
         messageSize = new SizeStatisticImpl("messageSize", sizeDescription);
 
-        addStatistic("messageCount", messageCount);
-        addStatistic("messageSize", messageSize);
+        addStatistics(Set.of(messageCount, messageSize));
 
         this.setEnabled(enabled);
     }

--- a/activemq-broker/src/main/java/org/apache/activemq/store/MessageStoreStatistics.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/store/MessageStoreStatistics.java
@@ -17,6 +17,8 @@
 
 package org.apache.activemq.store;
 
+import java.util.Set;
+
 import org.apache.activemq.management.CountStatisticImpl;
 import org.apache.activemq.management.SizeStatisticImpl;
 import org.apache.activemq.management.StatsImpl;
@@ -39,8 +41,7 @@ public class MessageStoreStatistics extends StatsImpl {
         messageCount = new CountStatisticImpl("messageCount", "The number of messages in the store passing through the destination");
         messageSize = new SizeStatisticImpl("messageSize","Size of messages in the store passing through the destination");
 
-        addStatistic("messageCount", messageCount);
-        addStatistic("messageSize", messageSize);
+        addStatistics(Set.of(messageCount, messageSize));
 
         this.setEnabled(enabled);
     }

--- a/activemq-broker/src/main/java/org/apache/activemq/store/PersistenceAdapterStatistics.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/store/PersistenceAdapterStatistics.java
@@ -16,6 +16,8 @@
  */
 package org.apache.activemq.store;
 
+import java.util.Set;
+
 import org.apache.activemq.management.StatsImpl;
 import org.apache.activemq.management.TimeStatisticImpl;
 
@@ -31,14 +33,11 @@ public class PersistenceAdapterStatistics extends StatsImpl {
     	slowCleanupTime = new TimeStatisticImpl("slowCleanupTime", "Slow time to cleanup data in the PersistentAdapter.");
     	slowWriteTime = new TimeStatisticImpl("slowWriteTime", "Slow time to write data to the PersistentAdapter.");
         slowReadTime = new TimeStatisticImpl("slowReadTime", "Slow time to read data from the PersistentAdapter.");
-        addStatistic("slowCleanupTime", slowCleanupTime);
-        addStatistic("slowWriteTime", slowWriteTime);
-        addStatistic("slowReadTime", slowReadTime);
-        
+        addStatistics(Set.of(slowCleanupTime, slowWriteTime, slowReadTime));
+
         writeTime = new TimeStatisticImpl("writeTime", "Time to write data to the PersistentAdapter.");
         readTime = new TimeStatisticImpl("readTime", "Time to read data from the PersistentAdapter.");
-        addStatistic("writeTime", writeTime);
-        addStatistic("readTime", readTime);
+        addStatistics(Set.of(writeTime, readTime));
     }
 
     public void addSlowCleanupTime(final long time) {


### PR DESCRIPTION
<!--
DRAFT PR body for apache/activemq #1984. NOT PUSHED / NOT OPENED.
Create after review with:
  cd /Users/trevdyck/code/activemq
  git push -u origin refactor/1984-batch-addstatistics
  gh pr create --repo apache/activemq --base main \
    --head trex-amazon:refactor/1984-batch-addstatistics \
    --title "Replace deprecated StatsImpl.addStatistic with addStatistics(Set.of(..))" \
    --body-file /Users/trevdyck/code/sqs-jms-drafts/activemq-pr-1984-body.md
-->
## Summary

`StatsImpl.addStatistic(String, StatisticImpl)` is marked `@Deprecated(forRemoval = true, since = "6.2.0")`, and its `String name` argument is unused (the method simply adds the statistic to the backing set). This PR replaces the remaining call sites in the broker statistics classes with the batched `addStatistics(Collection)` API.

This follows the pattern already adopted in the `activemq-client` management classes (e.g. `JMSSessionStatsImpl`, `JCAConnectionPoolStatsImpl`), and finishes migrating the broker-side `StatsImpl` subclasses off the deprecated method.

Fixes #1984

## Changes

Each constructor now registers its statistics in a single `addStatistics(Set.of(...))` call instead of multiple `addStatistic("name", stat)` calls. Eight classes in `activemq-broker`:

- `broker/region/ConnectionStatistics`
- `broker/region/ConnectorStatistics`
- `broker/region/RegionStatistics`
- `broker/region/SubscriptionStatistics`
- `network/NetworkBridgeStatistics`
- `store/AbstractMessageStoreStatistics`
- `store/MessageStoreStatistics`
- `store/PersistenceAdapterStatistics`

## Behavioral impact

None. The statistics are stored in the same backing set; only the redundant (ignored) `name` argument and the deprecated call are removed. No public API changes, no new files.

## Testing

- `mvn clean compile` on `activemq-broker` (JDK 17) — builds clean; the previously-emitted deprecation warnings for these classes are gone.
- Statistics/management tests pass: `NetworkAdvancedStatisticsTest`, `BrokerStatisticsPluginTest`, `AbstractInflightMessageSizeTest`, and the full `org.apache.activemq.management.*` / `org.apache.activemq.statistics.*` packages.
