### PR TITLE
[6.2.x] Update spring.schemas to include missing 'spring-beans.xsd' mapping

### DIFF
--- a/activemq-spring/src/main/resources/META-INF/spring.schemas
+++ b/activemq-spring/src/main/resources/META-INF/spring.schemas
@@ -33,3 +33,5 @@ http\://activemq.apache.org/schema/core/activemq-core-6.2.8.xsd=activemq.xsd
 
 http\://camel.apache.org/schema/osgi/camel-osgi.xsd=camel-osgi.xsd
 http\://camel.apache.org/schema/spring/camel-spring.xsd=camel-spring.xsd
+
+http\://www.springframework.org/schema/beans/spring-beans.xsd=org/springframework/beans/factory/xml/spring-beans.xsd


### PR DESCRIPTION
Backport of #2202 to the `activemq-6.2.x` branch.

Update `spring.schemas` to add the missing `spring-beans.xsd` mapping, fixing issue #2201.