### PR TITLE
[#2271] Update Producer getDeliveryDelay() to always return zero (0) …

### DIFF
--- a/activemq-client/src/main/java/org/apache/activemq/ActiveMQMessageProducerSupport.java
+++ b/activemq-client/src/main/java/org/apache/activemq/ActiveMQMessageProducerSupport.java
@@ -68,7 +68,7 @@ public abstract class ActiveMQMessageProducerSupport implements MessageProducer,
      */
     @Override
     public long getDeliveryDelay() throws JMSException {
-        throw new UnsupportedOperationException("getDeliveryDelay() is not supported");
+        return 0L;
     }
     
     /**

--- a/activemq-client/src/main/java/org/apache/activemq/ActiveMQProducer.java
+++ b/activemq-client/src/main/java/org/apache/activemq/ActiveMQProducer.java
@@ -251,7 +251,7 @@ public class ActiveMQProducer implements JMSProducer {
 
     @Override
     public long getDeliveryDelay() {
-        throw new UnsupportedOperationException("getDeliveryDelay() is not supported");
+        return 0L;
     }
 
     @Override

--- a/activemq-jms-pool/src/main/java/org/apache/activemq/jms/pool/PooledProducer.java
+++ b/activemq-jms-pool/src/main/java/org/apache/activemq/jms/pool/PooledProducer.java
@@ -156,7 +156,7 @@ public class PooledProducer implements MessageProducer {
      */
     @Override
     public long getDeliveryDelay() throws JMSException {
-        throw new UnsupportedOperationException("getDeliveryDelay() is not supported");
+        return 0L;
     }
 
     @Override

--- a/activemq-ra/src/main/java/org/apache/activemq/ra/InboundMessageProducerProxy.java
+++ b/activemq-ra/src/main/java/org/apache/activemq/ra/InboundMessageProducerProxy.java
@@ -218,6 +218,6 @@ public class InboundMessageProducerProxy implements MessageProducer, QueueSender
      */
     @Override
     public long getDeliveryDelay() throws JMSException {
-        throw new UnsupportedOperationException("getDeliveryDelay() is not supported");
+        return 0L;
     }
 }

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/jms2/ActiveMQJMS2ContextTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/jms2/ActiveMQJMS2ContextTest.java
@@ -289,9 +289,14 @@ public class ActiveMQJMS2ContextTest extends ActiveMQJMS2TestBase {
         session.createSharedDurableConsumer(session.createTopic("test"), null, null);
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testProducerDeliveryDelayGet() throws JMSException {
-        messageProducer.getDeliveryDelay();
+        assertEquals(0L, messageProducer.getDeliveryDelay());
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testProducerDeliveryDelaySetZero() throws JMSException {
+        messageProducer.setDeliveryDelay(0L);
     }
 
     @Test(expected = UnsupportedOperationException.class)


### PR DESCRIPTION
…(#2272)

- Fixes messagehub jms pool w/ Spring Boot

(cherry picked from commit 4da5d4e76af4e53132b39fba8cc20bb4a69c0a28)