### PR TITLE
Improve destination type configuration mismatch visibility

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/security/AuthorizationBroker.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/security/AuthorizationBroker.java
@@ -35,6 +35,8 @@ import org.apache.activemq.command.ConsumerInfo;
 import org.apache.activemq.command.DestinationInfo;
 import org.apache.activemq.command.Message;
 import org.apache.activemq.command.ProducerInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Verifies if a authenticated user can do an operation against the broker using
@@ -43,6 +45,8 @@ import org.apache.activemq.command.ProducerInfo;
  *
  */
 public class AuthorizationBroker extends BrokerFilter implements SecurityAdminMBean {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AuthorizationBroker.class);
 
     private volatile AuthorizationMap authorizationMap;
 
@@ -110,6 +114,7 @@ public class AuthorizationBroker extends BrokerFilter implements SecurityAdminMB
         final SecurityContext securityContext = checkSecurityContext(context);
 
         if (!checkDestinationAdminAdd(securityContext, info.getDestination())) {
+            logDestinationTypeHint(securityContext, info.getDestination(), "admin");
             throw new SecurityException("User " + securityContext.getUserName() + " is not authorized to create: " + info.getDestination());
         }
 
@@ -121,6 +126,7 @@ public class AuthorizationBroker extends BrokerFilter implements SecurityAdminMB
         final SecurityContext securityContext = checkSecurityContext(context);
 
         if (!checkDestinationAdminAdd(securityContext, destination)) {
+            logDestinationTypeHint(securityContext, destination, "admin");
             throw new SecurityException("User " + securityContext.getUserName() + " is not authorized to create: " + destination);
         }
 
@@ -132,6 +138,7 @@ public class AuthorizationBroker extends BrokerFilter implements SecurityAdminMB
         final SecurityContext securityContext = checkSecurityContext(context);
 
         if (!checkDestinationAdminRemove(securityContext, destination)) {
+            logDestinationTypeHint(securityContext, destination, "admin");
             throw new SecurityException("User " + securityContext.getUserName() + " is not authorized to remove: " + destination);
         }
 
@@ -145,6 +152,7 @@ public class AuthorizationBroker extends BrokerFilter implements SecurityAdminMB
         final SecurityContext securityContext = checkSecurityContext(context);
 
         if (!checkDestinationAdminRemove(securityContext, info.getDestination())) {
+            logDestinationTypeHint(securityContext, info.getDestination(), "admin");
             throw new SecurityException("User " + securityContext.getUserName() + " is not authorized to remove: " + info.getDestination());
         }
 
@@ -165,6 +173,7 @@ public class AuthorizationBroker extends BrokerFilter implements SecurityAdminMB
         }
 
         if (!securityContext.isBrokerContext() && allowedACLs != null && !securityContext.isInOneOf(allowedACLs) ) {
+            logDestinationTypeHint(securityContext, info.getDestination(), "read");
             throw new SecurityException("User " + securityContext.getUserName() + " is not authorized to read from: " + info.getDestination());
         }
 
@@ -205,6 +214,7 @@ public class AuthorizationBroker extends BrokerFilter implements SecurityAdminMB
                 allowedACLs = authorizationMap.getTempDestinationWriteACLs();
             }
             if (allowedACLs != null && !securityContext.isInOneOf(allowedACLs)) {
+                logDestinationTypeHint(securityContext, info.getDestination(), "write");
                 throw new SecurityException("User " + securityContext.getUserName() + " is not authorized to write to: " + info.getDestination());
             }
             securityContext.getAuthorizedWriteDests().put(info.getDestination(), info.getDestination());
@@ -227,12 +237,52 @@ public class AuthorizationBroker extends BrokerFilter implements SecurityAdminMB
             }
 
             if (allowedACLs != null && !securityContext.isInOneOf(allowedACLs)) {
+                logDestinationTypeHint(securityContext, messageSend.getDestination(), "write");
                 throw new SecurityException("User " + securityContext.getUserName() + " is not authorized to write to: " + messageSend.getDestination());
             }
             securityContext.getAuthorizedWriteDests().put(messageSend.getDestination(), messageSend.getDestination());
         }
 
         super.send(producerExchange, messageSend);
