### PR TITLE
Fix TextMessage body thread safety

### DIFF
--- a/activemq-client/src/main/java/org/apache/activemq/command/ActiveMQTextMessage.java
+++ b/activemq-client/src/main/java/org/apache/activemq/command/ActiveMQTextMessage.java
@@ -51,13 +51,11 @@ public class ActiveMQTextMessage extends ActiveMQMessage implements TextMessage 
     @Override
     public Message copy() {
         ActiveMQTextMessage copy = new ActiveMQTextMessage();
-        copy(copy);
+        synchronized (this) {
+            super.copy(copy);
+            copy.text = text;
+        }
         return copy;
-    }
-
-    private synchronized void copy(ActiveMQTextMessage copy) {
-        super.copy(copy);
-        copy.text = text;
     }
 
     @Override
@@ -88,15 +86,12 @@ public class ActiveMQTextMessage extends ActiveMQMessage implements TextMessage 
 
     @Override
     public String getText() throws JMSException {
-        ByteSequence content = getContent();
         String text = this.text;
 
-        if (text == null && content != null) {
+        if (text == null) {
             synchronized (this) {
-                content = getContent();
                 text = this.text;
-                // Double-checked locking, re-check under lock if we need
-                // to decode
+                // Double-checked locking, re-check under lock if we need to decode
                 if (text == null && content != null) {
                     this.text = text = decodeContent(content);
                     setContent(null);
@@ -104,6 +99,7 @@ public class ActiveMQTextMessage extends ActiveMQMessage implements TextMessage 
                 }
             }
         }
+
         return text;
     }
 
@@ -143,26 +139,22 @@ public class ActiveMQTextMessage extends ActiveMQMessage implements TextMessage 
 
     @Override
     public void storeContentAndClear() {
-        storeContent(true);
+        // always lock to simplify things because if this method is being called
+        // it's right before send so it's very likely to need to mutate state
+        // This should generally be uncontested lock so it will be fast
+        synchronized (this) {
+            storeContent();
+            text = null;
+        }
     }
 
     @Override
     public void storeContent() {
-        storeContent(false);
-    }
-
-    private void storeContent(final boolean clear) {
         try {
-            ByteSequence content = getContent();
-            String text = this.text;
-            // Both of these are volatile reads, we can just skip
-            // if state is already correct
-            if (content == null && text != null) {
+            // Content is volatile so if it's not null we can skip and do nothing
+            if (content == null) {
                 synchronized (this) {
-                    // Double-checked locking, re-read under lock
-                    content = getContent();
-                    text = this.text;
-                    // re-check if we need to store under lock
+                    // Double-checked locking, re-check state under lock
                     if (content == null && text != null) {
                         ByteArrayOutputStream bytesOut = new ByteArrayOutputStream();
                         OutputStream os = bytesOut;
@@ -174,24 +166,7 @@ public class ActiveMQTextMessage extends ActiveMQMessage implements TextMessage 
                         DataOutputStream dataOut = new DataOutputStream(os);
                         MarshallingSupport.writeUTF8(dataOut, text);
                         dataOut.close();
-                        this.content = content = bytesOut.toByteSequence();
-                    }
-                    // We are in a synchornized block so at this point we know we only need
-                    // to clear if content is not null and text is not null
-                    if (clear && text != null && content != null) {
-                        this.text = null;
-                    }
-                }
-            } else if (clear && content != null && text != null) {
-                synchronized (this) {
-                    // re-read under lock
-                    content = getContent();
-                    text = this.text;
-                    // Double-checked locking
-                    // We are in a synchornized block so at this point we know we only need
-                    // to clear if content is not null and text is not null
-                    if (text != null && content != null) {
-                        this.text = null;
+                        setContent(bytesOut.toByteSequence());
                     }
                 }
             }
@@ -215,9 +190,9 @@ public class ActiveMQTextMessage extends ActiveMQMessage implements TextMessage 
         }
     }
 
+    // We need to sync because both variables need to be read independently
     @Override
-    public boolean isContentMarshalled() {
-        // volatile reads, should be fine to just check without synchronized
+    public synchronized boolean isContentMarshalled() {
         return content != null || text == null;
     }
 
@@ -242,14 +217,23 @@ public class ActiveMQTextMessage extends ActiveMQMessage implements TextMessage 
 
     @Override
     public int getSize() {
-        String text = this.text;
-        ByteSequence content = getContent();
-        if (size == 0 && content == null && text != null) {
-            size = getMinimumMessageSize();
-            if (marshalledProperties != null) {
-                size += marshalledProperties.getLength();
+        int size = this.size;
+        if (size == 0) {
+            synchronized (this) {
+                size = this.size;
+                String text = this.text;
+                ByteSequence content = getContent();
+                if (size == 0 && content == null && text != null) {
+                    size = getMinimumMessageSize();
+                    ByteSequence marshalledProperties = this.marshalledProperties;
+                    if (marshalledProperties != null) {
+                        size += marshalledProperties.getLength();
+                    }
+                    size += text.length() * 2;
+                    this.size = size;
+                }
+                return super.getSize();
             }
-            size += text.length() * 2;
         }
         return super.getSize();
     }
@@ -258,7 +242,7 @@ public class ActiveMQTextMessage extends ActiveMQMessage implements TextMessage 
     public String toString() {
         try {
             String text = this.text;
-            if( text == null ) {
+            if (text == null) {
                 text = decodeContent(getContent());
             }
             if (text != null) {

--- a/activemq-client/src/main/java/org/apache/activemq/command/ActiveMQTextMessage.java
+++ b/activemq-client/src/main/java/org/apache/activemq/command/ActiveMQTextMessage.java
@@ -79,6 +79,13 @@ public class ActiveMQTextMessage extends ActiveMQMessage implements TextMessage 
         }
     }
 
+    // Synchronize this to prevent setting content if another mutation operation
+    // is happening concurrently.
+    @Override
+    public synchronized void setContent(ByteSequence content) {
+        super.setContent(content);
+    }
+
     @Override
     public String getText() throws JMSException {
         ByteSequence content = getContent();

--- a/activemq-client/src/main/java/org/apache/activemq/command/ActiveMQTextMessage.java
+++ b/activemq-client/src/main/java/org/apache/activemq/command/ActiveMQTextMessage.java
@@ -45,7 +45,8 @@ public class ActiveMQTextMessage extends ActiveMQMessage implements TextMessage 
 
     public static final byte DATA_STRUCTURE_TYPE = CommandTypes.ACTIVEMQ_TEXT_MESSAGE;
 
-    protected String text;
+    // This is package scope (instead of private) for testing purposes
+    volatile String text;
 
     @Override
     public Message copy() {
@@ -54,7 +55,7 @@ public class ActiveMQTextMessage extends ActiveMQMessage implements TextMessage 
         return copy;
     }
 
-    private void copy(ActiveMQTextMessage copy) {
+    private synchronized void copy(ActiveMQTextMessage copy) {
         super.copy(copy);
         copy.text = text;
     }
@@ -72,18 +73,29 @@ public class ActiveMQTextMessage extends ActiveMQMessage implements TextMessage 
     @Override
     public void setText(String text) throws MessageNotWriteableException {
         checkReadOnlyBody();
-        this.text = text;
-        setContent(null);
+        synchronized (this) {
+            this.text = text;
+            setContent(null);
+        }
     }
 
     @Override
     public String getText() throws JMSException {
         ByteSequence content = getContent();
+        String text = this.text;
 
         if (text == null && content != null) {
-            text = decodeContent(content);
-            setContent(null);
-            setCompressed(false);
+            synchronized (this) {
+                content = getContent();
+                text = this.text;
+                // Double-checked locking, re-check under lock if we need
+                // to decode
+                if (text == null && content != null) {
+                    this.text = text = decodeContent(content);
+                    setContent(null);
+                    setCompressed(false);
+                }
+            }
         }
         return text;
     }
@@ -124,27 +136,57 @@ public class ActiveMQTextMessage extends ActiveMQMessage implements TextMessage 
 
     @Override
     public void storeContentAndClear() {
-        storeContent();
-        text=null;
+        storeContent(true);
     }
 
     @Override
     public void storeContent() {
+        storeContent(false);
+    }
+
+    private void storeContent(final boolean clear) {
         try {
             ByteSequence content = getContent();
             String text = this.text;
+            // Both of these are volatile reads, we can just skip
+            // if state is already correct
             if (content == null && text != null) {
-                ByteArrayOutputStream bytesOut = new ByteArrayOutputStream();
-                OutputStream os = bytesOut;
-                ActiveMQConnection connection = getConnection();
-                if (connection != null && connection.isUseCompression()) {
-                    compressed = true;
-                    os = new DeflaterOutputStream(os);
+                synchronized (this) {
+                    // Double-checked locking, re-read under lock
+                    content = getContent();
+                    text = this.text;
+                    // re-check if we need to store under lock
+                    if (content == null && text != null) {
+                        ByteArrayOutputStream bytesOut = new ByteArrayOutputStream();
+                        OutputStream os = bytesOut;
+                        ActiveMQConnection connection = getConnection();
+                        if (connection != null && connection.isUseCompression()) {
+                            compressed = true;
+                            os = new DeflaterOutputStream(os);
+                        }
+                        DataOutputStream dataOut = new DataOutputStream(os);
+                        MarshallingSupport.writeUTF8(dataOut, text);
+                        dataOut.close();
+                        this.content = content = bytesOut.toByteSequence();
+                    }
+                    // We are in a synchornized block so at this point we know we only need
+                    // to clear if content is not null and text is not null
+                    if (clear && text != null && content != null) {
+                        this.text = null;
+                    }
                 }
-                DataOutputStream dataOut = new DataOutputStream(os);
-                MarshallingSupport.writeUTF8(dataOut, text);
-                dataOut.close();
-                setContent(bytesOut.toByteSequence());
+            } else if (clear && content != null && text != null) {
+                synchronized (this) {
+                    // re-read under lock
+                    content = getContent();
+                    text = this.text;
+                    // Double-checked locking
+                    // We are in a synchornized block so at this point we know we only need
+                    // to clear if content is not null and text is not null
+                    if (text != null && content != null) {
+                        this.text = null;
+                    }
+                }
             }
         } catch (IOException e) {
             throw new RuntimeException(e);
@@ -156,11 +198,19 @@ public class ActiveMQTextMessage extends ActiveMQMessage implements TextMessage 
     @Override
     public void clearUnMarshalledState() throws JMSException {
         super.clearUnMarshalledState();
-        this.text = null;
+        if (this.text != null) {
+            synchronized (this) {
+                // This is volatile but another locking makes sure another thread
+                // isn't attempting to read this value to marshal to the content at the
+                // same time
+                this.text = null;
+            }
+        }
     }
 
     @Override
     public boolean isContentMarshalled() {
+        // volatile reads, should be fine to just check without synchronized
         return content != null || text == null;
     }
 
@@ -177,13 +227,16 @@ public class ActiveMQTextMessage extends ActiveMQMessage implements TextMessage 
      */
     @Override
     public void clearBody() throws JMSException {
-        super.clearBody();
-        this.text = null;
+        synchronized (this) {
+            super.clearBody();
+            this.text = null;
+        }
     }
 
     @Override
     public int getSize() {
         String text = this.text;
+        ByteSequence content = getContent();
         if (size == 0 && content == null && text != null) {
             size = getMinimumMessageSize();
             if (marshalledProperties != null) {

--- a/activemq-client/src/main/java/org/apache/activemq/command/Message.java
+++ b/activemq-client/src/main/java/org/apache/activemq/command/Message.java
@@ -81,7 +81,7 @@ public abstract class Message extends BaseCommand implements MarshallAware, Mess
     protected boolean compressed;
     protected String userID;
 
-    protected ByteSequence content;
+    protected volatile ByteSequence content;
     protected volatile ByteSequence marshalledProperties;
     protected DataStructure dataStructure;
     protected int redeliveryCounter;
@@ -715,6 +715,7 @@ public abstract class Message extends BaseCommand implements MarshallAware, Mess
     @Override
 	public int getSize() {
         int minimumMessageSize = getMinimumMessageSize();
+        ByteSequence content = this.content;
         if (size < minimumMessageSize || size == 0) {
             size = minimumMessageSize;
             if (marshalledProperties != null) {

--- a/activemq-client/src/main/java/org/apache/activemq/command/Message.java
+++ b/activemq-client/src/main/java/org/apache/activemq/command/Message.java
@@ -86,7 +86,7 @@ public abstract class Message extends BaseCommand implements MarshallAware, Mess
     protected DataStructure dataStructure;
     protected int redeliveryCounter;
 
-    protected int size;
+    protected volatile int size;
     protected Map<String, Object> properties;
     protected boolean readOnlyProperties;
     protected boolean readOnlyBody;
@@ -716,14 +716,17 @@ public abstract class Message extends BaseCommand implements MarshallAware, Mess
 	public int getSize() {
         int minimumMessageSize = getMinimumMessageSize();
         ByteSequence content = this.content;
+        int size = this.size;
         if (size < minimumMessageSize || size == 0) {
             size = minimumMessageSize;
+            ByteSequence marshalledProperties = this.marshalledProperties;
             if (marshalledProperties != null) {
                 size += marshalledProperties.getLength();
             }
             if (content != null) {
                 size += content.getLength();
             }
+            this.size = size;
         }
         return size;
     }


### PR DESCRIPTION
This fixes the rare null body issues seen on the broker when using **text** messages by using synchronization when marshaling or unmarshaling the body into a String to prevent a race condition from causing the body to end up null. This has been optimized to use volatiles and double checked locking to avoid synchronization unless needed.

For some background, this has been a long running issue that has come up over the years and there have been many proposed ways to fix it (see #1851 and #1659 for examples). Despite the fact that these messages are supposed to be copied and not used across multiple threads there are cases where that is not true and can cause issues (topic consumers on dispatch for example don't copy) so this issue still pops up from time to time.

After looking at all the options and how disruptive it would be, I think this is the best approach for now as a short term fix. I think long term we could look at better solutions. I think ideally on the server side it would be nice to use messages that only store the data in the marshaled format as the vast majority of the the time the body should not need to be unmarshaled anyways (exceptions include protocol conversion or logging). The client versions could still use mutable messages that can store either version.

**Notes on other message types and properties:**

1. This PR only attempts to fix the body for ActiveMQTextMessage because this is **not a problem for the body of other message types** (including Map, object message, etc). This issue is specific to ActiveMQTextMessage because it is the only message type that will only store either the unmarshaled data (text) or the bytes, but not both. Other message types do not clear the content after unmarshaling. This means that if multiple threads try and do a conversion on a message like Map or Object message, it may convert twice, but you won't get null. The other message types only clear unmarshaled content at certain points in the broker if reduceMemoryFootprint is true.
2. The properties map also changes state between unmarshalled and marshaled so it needs to be investigated more, but it looks like we may be ok for now. Just like the other non-text messages, when getting properties if the map is null it will unmarshall but it won't clear the original content. This is confirmed by the fact that no one has reported null properties.