### PR TITLE
build(deps): bump shiro-version from 2.2.0 to 2.2.1 (#2124)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
     <qpid-jms-version>2.10.0</qpid-jms-version>
     <netty-version>4.2.10.Final</netty-version>
     <rome-version>2.1.0</rome-version>
-    <shiro-version>2.2.0</shiro-version>
+    <shiro-version>2.2.1</shiro-version>
     <slf4j-version>2.0.17</slf4j-version>
     <snappy-version>1.1.10.7</snappy-version>
     <spring-version>6.2.18</spring-version>


### PR DESCRIPTION
Bumps `shiro-version` from 2.2.0 to 2.2.1.

Updates `org.apache.shiro:shiro-core` from 2.2.0 to 2.2.1
- [Release notes](https://github.com/apache/shiro/releases)
- [Changelog](https://github.com/apache/shiro/blob/main/RELEASE-NOTES)
- [Commits](https://github.com/apache/shiro/compare/shiro-root-2.2.0...shiro-root-2.2.1)

Updates `org.apache.shiro:shiro-spring` from 2.2.0 to 2.2.1

---
updated-dependencies:
- dependency-name: org.apache.shiro:shiro-core dependency-version: 2.2.1 dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: org.apache.shiro:shiro-spring dependency-version: 2.2.1 dependency-type: direct:production update-type: version-update:semver-patch ...