### PR TITLE
[#2418] Improve performance of IntSequenceGenerator

### DIFF
--- a/activemq-client/src/main/java/org/apache/activemq/util/IntSequenceGenerator.java
+++ b/activemq-client/src/main/java/org/apache/activemq/util/IntSequenceGenerator.java
@@ -16,19 +16,24 @@
  */
 package org.apache.activemq.util;
 
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 public class IntSequenceGenerator {
 
-    private int lastSequenceId;
+    private static final AtomicIntegerFieldUpdater<IntSequenceGenerator> SEQUENCE_UPDATER =
+            AtomicIntegerFieldUpdater.newUpdater(IntSequenceGenerator.class, "lastSequenceId");
 
-    public synchronized int getNextSequenceId() {
-        return ++lastSequenceId;
+    private volatile int lastSequenceId;
+
+    public int getNextSequenceId() {
+        return SEQUENCE_UPDATER.incrementAndGet(this);
     }
 
-    public synchronized int getLastSequenceId() {
+    public int getLastSequenceId() {
         return lastSequenceId;
     }
 
-    public synchronized void setLastSequenceId(int l) {
-        lastSequenceId = l;
+    public void setLastSequenceId(int l) {
+        SEQUENCE_UPDATER.set(this, l);
     }
 }


### PR DESCRIPTION
This adopts the same approach as [LongSequenceGenerator](https://github.com/apache/activemq/blob/cd1dfa298c11dd614fdc16bad0b694639f185991/activemq-client/src/main/java/org/apache/activemq/util/LongSequenceGenerator.java#L25) and uses an Atomic field updater to avoid using synchronized.

The sequence generator is used by ResponseCorrelator so the existing tests will catch any errors.

See https://issues.apache.org/jira/browse/AMQ-7300