### PR TITLE
[5.19.x] Validate Stomp headers against max frame size (#2104)

### DIFF
--- a/activemq-stomp/src/main/java/org/apache/activemq/transport/stomp/StompCodec.java
+++ b/activemq-stomp/src/main/java/org/apache/activemq/transport/stomp/StompCodec.java
@@ -67,6 +67,15 @@ public class StompCodec {
                }
 
                currentCommand.write(b);
+
+               if (currentCommand.size() > wireFormat.getMaxFrameSize()) {
+                   StompFrameError errorFrame = new StompFrameError(
+                           new ProtocolException("The maximum frame size was exceeded while processing headers.", true));
+                   errorFrame.setAction(this.action);
+                   transport.doConsume(errorFrame);
+                   return;
+               }
+
                // end of headers section, parse action and header
                if (b == '\n' && (previousByte == '\n' || currentCommand.endsWith(crlfcrlf))) {
                    DataByteArrayInputStream data = new DataByteArrayInputStream(currentCommand.toByteArray());

--- a/activemq-stomp/src/test/java/org/apache/activemq/transport/stomp/StompMaxFrameSizeTest.java
+++ b/activemq-stomp/src/test/java/org/apache/activemq/transport/stomp/StompMaxFrameSizeTest.java
@@ -205,25 +205,25 @@ public class StompMaxFrameSizeTest extends StompTestSupport {
     @Test(timeout = 60000)
     public void testOversizedHeadersOnPlainSocket() throws Exception {
         Assume.assumeTrue(testType == TestType.FRAME_MAX_LESS_THAN_HEADER_MAX);
-        doTestOversizedHeaders(port, false);
+        doTestOversizedHeaders(port, false, false);
     }
 
     @Test(timeout = 60000)
     public void testOversizedHeadersOnNioSocket() throws Exception {
         Assume.assumeTrue(testType == TestType.FRAME_MAX_LESS_THAN_HEADER_MAX);
-        doTestOversizedHeaders(nioPort, false);
+        doTestOversizedHeaders(nioPort, false, true);
     }
 
     @Test(timeout = 60000)
     public void testOversizedHeadersOnSslSocket() throws Exception {
         Assume.assumeTrue(testType == TestType.FRAME_MAX_LESS_THAN_HEADER_MAX);
-        doTestOversizedHeaders(sslPort, true);
+        doTestOversizedHeaders(sslPort, true, false);
     }
 
     @Test(timeout = 60000)
     public void testOversizedHeadersOnNioSslSocket() throws Exception {
         Assume.assumeTrue(testType == TestType.FRAME_MAX_LESS_THAN_HEADER_MAX);
-        doTestOversizedHeaders(nioSslPort, true);
+        doTestOversizedHeaders(nioSslPort, true, true);
     }
 
     protected void doTestOversizedAction(int port, boolean useSsl) throws Exception {
@@ -242,7 +242,7 @@ public class StompMaxFrameSizeTest extends StompTestSupport {
         assertTrue(received.getBody().contains("maximum frame size"));
     }
 
-    protected void doTestOversizedHeaders(int port, boolean useSsl) throws Exception {
+    protected void doTestOversizedHeaders(int port, boolean useSsl, boolean nio) throws Exception {
         initializeStomp(port, useSsl);
 
         StringBuilder headers = new StringBuilder(maxFrameSize + 100);
@@ -259,6 +259,10 @@ public class StompMaxFrameSizeTest extends StompTestSupport {
         assertNotNull(received);
         assertEquals("ERROR", received.getAction());
         assertTrue(received.getBody().contains("maximum frame size"));
+        // verify we terminated during header processing and not later during the action
+        if (nio) {
+            assertTrue(received.getBody().contains("while processing headers"));
+        }
     }
 
     protected void doOversizedTestMessage(int port, boolean useSsl, int dataSize) throws Exception {


### PR DESCRIPTION
Updates Stomp codec to check headers against max frame size during reading of the headers and not after when reading the body.

(cherry picked from commit 7cb413bc3175cc04a6d21228f049ab258b24833a)