### PR TITLE
[5.19.x] Add https to BrokerView restricted list (#2073)

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/broker/jmx/BrokerView.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/jmx/BrokerView.java
@@ -44,7 +44,7 @@ public class BrokerView implements BrokerViewMBean {
 
     private static final Logger LOG = LoggerFactory.getLogger(BrokerView.class);
 
-    public static final Set<String> DENIED_TRANSPORT_SCHEMES = Set.of("vm", "http",
+    public static final Set<String> DENIED_TRANSPORT_SCHEMES = Set.of("vm", "http", "https",
             "multicast", "zeroconf", "discovery", "fanout", "mock", "peer", "failover",
             "proxy", "reliable", "simple", "udp", "masterslave");
 


### PR DESCRIPTION
This adds https to the denied list eventhough there is currently no https discovery protocol. This is being done just for extra defense in depth in case a protocol is added in the future. There's also already other checks in place (we deny remote protocols by default already, etc) so this is just precautionary.

(cherry picked from commit dfa00d04d4aae678e0eca7e43d4ebd9dea512696)