### PR TITLE
[6.3.x] Fix: Assembly startup logs harmless WARN about schemas (#2501)

### DIFF
--- a/assembly/src/release/conf/log4j2.properties
+++ b/assembly/src/release/conf/log4j2.properties
@@ -49,7 +49,14 @@ logger.jetty.level=WARN
 
 # Jetty startup via Spring
 logger.jetty-spring.name=org.apache.activemq.spring.jetty
-logger.xbean.level=INFO
+logger.jetty-spring.level=INFO
+
+# The web console's JSP support (Tomcat Jasper via Jetty) probes for the XML meta-schemas
+# XMLSchema.dtd, datatypes.dtd and xml.xsd, which the jakarta.servlet-api jar does not
+# bundle. They are only consulted when XML validation of web.xml/TLD files is enabled
+# (off by default), so the startup warnings are harmless noise.
+logger.jasper-digester.name=org.apache.tomcat.util.descriptor.DigesterFactory
+logger.jasper-digester.level=ERROR
 
 # ActiveMQ
 #log4j2.logger.activemq.name=org.apache.activemq


### PR DESCRIPTION
The schemas are included internally to tomcat's jasper support.

These are harmeless for running in Jetty

(cherry picked from commit aa6c07ecab9b7166016aec25bdc3616683a1ef62)