### PR TITLE
[5.19.x] Restrict full web console URI to admins role (#2074)

### DIFF
--- a/assembly/src/release/conf/jetty.xml
+++ b/assembly/src/release/conf/jetty.xml
@@ -68,14 +68,27 @@
          <!-- set authenticate=false to disable login -->
         <property name="authenticate" value="true" />
     </bean>
+    <!--
+        Catch-all mapping: any request not matched by a more specific
+        constraint below requires authentication as a user or admin.
+    -->
     <bean id="securityConstraintMapping" class="org.eclipse.jetty.security.ConstraintMapping">
         <property name="constraint" ref="securityConstraint" />
         <property name="pathSpec" value="/,/api/*,*.jsp,*.html,*.js,*.css,*.png,*.gif,*.ico" />
     </bean>
+    <!--
+        Web console (/admin/*) is restricted to the admins role. This covers
+        the full console UI, not just the *.action endpoints, so read-only
+        pages (queue listings, message browsing, etc.) also require admin.
+    -->
     <bean id="adminSecurityConstraintMapping" class="org.eclipse.jetty.security.ConstraintMapping">
         <property name="constraint" ref="adminSecurityConstraint" />
-        <property name="pathSpec" value="*.action" />
+        <property name="pathSpec" value="/admin/*" />
     </bean>
+    <!--
+        Jolokia JMX bridge exposes broker management operations over HTTP;
+        restrict to the admins role to prevent privilege escalation via JMX.
+    -->
     <bean id="jolokiaSecurityConstraintMapping" class="org.eclipse.jetty.security.ConstraintMapping">
         <property name="constraint" ref="adminSecurityConstraint" />
         <property name="pathSpec" value="/api/jolokia/*" />


### PR DESCRIPTION
Change the admin security constraint mapping from *.action to /admin/* so the entire web console (including read-only pages) requires the admins role, not just action endpoints. Add comments to each constraint mapping explaining its scope, and remove duplicate Referrer-Policy and Permissions-Policy rewrite rules left over from earlier edits.

(cherry picked from commit 085efea55270aca20f2158c0a91a0f4a9fe497f4)