### PR TITLE
[#2275] Drop redundant consumers monitor from topic dispatch empty-check

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/broker/region/Topic.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/region/Topic.java
@@ -860,11 +860,12 @@ public class Topic extends BaseDestination implements Task {
                 }
             }
 
-            synchronized (consumers) {
-                if (consumers.isEmpty()) {
-                    onMessageWithNoConsumers(context, message);
-                    return;
-                }
+            // CopyOnWriteArrayList.isEmpty() is a volatile snapshot read; no
+            // monitor needed — the check is advisory at message granularity
+            // either way (subscription cutover is quiesced by dispatchLock).
+            if (consumers.isEmpty()) {
+                onMessageWithNoConsumers(context, message);
+                return;
             }
 
             // Clear memory before dispatch - need to clear here because the call to


### PR DESCRIPTION
Currently, there is a synchronized guard around consumers being empty to fire an advisory. The consumers collection is protected final and uses a CopyOnWriteArrayList.

The risk to anyone extending Topic would be if they override the consumers collection with a non-thread safe collection type, they may miss an advisory for a message arriving when there are no consumers.