### PR TITLE
[6.2.x] feat(#1828): Expose NetworkConnector URI and local URI in JMX MBean (activemq-6.2.x)

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/broker/jmx/NetworkConnectorView.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/jmx/NetworkConnectorView.java
@@ -16,6 +16,8 @@
  */
 package org.apache.activemq.broker.jmx;
 
+import java.net.URISyntaxException;
+
 import org.apache.activemq.network.NetworkConnector;
 
 public class NetworkConnectorView implements NetworkConnectorViewMBean {
@@ -35,6 +37,20 @@ public class NetworkConnectorView implements NetworkConnectorViewMBean {
     @Override
     public void stop() throws Exception {
         connector.stop();
+    }
+
+    @Override
+    public String getUri() {
+        return connector.getUri() != null ? connector.getUri().toString() : "";
+    }
+
+    @Override
+    public String getLocalUri() {
+        try {
+            return connector.getLocalUri() != null ? connector.getLocalUri().toString() : "";
+        } catch (URISyntaxException e) {
+            return "";
+        }
     }
 
     @Override

--- a/activemq-broker/src/main/java/org/apache/activemq/broker/jmx/NetworkConnectorViewMBean.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/jmx/NetworkConnectorViewMBean.java
@@ -20,6 +20,10 @@ import org.apache.activemq.Service;
 
 public interface NetworkConnectorViewMBean extends Service {
 
+    String getUri();
+
+    String getLocalUri();
+
     String getName();
 
     int getMessageTTL();

--- a/activemq-broker/src/main/java/org/apache/activemq/network/MulticastNetworkConnector.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/network/MulticastNetworkConnector.java
@@ -77,6 +77,12 @@ public class MulticastNetworkConnector extends NetworkConnector {
         this.remoteTransport = remoteTransport;
     }
 
+    // Satisfies the abstract getUri() contract from NetworkConnector; delegates to getRemoteURI()
+    @Override
+    public URI getUri() {
+        return getRemoteURI();
+    }
+
     public URI getRemoteURI() {
         return remoteURI;
     }

--- a/activemq-broker/src/main/java/org/apache/activemq/network/NetworkConnector.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/network/NetworkConnector.java
@@ -77,6 +77,8 @@ public abstract class NetworkConnector extends NetworkBridgeConfiguration implem
         this.localURI = localURI;
     }
 
+    public abstract URI getUri();
+
     public URI getLocalUri() throws URISyntaxException {
         return localURI;
     }

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/jmx/JmxCreateNCTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/jmx/JmxCreateNCTest.java
@@ -80,6 +80,8 @@ public class JmxCreateNCTest {
 
         assertNotNull(nc);
         assertEquals("NC", nc.getName());
+        assertEquals("static:(tcp://localhost:61617)", nc.getUri());
+        assertNotNull(nc.getLocalUri());
     }
 
     @Test


### PR DESCRIPTION
Backport of #1829 to the `activemq-6.2.x` branch.

## Summary

- Add `getUri()` and `getLocalUri()` to `NetworkConnectorViewMBean` so the network connector URI is visible via JMX.
- Add `abstract getUri()` to the `NetworkConnector` base class.
- Implement `getUri()` in `MulticastNetworkConnector` (delegates to `getRemoteURI()`).
- `DiscoveryNetworkConnector` and `LdapNetworkConnector` already had `getUri()` implementations and satisfy the new abstract contract without changes.
- Extend `JmxCreateNCTest` to assert the exposed URI values.