### PR TITLE
[#2400] Make networkBridgeListener volatile for safe cross-thread publication

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/network/DemandForwardingBridgeSupport.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/network/DemandForwardingBridgeSupport.java
@@ -156,7 +156,7 @@ public abstract class DemandForwardingBridgeSupport implements NetworkBridge, Br
 
     protected final NetworkBridgeStatistics networkBridgeStatistics = new NetworkBridgeStatistics();
 
-    private NetworkBridgeListener networkBridgeListener;
+    private volatile NetworkBridgeListener networkBridgeListener;
     private boolean createdByDuplex;
     private BrokerInfo localBrokerInfo;
     private BrokerInfo remoteBrokerInfo;


### PR DESCRIPTION
The listener is set from the connector setup thread and read from transport and executor threads via local snapshots without volatile those reads may miss.