### PR TITLE
[#2446] Add missing jetty dependency to assembly for websockets

### DIFF
--- a/assembly/src/main/descriptors/common-bin.xml
+++ b/assembly/src/main/descriptors/common-bin.xml
@@ -283,11 +283,12 @@
         <include>org.eclipse.jetty.websocket:jetty-websocket-core-client</include>
         <include>org.eclipse.jetty.websocket:jetty-websocket-core-common</include>
         <include>org.eclipse.jetty.websocket:jetty-websocket-core-server</include>
-        <include>org.eclipse.jetty.websocket:jetty-websocket-jetty-client</include>
         <include>org.eclipse.jetty.websocket:jetty-websocket-jetty-api</include>
+        <include>org.eclipse.jetty.websocket:jetty-websocket-jetty-client</include>
+        <include>org.eclipse.jetty.websocket:jetty-websocket-jetty-common</include>
+        <include>org.eclipse.jetty.websocket:jetty-websocket-jetty-server</include>
         <include>org.eclipse.jetty.orbit:javax.security.auth.message</include>
         <include>org.eclipse.jetty.ee11.websocket:jetty-ee11-websocket-jakarta-client</include>
-        <include>org.eclipse.jetty.websocket:jetty-websocket-jetty-common</include>
         <include>org.eclipse.jetty.ee11.websocket:jetty-ee11-websocket-jetty-server</include>
         <include>org.eclipse.jetty.ee11.websocket:jetty-ee11-websocket-servlet</include>
         <include>jakarta.websocket:jakarta.websocket-api</include>


### PR DESCRIPTION
Add missing jar to assembly for Jetty 12 websockets