### PR TITLE
[6.2.x] [#2406] Guard against null region subscriptions in duplicate suppression

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/network/DemandForwardingBridgeSupport.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/network/DemandForwardingBridgeSupport.java
@@ -1583,17 +1583,21 @@ public abstract class DemandForwardingBridgeSupport implements NetworkBridge, Br
         }
 
         List<ConsumerId> candidateConsumers = consumerInfo.getNetworkConsumerIds();
+        // null when the destination's region is not an AbstractRegion (no
+        // subscription view available) - nothing to compare against
         Collection<Subscription> currentSubs = getRegionSubscriptions(consumerInfo.getDestination());
-        for (Subscription sub : currentSubs) {
-            List<ConsumerId> networkConsumers = sub.getConsumerInfo().getNetworkConsumerIds();
-            if (!networkConsumers.isEmpty()) {
-                if (matchFound(candidateConsumers, networkConsumers)) {
-                    if (isInActiveDurableSub(sub)) {
-                        suppress = false;
-                    } else {
-                        suppress = hasLowerPriority(sub, candidate.getLocalInfo());
+        if (currentSubs != null) {
+            for (Subscription sub : currentSubs) {
+                List<ConsumerId> networkConsumers = sub.getConsumerInfo().getNetworkConsumerIds();
+                if (!networkConsumers.isEmpty()) {
+                    if (matchFound(candidateConsumers, networkConsumers)) {
+                        if (isInActiveDurableSub(sub)) {
+                            suppress = false;
+                        } else {
+                            suppress = hasLowerPriority(sub, candidate.getLocalInfo());
+                        }
+                        break;
                     }
-                    break;
                 }
             }
         }


### PR DESCRIPTION
getRegionSubscriptions returns null when the destination's region is not an AbstractRegion; duplicateSuppressionIsRequired iterated the result unconditionally, throwing NPE on the advisory path and tearing down the bridge. Treat a null view as nothing to compare against.

(cherry picked from commit 5b0f3fa822bf1f95540524262117d829d4820507)