### PR TITLE
Bootstrap activemq-6.3.x branch

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -45,6 +45,13 @@ github:
         require_last_push_approval: false
         required_approving_review_count: 1
       required_linear_history: true
+    activemq-6.3.x:
+      required_pull_request_reviews:
+        require_code_owner_reviews: false
+        dismiss_stale_reviews: true
+        require_last_push_approval: false
+        required_approving_review_count: 0
+      required_linear_history: true
     activemq-6.2.x:
       required_pull_request_reviews:
         require_code_owner_reviews: false

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,6 +34,25 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    target-branch: "activemq-6.3.x"
+    commit-message:
+      prefix: "[6.3.x] "
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    target-branch: "activemq-6.3.x"
+    commit-message:
+      prefix: "[6.3.x] "
+    open-pull-requests-limits: 50
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
     target-branch: "activemq-6.2.x"
     commit-message:
       prefix: "[6.2.x] "

--- a/.github/workflows/ci-quick.yml
+++ b/.github/workflows/ci-quick.yml
@@ -25,9 +25,9 @@ name: CI Quick
 
 on:
   push:
-    branches: [ "main", "activemq-6.2.x", "activemq-5.19.x" ]
+    branches: [ "main", "activemq-6.3.x", "activemq-6.2.x", "activemq-5.19.x" ]
   pull_request:
-    branches: [ "main", "activemq-6.2.x", "activemq-5.19.x" ]
+    branches: [ "main", "activemq-6.3.x", "activemq-6.2.x", "activemq-5.19.x" ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Now that the `activemq-6.3.x` branch has been created, we can use it in the infra resources.