### PR TITLE
[#2282] Drop redundant sequence generator monitor in RegionBroker

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/broker/region/RegionBroker.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/region/RegionBroker.java
@@ -865,9 +865,9 @@ public class RegionBroker extends EmptyBroker {
      */
     @Override
     public long getBrokerSequenceId() {
-        synchronized (sequenceGenerator) {
-            return sequenceGenerator.getNextSequenceId();
-        }
+        // LongSequenceGenerator is atomic; no monitor needed on this hot path
+        // (stamped on every send for every destination).
+        return sequenceGenerator.getNextSequenceId();
     }
 
     @Override


### PR DESCRIPTION
LongSequenceGenerator is private final on RegionBroker and is already thread-safe. The synchronized is redundant.