### PR TITLE
Upgrade to Spring 7.0.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,8 +93,8 @@
     <rome-version>2.1.0</rome-version>
     <shiro-version>2.2.1</shiro-version>
     <slf4j-version>2.0.18</slf4j-version>
-    <spring-version>6.2.19</spring-version>
-    <spring-version-range>[6,7)</spring-version-range>
+    <spring-version>7.0.8</spring-version>
+    <spring-version-range>[7,8)</spring-version-range>
     <taglibs-version>1.2.5</taglibs-version>
     <xpp3-version>1.1.4c</xpp3-version>
     <xstream-version>1.4.21</xstream-version>


### PR DESCRIPTION
Spring 6.2.x is now EOL so this upgrades to Spring 7.0.x going forward. Spring 7 requires JakartaEE 11, which was upgraded in #1734

I looked this over and I think the only thing that needs to be done is updating the version and version range (which is used for OSGi). I ran through some of the spring tests and things seem to work without any issue but the full test suite needs to run.