### PR TITLE
Fix AMQP Object message decompression

### DIFF
--- a/activemq-amqp/src/main/java/org/apache/activemq/transport/amqp/message/AmqpMessageSupport.java
+++ b/activemq-amqp/src/main/java/org/apache/activemq/transport/amqp/message/AmqpMessageSupport.java
@@ -256,12 +256,6 @@ public final class AmqpMessageSupport {
                      InputStream iis = MarshallingSupport.createInflaterInputStream(
                             message.getMaxInflatedDataSize(), is)) {
 
-                    // Keep the value as an int and don't cast to a byte.
-                    // The read() method can return a int between -1 and 255 and
-                    // previously the returned value was being cast to a byte.
-                    // If the returned int happens to be 255, then casting that to a byte
-                    // causes the value to become -1 (java use's Two's Complement for ints)
-                    // so the loop will think we reached end of stream too early
                     int value;
                     while ((value = iis.read()) != -1) {
                         os.write(value);

--- a/activemq-amqp/src/main/java/org/apache/activemq/transport/amqp/message/AmqpMessageSupport.java
+++ b/activemq-amqp/src/main/java/org/apache/activemq/transport/amqp/message/AmqpMessageSupport.java
@@ -256,8 +256,14 @@ public final class AmqpMessageSupport {
                      InputStream iis = MarshallingSupport.createInflaterInputStream(
                             message.getMaxInflatedDataSize(), is)) {
 
-                    byte value;
-                    while ((value = (byte) iis.read()) != -1) {
+                    // Keep the value as an int and don't cast to a byte.
+                    // The read() method can return a int between -1 and 255 and
+                    // previously the returned value was being cast to a byte.
+                    // If the returned int happens to be 255, then casting that to a byte
+                    // causes the value to become -1 (java use's Two's Complement for ints)
+                    // so the loop will think we reached end of stream too early
+                    int value;
+                    while ((value = iis.read()) != -1) {
                         os.write(value);
                     }
 

--- a/activemq-amqp/src/test/java/org/apache/activemq/transport/amqp/message/JMSMappingOutboundTransformerTest.java
+++ b/activemq-amqp/src/test/java/org/apache/activemq/transport/amqp/message/JMSMappingOutboundTransformerTest.java
@@ -584,8 +584,31 @@ public class JMSMappingOutboundTransformerTest {
     }
 
     @Test
+    public void testConvertCompressedObjectMessageToAmqpMessageByte255() throws Exception {
+        // This specific UUID tests a decompression edge case found for Objects messages and
+        // is used to verify AmqpMessageSupport.getBinaryFromMessageBody() is correct.
+        //
+        // Previously the decompression could stop early and not decompress the entire stream of
+        // data. This was due to the loop incorrectly casting the read int from the inflater
+        // stream as a byte before comparing to -1 to look for end of stream.
+        //
+        // This is incorrect because the read() method can return a value between -1 and 255.
+        // Java uses Two's Complement to represent signed ints, so if the returned value int
+        // is 255 and is cast to a byte it becomes -1. This meant that reading 255 would return -1
+        // leading to the code to exit thinking end of stream has been reached.
+        //
+        // This particular UUID includes a byte of 255 when decompressed to test this edge case.
+        testConvertCompressedObjectMessageToAmqpMessageWithDataBody(
+                UUID.fromString("14faffdc-387d-4e2e-8b44-748d47eaaf06"));
+    }
+
+    @Test
     public void testConvertCompressedObjectMessageToAmqpMessageWithDataBody() throws Exception {
-        ActiveMQObjectMessage outbound = createObjectMessage(TEST_OBJECT_VALUE, true);
+        testConvertCompressedObjectMessageToAmqpMessageWithDataBody(TEST_OBJECT_VALUE);
+    }
+
+    private void testConvertCompressedObjectMessageToAmqpMessageWithDataBody(UUID uuid) throws Exception {
+        ActiveMQObjectMessage outbound = createObjectMessage(uuid, true);
         outbound.onSend();
         outbound.storeContent();
 


### PR DESCRIPTION
This fixes the AmqpMessageSupport utility to correctly decompress the body of Object Message's in all cases.

Previously the decompression could stop early and not decompress the entire stream of data. This was due to the loop incorrectly casting the read int from the inflater stream as a byte before comparing to -1 to look for end of stream.

This is incorrect because the read() method can return a value between -1 and 255. Java uses Two's Complement to represent signed ints, so if the returned value int is 255 and is cast to a byte it becomes -1. This meant that reading 255 would return -1 leading to the code to exit thinking end of stream has been reached.

This was discovered when I as was looking into the "flaky" test error for https://github.com/apache/activemq/issues/2238, `JMSInteroperabilityTest.testOpenWireToQpidObjectMessageWithOpenWireCompression:493 » MessageFormat Failed to read object: null`

Turns out, the test was not flaky but showed a real error. The test uses a random UUID, so by the test would intermittently fail depending on if the UUID decompression ran into a 255 int or not.