### PR TITLE
[6.3.x] Fix dependabot yml typo (#2284)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,7 +44,7 @@ updates:
     target-branch: "activemq-6.3.x"
     commit-message:
       prefix: "[6.3.x] "
-    open-pull-requests-limits: 50
+    open-pull-requests-limit: 50
     ignore:
       - dependency-name: "*"
         update-types:
@@ -63,7 +63,7 @@ updates:
     target-branch: "activemq-6.2.x"
     commit-message:
       prefix: "[6.2.x] "
-    open-pull-requests-limits: 50
+    open-pull-requests-limit: 50
     ignore:
       - dependency-name: "*"
         update-types:
@@ -82,7 +82,7 @@ updates:
     target-branch: "activemq-5.19.x"
     commit-message:
       prefix: "[5.19.x] "
-    open-pull-requests-limits: 50
+    open-pull-requests-limit: 50
     ignore:
       - dependency-name: "*"
         update-types:


### PR DESCRIPTION
(cherry picked from commit d66b4648cdd6a6a9221882540eb0c97d525bf674)