### PR TITLE
Disable dependabot on 6.2.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -53,25 +53,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    target-branch: "activemq-6.2.x"
-    commit-message:
-      prefix: "[6.2.x] "
-  - package-ecosystem: "maven"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    target-branch: "activemq-6.2.x"
-    commit-message:
-      prefix: "[6.2.x] "
-    open-pull-requests-limit: 50
-    ignore:
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-major"
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "daily"
     target-branch: "activemq-5.19.x"
     commit-message:
       prefix: "[5.19.x] "


### PR DESCRIPTION
6.2.x is now deprecated in favor of 6.3.x