### PR TITLE
[6.2.x] [#2282] Drop redundant sequence generator monitor in RegionBroker

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/broker/region/RegionBroker.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/region/RegionBroker.java
@@ -865,9 +865,9 @@ public class RegionBroker extends EmptyBroker {
      */
     @Override
     public long getBrokerSequenceId() {
-        synchronized (sequenceGenerator) {
-            return sequenceGenerator.getNextSequenceId();
-        }
+        // LongSequenceGenerator is atomic; no monitor needed on this hot path
+        // (stamped on every send for every destination).
+        return sequenceGenerator.getNextSequenceId();
     }
 
     @Override


### PR DESCRIPTION
(cherry picked from commit 1907de6aba1299a3e60a2b20d8c38e19f9813ac2)