### PR TITLE
[6.2.x] Add back missing closing tag (#2100)

### DIFF
--- a/activemq-web-console/src/main/webapp/browse.jsp
+++ b/activemq-web-console/src/main/webapp/browse.jsp
@@ -48,7 +48,7 @@
 <td><a href="<c:url value="message.jsp">
                  <c:param name="id" value="${row.JMSMessageID}" />
                  <c:param name="JMSDestination" value="${requestContext.queueBrowser.JMSDestination}"/></c:url>"
-    title="<c:out value="${row.properties}"/>"><c:out value="${row.JMSMessageID}"/></a>
+    title="<c:out value="${row.properties}"/>"><c:out value="${row.JMSMessageID}"/></a></td>
 <td><c:out value="${row.JMSCorrelationID}"/></td>
 <td><jms:persistent message="${row}"/></td>
 <td><c:out value="${row.JMSPriority}"/></td>


### PR DESCRIPTION
Fix typo introduced in #2089

(cherry picked from commit 83ce2bacd84edfea4282132aff64f49ecb6baefd)