### PR TITLE
[#2436] Fix SizeStatisticImpl.addSize on isEnabled like CountStatisticImpl

### DIFF
--- a/activemq-client/src/main/java/org/apache/activemq/management/SizeStatisticImpl.java
+++ b/activemq-client/src/main/java/org/apache/activemq/management/SizeStatisticImpl.java
@@ -52,18 +52,26 @@ public class SizeStatisticImpl extends StatisticImpl {
         return count;
     }
 
-    public synchronized void addSize(long size) {
-        count++;
-        totalSize += size;
-        if (size > maxSize) {
-            maxSize = size;
+    public void addSize(long size) {
+        // Same enabled gate as CountStatisticImpl.increment(): skip the monitor
+        // (and parent propagation) entirely when statistics are disabled —
+        // enabled is a volatile read, so the disabled fast path is contention-free.
+        if (!isEnabled()) {
+            return;
         }
-        if (size < minSize || minSize == 0) {
-            minSize = size;
-        }
-        updateSampleTime();
-        if (parent != null) {
-            parent.addSize(size);
+        synchronized (this) {
+            count++;
+            totalSize += size;
+            if (size > maxSize) {
+                maxSize = size;
+            }
+            if (size < minSize || minSize == 0) {
+                minSize = size;
+            }
+            updateSampleTime();
+            if (parent != null) {
+                parent.addSize(size);
+            }
         }
     }
 


### PR DESCRIPTION
The SizeStastic addSize is synchronized at the method level and missing the isEnabled check.

This means, even when statistics are disabled both the synchronization penalty and calculation performance hit are unintentionally taken.