### PR TITLE
Improve Stomp protocol error messages

### DIFF
--- a/activemq-http/src/test/java/org/apache/activemq/transport/ws/StompWSTransportTest.java
+++ b/activemq-http/src/test/java/org/apache/activemq/transport/ws/StompWSTransportTest.java
@@ -132,7 +132,8 @@ public class StompWSTransportTest extends WSTransportTestSupport {
         String incoming = wsStompConnection.receive(5, TimeUnit.SECONDS);
         assertNotNull(incoming);
         assertTrue(incoming.startsWith("ERROR"));
-        assertTrue(incoming.contains("Invalid frame received before CONNECT or STOMP frame: SEND"));
+        assertTrue(incoming.contains("StompWireFormat is configured for 'server' mode and received an"
+                + " unexpected frame before CONNECT or STOMP frame: SEND"));
 
         assertTrue("Connection should close", Wait.waitFor(
                 (Condition) () -> wsStompConnection.isNotConnected()));
@@ -188,7 +189,7 @@ public class StompWSTransportTest extends WSTransportTestSupport {
         incoming = wsStompConnection.receive(5, TimeUnit.SECONDS);
         assertNotNull(incoming);
         assertTrue(incoming.startsWith("ERROR"));
-        assertTrue(incoming.contains("Duplicate CONNECT or STOMP packet received"));
+        assertTrue(incoming.contains("duplicate CONNECT or STOMP frame"));
 
         assertTrue("Connection should close", Wait.waitFor(
                 (Condition) () -> wsStompConnection.isNotConnected()));
@@ -215,7 +216,8 @@ public class StompWSTransportTest extends WSTransportTestSupport {
         incoming = wsStompConnection.receive(5, TimeUnit.SECONDS);
         assertNotNull(incoming);
         assertTrue(incoming.startsWith("ERROR"));
-        assertTrue(incoming.contains("Invalid response frame received from Client: RECEIPT"));
+        assertTrue(incoming.contains("StompWireFormat is configured for 'server' mode and received a"
+                + " frame that is only excepted when configured for 'client' mode: RECEIPT"));
 
         // make sure the connection was closed by the server
         assertTrue("Connection should close", Wait.waitFor(

--- a/activemq-http/src/test/java/org/apache/activemq/transport/ws/StompWSTransportTest.java
+++ b/activemq-http/src/test/java/org/apache/activemq/transport/ws/StompWSTransportTest.java
@@ -217,7 +217,7 @@ public class StompWSTransportTest extends WSTransportTestSupport {
         assertNotNull(incoming);
         assertTrue(incoming.startsWith("ERROR"));
         assertTrue(incoming.contains("StompWireFormat is configured for 'server' mode and received a"
-                + " frame that is only excepted when configured for 'client' mode: RECEIPT"));
+                + " frame that is only expected when configured for 'client' mode: RECEIPT"));
 
         // make sure the connection was closed by the server
         assertTrue("Connection should close", Wait.waitFor(

--- a/activemq-stomp/src/main/java/org/apache/activemq/transport/stomp/StompWireFormat.java
+++ b/activemq-stomp/src/main/java/org/apache/activemq/transport/stomp/StompWireFormat.java
@@ -263,7 +263,8 @@ public class StompWireFormat implements WireFormat {
                 case Commands.CONNECT:
                 case Commands.STOMP:
                     if (processedConnect) {
-                        throw new ProtocolException("Duplicate CONNECT or STOMP packet received",
+                        throw new ProtocolException("StompWireFormat is configured for 'server' mode"
+                                + " and received a duplicate CONNECT or STOMP frame",
                                 true);
                     }
                     processedConnect = true;
@@ -274,12 +275,13 @@ public class StompWireFormat implements WireFormat {
                 case Responses.ERROR:
                 case Responses.RECEIPT:
                     throw new ProtocolException(
-                            "Invalid response frame received from Client: " + action, true);
+                            "StompWireFormat is configured for 'server' mode and received a"
+                                    + " frame that is only excepted when configured for 'client' mode: " + action, true);
                 default:
                     // Any other frame received before CONNECT/STOMP is an error
                     if (!processedConnect) {
-                        throw new ProtocolException(
-                                "Invalid frame received before CONNECT or STOMP frame: " + action, true);
+                        throw new ProtocolException("StompWireFormat is configured for 'server' mode and received an" +
+                                " unexpected frame before CONNECT or STOMP frame: " + action, true);
                     }
             }
         } else {
@@ -291,9 +293,10 @@ public class StompWireFormat implements WireFormat {
                 case Responses.RECEIPT:
                     return;
                 default:
-                    // Any other frame received before CONNECT/STOMP is an error
+                    // Any other frame received that is not a Response is an error in client mode
                     throw new ProtocolException(
-                            "Invalid frame received by client: " + action, true);
+                            "StompWireFormat is configured for 'client' mode and received a"
+                                    + " frame that is not expected: " + action, true);
             }
         }
 

--- a/activemq-stomp/src/main/java/org/apache/activemq/transport/stomp/StompWireFormat.java
+++ b/activemq-stomp/src/main/java/org/apache/activemq/transport/stomp/StompWireFormat.java
@@ -276,7 +276,7 @@ public class StompWireFormat implements WireFormat {
                 case Responses.RECEIPT:
                     throw new ProtocolException(
                             "StompWireFormat is configured for 'server' mode and received a"
-                                    + " frame that is only excepted when configured for 'client' mode: " + action, true);
+                                    + " frame that is only expected when configured for 'client' mode: " + action, true);
                 default:
                     // Any other frame received before CONNECT/STOMP is an error
                     if (!processedConnect) {

--- a/activemq-stomp/src/test/java/org/apache/activemq/transport/stomp/StompTest.java
+++ b/activemq-stomp/src/test/java/org/apache/activemq/transport/stomp/StompTest.java
@@ -2736,7 +2736,7 @@ public class StompTest extends StompTestSupport {
         StompFrame message = stompConnection.receive();
         assertEquals(Responses.ERROR, message.getAction());
         assertTrue(message.getBody().contains("StompWireFormat is configured for 'server' mode and received a"
-                + " frame that is only excepted when configured for 'client' mode: RECEIPT"));
+                + " frame that is only expected when configured for 'client' mode: RECEIPT"));
 
         // make sure the connection was closed by the server
         assertConnectionClosed(5000);

--- a/activemq-stomp/src/test/java/org/apache/activemq/transport/stomp/StompTest.java
+++ b/activemq-stomp/src/test/java/org/apache/activemq/transport/stomp/StompTest.java
@@ -2667,7 +2667,8 @@ public class StompTest extends StompTestSupport {
             StompFrame message = stompConnection.receive();
             assertEquals(Responses.ERROR, message.getAction());
             assertTrue(message.getBody().contains(
-                    "Invalid frame received before CONNECT or STOMP frame: SEND"));
+                    "StompWireFormat is configured for 'server' mode and received an"
+                            + " unexpected frame before CONNECT or STOMP frame: SEND"));
             // make sure the connection was closed by the server
             assertConnectionClosed(5000);
         }
@@ -2715,7 +2716,7 @@ public class StompTest extends StompTestSupport {
         stompConnection.sendFrame(frame);
         StompFrame message = stompConnection.receive();
         assertEquals(Responses.ERROR, message.getAction());
-        assertTrue(message.getBody().contains("Duplicate CONNECT or STOMP packet received"));
+        assertTrue(message.getBody().contains("duplicate CONNECT or STOMP frame"));
 
         // make sure the connection was closed by the server
         assertConnectionClosed(5000);
@@ -2734,7 +2735,8 @@ public class StompTest extends StompTestSupport {
         stompConnection.sendFrame(frame);
         StompFrame message = stompConnection.receive();
         assertEquals(Responses.ERROR, message.getAction());
-        assertTrue(message.getBody().contains("Invalid response frame received from Client: RECEIPT"));
+        assertTrue(message.getBody().contains("StompWireFormat is configured for 'server' mode and received a"
+                + " frame that is only excepted when configured for 'client' mode: RECEIPT"));
 
         // make sure the connection was closed by the server
         assertConnectionClosed(5000);


### PR DESCRIPTION
This adds some more detail to the error messages in StompWireFormat to
make it easier to debug if using the wireformat and it is configured
incorrectly.

**Note:** this was already added to the backport PRs for [6.2.x](https://github.com/apache/activemq/pull/2065) and [5.19.x](https://github.com/apache/activemq/pull/2066) so won't need a separate backport.