+    }
+
+    /**
+     * Logs a server-side warning hint when a user is denied access to a destination,
+     * but would have access to the same destination name under the alternate type
+     * (queue vs topic). This helps operators diagnose configuration mismatches
+     * where a destination is declared as the wrong type in the authorization map.
+     */
+    void logDestinationTypeHint(SecurityContext securityContext, ActiveMQDestination destination, String operation) {
+        if (destination.isTemporary() || destination.isComposite()) {
+            return;
+        }
+
+        final ActiveMQDestination alternate = destination.isQueue()
+            ? new ActiveMQTopic(destination.getPhysicalName())
+            : new ActiveMQQueue(destination.getPhysicalName());
+
+        final Set<?> alternateACLs;
+        if ("write".equals(operation)) {
+            alternateACLs = authorizationMap.getWriteACLs(alternate);
+        } else if ("read".equals(operation)) {
+            alternateACLs = authorizationMap.getReadACLs(alternate);
+        } else {
+            alternateACLs = authorizationMap.getAdminACLs(alternate);
+        }
+
+        if (alternateACLs != null && securityContext.isInOneOf(alternateACLs)) {
+            final String currentType = destination.isQueue() ? "queue" : "topic";
+            final String alternateType = destination.isQueue() ? "topic" : "queue";
+            LOG.warn("Possible destination type mismatch: user '{}' is not authorized to {} {} '{}', "
+                + "but a {} authorization entry for '{}' would grant access. "
+                + "Verify the destination type in the broker configuration.",
+                securityContext.getUserName(),
+                operation,
+                currentType,
+                destination.getPhysicalName(),
+                alternateType,
+                destination.getPhysicalName());
+        }
     }
 
     // SecurityAdminMBean interface

--- a/activemq-broker/src/main/java/org/apache/activemq/security/AuthorizationDestinationFilter.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/security/AuthorizationDestinationFilter.java
@@ -54,6 +54,7 @@ public class AuthorizationDestinationFilter extends DestinationFilter {
         }
 
         if (!securityContext.isBrokerContext() && allowedACLs != null && !securityContext.isInOneOf(allowedACLs) ) {
+            broker.logDestinationTypeHint(securityContext, destination, "read");
             throw new SecurityException("User " + securityContext.getUserName() + " is not authorized to read from: " + destination);
         }
 


### PR DESCRIPTION
Adds a server-side log hint when an authorization failure may be caused by a queue/topic type mismatch in the broker configuration. When a user is denied access to a destination but would have access to the same destination name under the alternate type (e.g., queue://foo would be allowed but client accesses topic://foo), the broker now logs a warning suggesting the operator verify the destination type specified in the configuration. This is a misconfiguration that can be difficult to diagnose from only the "not authorized" error message. The hint is only written to the broker log; the client-facing error message is unchanged and no extra details are exposed.

Example log output when the authorization failure occurs (the first line is the new log):

```
2026-06-03 16:33:45,507 | WARN  | Possible destination type mismatch: user 'test-user' is not authorized to write topic 'test-queue', but a queue authorization entry for 'test-queue' would grant access. Verify the destination type in the broker configuration. | org.apache.activemq.security.AuthorizationBroker | ActiveMQ Transport: tcp:///127.0.0.1:60031@61613
2026-06-03 16:33:45,508 | WARN  | Async error occurred: User test-user is not authorized to write to: topic://test-queue | org.apache.activemq.broker.TransportConnection.Service | ActiveMQ Transport: tcp:///127.0.0.1:60031@61613
2026-06-03 16:33:45,508 | WARN  | Exception occurred while processing a command: java.lang.SecurityException: User test-user is not authorized to write to: topic://test-queue | org.apache.activemq.transport.stomp.ProtocolConverter | ActiveMQ BrokerService[localhost] Task-1
```