### PR TITLE
[5.19.x] Fix test by enabling allowTempDestinationStealing (#2146)

### DIFF
--- a/activemq-unit-tests/src/test/resources/org/apache/activemq/usecases/receiver-secured.xml
+++ b/activemq-unit-tests/src/test/resources/org/apache/activemq/usecases/receiver-secured.xml
@@ -73,6 +73,14 @@
       <transportConnector uri="tcp://localhost:62002"/>
     </transportConnectors>
 
+    <destinationPolicy>
+      <policyMap>
+        <policyEntries>
+          <policyEntry tempQueue="true" allowTempDestinationStealing="true"/>
+        </policyEntries>
+      </policyMap>
+    </destinationPolicy>
+
   </broker>
 
 </beans>

--- a/activemq-unit-tests/src/test/resources/org/apache/activemq/usecases/sender-secured.xml
+++ b/activemq-unit-tests/src/test/resources/org/apache/activemq/usecases/sender-secured.xml
@@ -77,6 +77,14 @@
       <transportConnector uri="tcp://localhost:62001"/>
     </transportConnectors>
 
+    <destinationPolicy>
+      <policyMap>
+        <policyEntries>
+          <policyEntry tempQueue="true" allowTempDestinationStealing="true"/>
+        </policyEntries>
+      </policyMap>
+    </destinationPolicy>
+
   </broker>
 
 </beans>


### PR DESCRIPTION
Fixes TwoSecureBrokerRequestReplyTest that was broken by https://github.com/apache/activemq/pull/2122 . The test requires allowTempDestinationStealing to be enabled to work.

(cherry picked from commit d4c0b3c213cdfd8f6c15b3737c178440d2542f11)