### PR TITLE
[AMQ-9288] Fix TransportConnection logger to include exception message on Async Error (5.19.x backport)

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/broker/TransportConnection.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/TransportConnection.java
@@ -312,7 +312,7 @@ public class TransportConnection implements Connection, Task, CommandVisitor {
                 if (SERVICELOG.isDebugEnabled()) {
                     SERVICELOG.debug("Async error occurred: {}", e.getMessage(), e);
                 } else {
-                    SERVICELOG.warn("Async error occurred", e.getMessage());
+                    SERVICELOG.warn("Async error occurred: {}", e.getMessage());
                 }
                 ConnectionError ce = new ConnectionError();
                 ce.setException(e);


### PR DESCRIPTION
## Summary

Backport of [AMQ-9288](https://issues.apache.org/jira/browse/AMQ-9288) (commit `b751428eb`, #1038) to the `activemq-5.19.x` branch.

When an async error occurs and DEBUG logging is not enabled, `TransportConnection` logged at WARN with a message that had no `{}` placeholder, while passing `e.getMessage()` as an argument:

```java
} else {
    SERVICELOG.warn("Async error occurred", e.getMessage());
}
```

SLF4J drops the unreferenced argument, so the broker logs only the bare text `Async error occurred` with no detail — making the failure undiagnosable at the default log level. This was reported by an Amazon MQ for ActiveMQ user on AWS re:Post: ["Async error occurred — without trace"](https://repost.aws/questions/QUXkj6j7zdQk2oQR6mY5kWWA).

The fix already exists on the `main`, `6.0.x`, `6.1.x`, and `6.2.x` branches via AMQ-9288, but was never backported to the still-supported `5.18.x` / `5.19.x` maintenance branches.

## Change

```java
-    SERVICELOG.warn("Async error occurred", e.getMessage());
+    SERVICELOG.warn("Async error occurred: {}", e.getMessage());
```

Adds the `{}` placeholder so the exception message is included at WARN. The `Throwable` is intentionally **not** passed — full stack traces at WARN were deliberately removed in [AMQ-8548](https://issues.apache.org/jira/browse/AMQ-8548); the DEBUG branch one line above continues to log the full trace.

## Testing

`mvn -DskipTests install` of the full 5.19.x reactor compiles cleanly on JDK 11. This mirrors the original AMQ-9288 commit exactly, which likewise changed only this line and added no test.
