### PR TITLE
fix: MQTTWireFormat rejecting valid 4-byte remaining lengths

### DIFF
--- a/activemq-mqtt/src/main/java/org/apache/activemq/transport/mqtt/MQTTWireFormat.java
+++ b/activemq-mqtt/src/main/java/org/apache/activemq/transport/mqtt/MQTTWireFormat.java
@@ -92,12 +92,12 @@ public class MQTTWireFormat implements WireFormat {
         int length = 0;
         do {
             digit = dataIn.readByte();
-            length += (digit & 0x7F) * multiplier;
-            multiplier <<= 7;
             // MQTT protocol limits Remaining Length to 4 bytes
             if (multiplier == MAX_MULTIPLIER && (digit & 128) != 0) {
                 throw new IOException("Remaining length exceeds 4 bytes");
             }
+            length += (digit & 0x7F) * multiplier;
+            multiplier <<= 7;
         }
         while ((digit & 0x80) != 0);
 

--- a/activemq-mqtt/src/test/java/org/apache/activemq/transport/mqtt/MQTTCodecTest.java
+++ b/activemq-mqtt/src/test/java/org/apache/activemq/transport/mqtt/MQTTCodecTest.java
@@ -378,12 +378,15 @@ public class MQTTCodecTest {
         publish.topicName(new UTF8Buffer(topic));
         publish.payload(new Buffer(new byte[payloadSize]));
 
-        DataByteArrayOutputStream output = new DataByteArrayOutputStream();
-        wireFormat.marshal(publish.encode(), output);
-        Buffer marshalled = output.toBuffer();
+        Buffer marshalled;
+        try (DataByteArrayOutputStream output = new DataByteArrayOutputStream()) {
+            wireFormat.marshal(publish.encode(), output);
+            marshalled = output.toBuffer();
+        }
 
-        DataByteArrayInputStream input = new DataByteArrayInputStream(marshalled);
-        codec.parse(input, marshalled.length());
+        try (DataByteArrayInputStream input = new DataByteArrayInputStream(marshalled)) {
+            codec.parse(input, marshalled.length());
+        }
 
         assertEquals("Expected one frame from a valid 4-byte Remaining Length", 1, frames.size());
         PUBLISH decoded = new PUBLISH().decode(frames.get(0));
@@ -402,11 +405,14 @@ public class MQTTCodecTest {
         publish.topicName(new UTF8Buffer(topic));
         publish.payload(new Buffer(new byte[payloadSize]));
 
-        DataByteArrayOutputStream output = new DataByteArrayOutputStream();
-        wireFormat.marshal(publish.encode(), output);
+        Buffer marshalled;
+        try (DataByteArrayOutputStream output = new DataByteArrayOutputStream()) {
+            wireFormat.marshal(publish.encode(), output);
+            marshalled = output.toBuffer();
+        }
 
-        MQTTFrame frame = (MQTTFrame) wireFormat.unmarshal(new ByteSequence(output.toBuffer().data,
-                output.toBuffer().offset, output.toBuffer().length));
+        MQTTFrame frame = (MQTTFrame) wireFormat.unmarshal(
+                new ByteSequence(marshalled.data, marshalled.offset, marshalled.length));
         PUBLISH decoded = new PUBLISH().decode(frame);
         assertEquals(payloadSize, decoded.payload().length());
     }

--- a/activemq-mqtt/src/test/java/org/apache/activemq/transport/mqtt/MQTTCodecTest.java
+++ b/activemq-mqtt/src/test/java/org/apache/activemq/transport/mqtt/MQTTCodecTest.java
@@ -364,4 +364,51 @@ public class MQTTCodecTest {
         }
     }
 
+    @Test
+    public void testCodecAcceptsFourByteRemainingLength() throws Exception {
+        // 2,097,152 is the smallest value that requires a 4-byte Remaining Length.
+        // Payload size = target RL - variable header overhead (2 topic length + topic + 2 packet id)
+        final String topic = "TOPIC";
+        final int overhead = 2 + topic.length() + 2;  // topic length field + topic + message id (QoS 1)
+        final int payloadSize = 2_097_152 - overhead;
+
+        PUBLISH publish = new PUBLISH();
+        publish.qos(QoS.AT_LEAST_ONCE);
+        publish.messageId((short) 1);
+        publish.topicName(new UTF8Buffer(topic));
+        publish.payload(new Buffer(new byte[payloadSize]));
+
+        DataByteArrayOutputStream output = new DataByteArrayOutputStream();
+        wireFormat.marshal(publish.encode(), output);
+        Buffer marshalled = output.toBuffer();
+
+        DataByteArrayInputStream input = new DataByteArrayInputStream(marshalled);
+        codec.parse(input, marshalled.length());
+
+        assertEquals("Expected one frame from a valid 4-byte Remaining Length", 1, frames.size());
+        PUBLISH decoded = new PUBLISH().decode(frames.get(0));
+        assertEquals(payloadSize, decoded.payload().length());
+    }
+
+    @Test
+    public void testUnmarshalAcceptsFourByteRemainingLength() throws Exception {
+        final String topic = "TOPIC";
+        final int overhead = 2 + topic.length() + 2;
+        final int payloadSize = 2_097_152 - overhead;
+
+        PUBLISH publish = new PUBLISH();
+        publish.qos(QoS.AT_LEAST_ONCE);
+        publish.messageId((short) 1);
+        publish.topicName(new UTF8Buffer(topic));
+        publish.payload(new Buffer(new byte[payloadSize]));
+
+        DataByteArrayOutputStream output = new DataByteArrayOutputStream();
+        wireFormat.marshal(publish.encode(), output);
+
+        MQTTFrame frame = (MQTTFrame) wireFormat.unmarshal(new ByteSequence(output.toBuffer().data,
+                output.toBuffer().offset, output.toBuffer().length));
+        PUBLISH decoded = new PUBLISH().decode(frame);
+        assertEquals(payloadSize, decoded.payload().length());
+    }
+
 }


### PR DESCRIPTION
Increment in the check loop happens before the check, causing an error. Additionally this code is [practically duplicated here](https://github.com/apache/activemq/blob/main/activemq-mqtt/src/main/java/org/apache/activemq/transport/mqtt/MQTTCodec.java#L165-L167C18). That code has it correct, but it looks tricky to abstract into a shared class.

See: https://github.com/apache/activemq/issues/2518