### PR TITLE
[6.2.x] Lower default maxFrameSize to 10 MB in xml config (#2166)

### DIFF
--- a/assembly/src/release/conf/activemq.xml
+++ b/assembly/src/release/conf/activemq.xml
@@ -168,23 +168,23 @@
         -->
         <transportConnectors>
             <!--
-                DOS protection, limit concurrent connections to 1000 and frame size to 100MB.
+                DOS protection, limit concurrent connections to 1000 and frame size to 10MB.
 
                 WARNING: this openwire connector uses plain TCP and traffic is unencrypted. It is
                 intended for initial testing only. For production deployments it is strongly
                 recommended to use the SSL variant (ssl://) so that credentials and message
                 payloads are not transmitted in cleartext.
             -->
-            <transportConnector name="openwire" uri="tcp://0.0.0.0:61616?maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/>
+            <transportConnector name="openwire" uri="tcp://0.0.0.0:61616?maximumConnections=1000&amp;wireFormat.maxFrameSize=10485760"/>
             <!--
                 Additional transports are disabled by default to reduce the exposed attack surface.
                 Uncomment only the protocols you actually need, and prefer the secured variants
                 (openwire+ssl, amqp+ssl, stomp+ssl, mqtt+nio+ssl, wss) in production deployments.
             -->
-            <!-- <transportConnector name="amqp" uri="amqp://0.0.0.0:5672?maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/> -->
-            <!-- <transportConnector name="stomp" uri="stomp://0.0.0.0:61613?maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/> -->
-            <!-- <transportConnector name="mqtt" uri="mqtt://0.0.0.0:1883?maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/> -->
-            <!-- <transportConnector name="ws" uri="ws://0.0.0.0:61614?maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/> -->
+            <!-- <transportConnector name="amqp" uri="amqp://0.0.0.0:5672?maximumConnections=1000&amp;wireFormat.maxFrameSize=10485760"/> -->
+            <!-- <transportConnector name="stomp" uri="stomp://0.0.0.0:61613?maximumConnections=1000&amp;wireFormat.maxFrameSize=10485760"/> -->
+            <!-- <transportConnector name="mqtt" uri="mqtt://0.0.0.0:1883?maximumConnections=1000&amp;wireFormat.maxFrameSize=10485760"/> -->
+            <!-- <transportConnector name="ws" uri="ws://0.0.0.0:61614?maximumConnections=1000&amp;wireFormat.maxFrameSize=10485760"/> -->
         </transportConnectors>
 
         <!-- destroy the spring context on shutdown to stop jetty -->


### PR DESCRIPTION
The previous default was 100 MB but 10 MB makes more sense as a default, especially with maxInflatedDataSize defaulting to 100 MB.

(cherry picked from commit 505f5a9c9924f18d3c23391bc0bb8de292e0e408)