### PR TITLE
Fix test by enabling allowTempDestinationStealing

### DIFF
--- a/activemq-unit-tests/src/test/resources/org/apache/activemq/usecases/receiver-secured.xml
+++ b/activemq-unit-tests/src/test/resources/org/apache/activemq/usecases/receiver-secured.xml
@@ -73,6 +73,14 @@
       <transportConnector uri="tcp://localhost:62002"/>
     </transportConnectors>
 
+    <destinationPolicy>
+      <policyMap>
+        <policyEntries>
+          <policyEntry tempQueue="true" allowTempDestinationStealing="true"/>
+        </policyEntries>
+      </policyMap>
+    </destinationPolicy>
+
   </broker>
 
 </beans>

--- a/activemq-unit-tests/src/test/resources/org/apache/activemq/usecases/sender-secured.xml
+++ b/activemq-unit-tests/src/test/resources/org/apache/activemq/usecases/sender-secured.xml
@@ -77,6 +77,14 @@
       <transportConnector uri="tcp://localhost:62001"/>
     </transportConnectors>
 
+    <destinationPolicy>
+      <policyMap>
+        <policyEntries>
+          <policyEntry tempQueue="true" allowTempDestinationStealing="true"/>
+        </policyEntries>
+      </policyMap>
+    </destinationPolicy>
+
   </broker>
 
 </beans>


### PR DESCRIPTION
Fixes TwoSecureBrokerRequestReplyTest that was broken by #2122 . The test requires allowTempDestinationStealing to be enabled to work.