### PR TITLE
Speed up activemq-runtime-config tests by waiting for the reload instead of sleeping

### DIFF
--- a/activemq-runtime-config/src/main/java/org/apache/activemq/plugin/RuntimeConfigurationBroker.java
+++ b/activemq-runtime-config/src/main/java/org/apache/activemq/plugin/RuntimeConfigurationBroker.java
@@ -57,6 +57,7 @@ public class RuntimeConfigurationBroker extends AbstractRuntimeConfigurationBrok
     PropertiesPlaceHolderUtil placeHolderUtil = null;
     private long checkPeriod;
     private long lastModified = -1;
+    private volatile long lastChecked = -1;
     private Resource configToMonitor;
     private DtoBroker currentConfiguration;
     private Schema schema;
@@ -139,15 +140,25 @@ public class RuntimeConfigurationBroker extends AbstractRuntimeConfigurationBrok
 
 
     private void applyModifications(Resource configToMonitor) {
-        DtoBroker changed = loadConfiguration(configToMonitor);
-        if (changed != null && !currentConfiguration.equals(changed)) {
-            LOG.info("change in " + configToMonitor + " at: " + new Date(lastModified));
-            LOG.debug("current:" + filterPasswords(currentConfiguration));
-            LOG.debug("new    :" + filterPasswords(changed));
-            processSelectiveChanges(currentConfiguration, changed);
-            currentConfiguration = changed;
-        } else {
-            info("No material change to configuration in " + configToMonitor + " at: " + new Date(lastModified));
+        long modified = -1;
+        try {
+            modified = configToMonitor.lastModified();
+        } catch (IOException e) {
+            LOG.debug("Failed to determine lastModified time on configuration: " + configToMonitor, e);
+        }
+        try {
+            DtoBroker changed = loadConfiguration(configToMonitor);
+            if (changed != null && !currentConfiguration.equals(changed)) {
+                LOG.info("change in " + configToMonitor + " at: " + new Date(lastModified));
+                LOG.debug("current:" + filterPasswords(currentConfiguration));
+                LOG.debug("new    :" + filterPasswords(changed));
+                processSelectiveChanges(currentConfiguration, changed);
+                currentConfiguration = changed;
+            } else {
+                info("No material change to configuration in " + configToMonitor + " at: " + new Date(lastModified));
+            }
+        } finally {
+            lastChecked = modified;
         }
     }
 
@@ -245,6 +256,16 @@ public class RuntimeConfigurationBroker extends AbstractRuntimeConfigurationBrok
 
     public long getLastModified() {
         return lastModified;
+    }
+
+    /**
+     * Modification time of the configuration file as of the most recent completed
+     * update attempt, whether or not that attempt parsed and applied. Unlike
+     * {@link #getLastModified()} it advances for rejected files too, so a caller
+     * can tell that a given version of the file has been looked at.
+     */
+    public long getLastChecked() {
+        return lastChecked;
     }
 
     public Resource getConfigToMonitor() {

--- a/activemq-runtime-config/src/test/java/org/apache/activemq/AbstractVirtualDestTest.java
+++ b/activemq-runtime-config/src/test/java/org/apache/activemq/AbstractVirtualDestTest.java
@@ -18,7 +18,6 @@ package org.apache.activemq;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 
 import java.util.Collections;
 import java.util.Map;
@@ -92,9 +91,17 @@ public abstract class AbstractVirtualDestTest extends RuntimeConfigTestSupport {
         assertNotNull("The message did not reach the destination even though it should pass through the filter.", message);
         assertEquals("Did not get expected message", body, ((TextMessage) message).getText());
 
-        // negative test
-        message = sendAndReceiveMessage(session, consumer, producer, "Not to filtered cq:" + dest, Collections.singletonMap("odd", "somethingElse"));
-        assertNull("The message reached the destination, but it should have been removed by the filter.", message);
+        // negative test: the consumer queue keeps send order, so when a passing
+        // message sent behind the rejected one is the next to arrive, the filter
+        // dropped the rejected one. That proves the point without waiting out a timeout.
+        TextMessage rejected = session.createTextMessage("Not to filtered cq:" + dest);
+        rejected.setStringProperty("odd", "somethingElse");
+        producer.send(rejected);
+
+        body = "After rejected, to filtered cq:" + dest;
+        message = sendAndReceiveMessage(session, consumer, producer, body, Collections.singletonMap("odd", acceptedHeaderValue));
+        assertNotNull("The message sent after the rejected one did not reach the destination.", message);
+        assertEquals("The message reached the destination, but it should have been removed by the filter.", body, ((TextMessage) message).getText());
 
         connection.close();
     }

--- a/activemq-runtime-config/src/test/java/org/apache/activemq/AuthenticationTest.java
+++ b/activemq-runtime-config/src/test/java/org/apache/activemq/AuthenticationTest.java
@@ -40,7 +40,7 @@ public class AuthenticationTest extends RuntimeConfigTestSupport {
         // anonymous
         assertDenied(null, "USERS.A");
 
-        applyNewConfig(brokerConfig, configurationSeed + "-two-users", SLEEP);
+        applyNewConfig(brokerConfig, configurationSeed + "-two-users", WAIT_FOR_CHANGE);
 
         assertAllowed("test_user_password", "USERS.A");
         assertAllowed("another_test_user_password", "USERS.A");

--- a/activemq-runtime-config/src/test/java/org/apache/activemq/AuthorizationTest.java
+++ b/activemq-runtime-config/src/test/java/org/apache/activemq/AuthorizationTest.java
@@ -38,7 +38,7 @@ public class AuthorizationTest extends AbstractAuthorizationTest {
 
         assertDeniedTemp("guest");
 
-        applyNewConfig(brokerConfig, configurationSeed + "-users-guests", SLEEP);
+        applyNewConfig(brokerConfig, configurationSeed + "-users-guests", WAIT_FOR_CHANGE);
 
         assertAllowed("user", "USERS.A");
         assertAllowed("guest", "GUESTS.A");
@@ -59,7 +59,7 @@ public class AuthorizationTest extends AbstractAuthorizationTest {
         assertDenied("user", "GUESTS.A");
         assertAllowedTemp("guest");
 
-        applyNewConfig(brokerConfig, configurationSeed + "-users", SLEEP);
+        applyNewConfig(brokerConfig, configurationSeed + "-users", WAIT_FOR_CHANGE);
 
         assertAllowed("user", "USERS.A");
         assertDenied("user", "GUESTS.A");
@@ -76,7 +76,7 @@ public class AuthorizationTest extends AbstractAuthorizationTest {
         assertAllowedWrite("user", "USERS.A");
         assertDeniedWrite("guest", "USERS.A");
 
-        applyNewConfig(brokerConfig, configurationSeed + "-users-add-write-guest", SLEEP);
+        applyNewConfig(brokerConfig, configurationSeed + "-users-add-write-guest", WAIT_FOR_CHANGE);
 
         assertAllowedWrite("user", "USERS.A");
         assertAllowedWrite("guest", "USERS.A");
@@ -90,10 +90,10 @@ public class AuthorizationTest extends AbstractAuthorizationTest {
         assertTrue("broker alive", brokerService.isStarted());
 
         assertAllowed("user", "USERS.A");
-        applyNewConfig(brokerConfig, configurationSeed + "-users-dud-groupClass", SLEEP);
+        applyNewConfig(brokerConfig, configurationSeed + "-users-dud-groupClass", WAIT_FOR_CHANGE);
         assertDenied("user", "USERS.A");
 
-        applyNewConfig(brokerConfig, configurationSeed + "-users", SLEEP);
+        applyNewConfig(brokerConfig, configurationSeed + "-users", WAIT_FOR_CHANGE);
         assertAllowed("user", "USERS.A");
     }
 
@@ -124,7 +124,6 @@ public class AuthorizationTest extends AbstractAuthorizationTest {
 
         assertDenied("user", "USERS.>");
         assertDenied("guest", "GUESTS.>");
-
 
         assertAllowedTemp("guest");
     }

--- a/activemq-runtime-config/src/test/java/org/apache/activemq/DestinationsTest.java
+++ b/activemq-runtime-config/src/test/java/org/apache/activemq/DestinationsTest.java
@@ -42,15 +42,14 @@ public class DestinationsTest extends RuntimeConfigTestSupport {
         assertTrue("contains original", containsDestination(new ActiveMQQueue("ORIGINAL")));
 
         LOG.info("Adding destinations");
-        applyNewConfig(brokerConfig, configurationSeed + "-add", SLEEP);
+        applyNewConfig(brokerConfig, configurationSeed + "-add", WAIT_FOR_CHANGE);
         printDestinations();
         assertTrue("contains original", containsDestination(new ActiveMQQueue("ORIGINAL")));
         assertTrue("contains before", containsDestination(new ActiveMQTopic("BEFORE")));
         assertTrue("contains after", containsDestination(new ActiveMQQueue("AFTER")));
 
-
         LOG.info("Removing destinations");
-        applyNewConfig(brokerConfig, configurationSeed + "-remove", SLEEP);
+        applyNewConfig(brokerConfig, configurationSeed + "-remove", WAIT_FOR_CHANGE);
         printDestinations();
         assertTrue("contains original", containsDestination(new ActiveMQQueue("ORIGINAL")));
         assertTrue("contains before", containsDestination(new ActiveMQTopic("BEFORE")));

--- a/activemq-runtime-config/src/test/java/org/apache/activemq/MBeanTest.java
+++ b/activemq-runtime-config/src/test/java/org/apache/activemq/MBeanTest.java
@@ -39,7 +39,7 @@ public class MBeanTest extends RuntimeConfigTestSupport {
         assertTrue("broker alive", brokerService.isStarted());
         assertEquals("no network connectors", 0, brokerService.getNetworkConnectors().size());
 
-        applyNewConfig(brokerConfig, "networkConnectorTest-one-nc", SLEEP);
+        applyNewConfig(brokerConfig, "networkConnectorTest-one-nc", WAIT_FOR_CHANGE);
 
         assertEquals("no network connectors", 0, brokerService.getNetworkConnectors().size());
 
@@ -79,7 +79,7 @@ public class MBeanTest extends RuntimeConfigTestSupport {
         assertTrue("broker alive", brokerService.isStarted());
         assertEquals("no network connectors", 0, brokerService.getNetworkConnectors().size());
 
-        applyNewConfig(brokerConfig, "parseErrorConfig", SLEEP);
+        applyNewConfig(brokerConfig, "parseErrorConfig", WAIT_FOR_CHANGE);
 
         // apply via jmx
         ObjectName objectName =
@@ -106,7 +106,7 @@ public class MBeanTest extends RuntimeConfigTestSupport {
         assertEquals("modified is same", props.get(propOfInterest), propsAfter.get(propOfInterest));
 
         // apply good change now
-        applyNewConfig(brokerConfig, "networkConnectorTest-one-nc", SLEEP);
+        applyNewConfig(brokerConfig, "networkConnectorTest-one-nc", WAIT_FOR_CHANGE);
 
         result = runtimeConfigurationView.updateNow();
 

--- a/activemq-runtime-config/src/test/java/org/apache/activemq/NetworkConnectorTest.java
+++ b/activemq-runtime-config/src/test/java/org/apache/activemq/NetworkConnectorTest.java
@@ -41,7 +41,7 @@ public class NetworkConnectorTest extends RuntimeConfigTestSupport {
         assertTrue("broker alive", brokerService.isStarted());
         assertEquals("no network connectors", 0, brokerService.getNetworkConnectors().size());
 
-        applyNewConfig(brokerConfig, configurationSeed + "-one-nc", SLEEP);
+        applyNewConfig(brokerConfig, configurationSeed + "-one-nc", WAIT_FOR_CHANGE);
 
         assertTrue("new network connectors", Wait.waitFor(new Wait.Condition() {
             @Override
@@ -82,7 +82,7 @@ public class NetworkConnectorTest extends RuntimeConfigTestSupport {
         NetworkConnector networkConnector = brokerService.getNetworkConnectors().get(0);
         assertEquals("network ttl is default", 1, networkConnector.getNetworkTTL());
 
-        applyNewConfig(brokerConfig, configurationSeed + "-mod-one-nc", SLEEP);
+        applyNewConfig(brokerConfig, configurationSeed + "-mod-one-nc", WAIT_FOR_CHANGE);
 
         assertEquals("still one network connectors", 1, brokerService.getNetworkConnectors().size());
 
@@ -92,7 +92,7 @@ public class NetworkConnectorTest extends RuntimeConfigTestSupport {
         assertNotNull("got ssl", modNetworkConnector.getSslContext());
 
         // apply again - ensure no change
-        applyNewConfig(brokerConfig, configurationSeed + "-mod-one-nc", SLEEP);
+        applyNewConfig(brokerConfig, configurationSeed + "-mod-one-nc", WAIT_FOR_CHANGE);
         assertEquals("no new network connectors", 1, brokerService.getNetworkConnectors().size());
         assertSame("same instance", modNetworkConnector, brokerService.getNetworkConnectors().get(0));
         assertFalse(modNetworkConnector.getBrokerName().isEmpty());
@@ -118,7 +118,7 @@ public class NetworkConnectorTest extends RuntimeConfigTestSupport {
             }
         }
 
-        applyNewConfig(brokerConfig, configurationSeed + "-one-nc", SLEEP);
+        applyNewConfig(brokerConfig, configurationSeed + "-one-nc", WAIT_FOR_CHANGE);
 
         assertTrue("expected mod on time, but found " + brokerService.getNetworkConnectors().size() + " connectors", Wait.waitFor(new Wait.Condition() {
             @Override
@@ -151,7 +151,7 @@ public class NetworkConnectorTest extends RuntimeConfigTestSupport {
         assertEquals("two network connectors", 2, brokerService.getNetworkConnectors().size());
 
         // apply a config that changes the order only
-        applyNewConfig(brokerConfig, configurationSeed + "-two-b-nc", SLEEP);
+        applyNewConfig(brokerConfig, configurationSeed + "-two-b-nc", WAIT_FOR_CHANGE);
 
         assertTrue("expected mod on time", Wait.waitFor(new Wait.Condition() {
             @Override

--- a/activemq-runtime-config/src/test/java/org/apache/activemq/PolicyEntryTest.java
+++ b/activemq-runtime-config/src/test/java/org/apache/activemq/PolicyEntryTest.java
@@ -38,7 +38,7 @@ public class PolicyEntryTest extends RuntimeConfigTestSupport {
         assertTrue("broker alive", brokerService.isStarted());
 
         verifyQueueLimit("Before", 1024);
-        applyNewConfig(brokerConfig, configurationSeed + "-policy-ml-mod", SLEEP);
+        applyNewConfig(brokerConfig, configurationSeed + "-policy-ml-mod", WAIT_FOR_CHANGE);
         verifyQueueLimit("After", 4194304);
 
         // change to existing dest
@@ -53,7 +53,7 @@ public class PolicyEntryTest extends RuntimeConfigTestSupport {
         assertTrue("broker alive", brokerService.isStarted());
 
         verifyBooleanField("AMQ.8397", "sendDuplicateFromStoreToDLQ", false);
-        applyNewConfig(brokerConfig, configurationSeed + "-policy-sendDuplicateFromStoreToDLQ-mod", SLEEP);
+        applyNewConfig(brokerConfig, configurationSeed + "-policy-sendDuplicateFromStoreToDLQ-mod", WAIT_FOR_CHANGE);
         verifyBooleanField("AMQ.8397", "sendDuplicateFromStoreToDLQ", true);
     }
 
@@ -65,7 +65,7 @@ public class PolicyEntryTest extends RuntimeConfigTestSupport {
         assertTrue("broker alive", brokerService.isStarted());
 
         verifyBooleanField("AMQ.8463", "advancedMessageStatisticsEnabled", false);
-        applyNewConfig(brokerConfig, configurationSeed + "-policy-advancedMessageStatistics-mod", SLEEP);
+        applyNewConfig(brokerConfig, configurationSeed + "-policy-advancedMessageStatistics-mod", WAIT_FOR_CHANGE);
         verifyBooleanField("AMQ.8463", "advancedMessageStatisticsEnabled", true);
     }
 
@@ -77,7 +77,7 @@ public class PolicyEntryTest extends RuntimeConfigTestSupport {
         assertTrue("broker alive", brokerService.isStarted());
 
         verifyBooleanField("AMQ.9437", "advancedNetworkStatisticsEnabled", false);
-        applyNewConfig(brokerConfig, configurationSeed + "-policy-advancedNetworkStatistics-mod", SLEEP);
+        applyNewConfig(brokerConfig, configurationSeed + "-policy-advancedNetworkStatistics-mod", WAIT_FOR_CHANGE);
         verifyBooleanField("AMQ.9437", "advancedNetworkStatisticsEnabled", true);
     }
 
@@ -91,7 +91,7 @@ public class PolicyEntryTest extends RuntimeConfigTestSupport {
         verifyQueueLimit("Before", 1024);
         verifyTopicLimit("Before", brokerService.getSystemUsage().getMemoryUsage().getLimit());
 
-        applyNewConfig(brokerConfig, configurationSeed + "-policy-ml-add", SLEEP);
+        applyNewConfig(brokerConfig, configurationSeed + "-policy-ml-add", WAIT_FOR_CHANGE);
 
         verifyTopicLimit("After", 2048l);
         verifyQueueLimit("After", 2048);
@@ -109,7 +109,7 @@ public class PolicyEntryTest extends RuntimeConfigTestSupport {
 
         verifyQueueLimit("queue.test", 1024);
         verifyQueueLimit("queue.child.test", 2048);
-        applyNewConfig(brokerConfig, configurationSeed + "-policy-ml-parent-mod", SLEEP);
+        applyNewConfig(brokerConfig, configurationSeed + "-policy-ml-parent-mod", WAIT_FOR_CHANGE);
         verifyQueueLimit("queue.test2", 4194304);
 
         // change to existing dest
@@ -127,7 +127,7 @@ public class PolicyEntryTest extends RuntimeConfigTestSupport {
 
         verifyQueueLimit("queue.test", 1024);
         verifyQueueLimit("queue.child.test", 2048);
-        applyNewConfig(brokerConfig, configurationSeed + "-policy-ml-child-mod", SLEEP);
+        applyNewConfig(brokerConfig, configurationSeed + "-policy-ml-child-mod", WAIT_FOR_CHANGE);
         //verify no change
         verifyQueueLimit("queue.test", 1024);
 

--- a/activemq-runtime-config/src/test/java/org/apache/activemq/RuntimeConfigTestSupport.java
+++ b/activemq-runtime-config/src/test/java/org/apache/activemq/RuntimeConfigTestSupport.java
@@ -19,11 +19,18 @@ package org.apache.activemq;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertTrue;
+
 import org.apache.activemq.broker.BrokerFactory;
 import org.apache.activemq.broker.BrokerService;
+import org.apache.activemq.plugin.RuntimeConfigurationBroker;
 import org.apache.activemq.spring.Utils;
+import org.apache.activemq.util.Wait;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.rules.TestWatcher;
@@ -36,6 +43,9 @@ public class RuntimeConfigTestSupport {
     public static final Logger LOG = LoggerFactory.getLogger(RuntimeConfigTestSupport.class);
 
     public static final int SLEEP = 4; // seconds
+    /** longest applyNewConfig waits for a running broker to process a changed file */
+    public static final long MAX_CHANGE_WAIT_SECONDS = 30;
+    public static final boolean WAIT_FOR_CHANGE = true;
     public static final String EMPTY_UPDATABLE_CONFIG = "emptyUpdatableConfig1000" ;
     protected BrokerService brokerService;
 
@@ -51,9 +61,6 @@ public class RuntimeConfigTestSupport {
         brokerService = createBroker(configFileName);
         brokerService.start();
         brokerService.waitUntilStarted();
-
-        // File system lastMod time granularity can be up to 2 seconds
-        TimeUnit.SECONDS.sleep(SLEEP);
     }
 
     public BrokerService createBroker(String configFileName) throws Exception {
@@ -62,12 +69,19 @@ public class RuntimeConfigTestSupport {
     }
 
     protected void applyNewConfig(String configName, String newConfigName) throws Exception {
-        applyNewConfig(configName, newConfigName, 0l);
+        applyNewConfig(configName, newConfigName, false);
     }
 
-    protected void applyNewConfig(String configName, String newConfigName, long sleep) throws Exception {
+    /**
+     * Copies {@code newConfigName.xml} over {@code configName.xml}. With
+     * {@code waitForChange} the call returns once the running broker's
+     * {@link RuntimeConfigurationBroker} has processed the new file, or at once
+     * when nothing is polling it (manual update mode, or no broker started).
+     */
+    protected void applyNewConfig(String configName, String newConfigName, boolean waitForChange) throws Exception {
         Resource resource = Utils.resourceFromString("org/apache/activemq");
         File file = new File(resource.getFile(), configName + ".xml");
+        long previous = file.lastModified();
         FileOutputStream current = new FileOutputStream(file);
         FileInputStream modifications = new FileInputStream(new File(resource.getFile(), newConfigName + ".xml"));
         modifications.getChannel().transferTo(0, Long.MAX_VALUE, current.getChannel());
@@ -75,11 +89,62 @@ public class RuntimeConfigTestSupport {
         current.getChannel().force(true);
         current.close();
         modifications.close();
-        LOG.info("Updated: " + file + " (" + file.lastModified() + ") " + new Date(file.lastModified()));
+        long modified = bumpLastModified(file, previous);
+        LOG.info("Updated: " + file + " (" + modified + ") " + new Date(modified));
 
-        if (sleep > 0) {
-            // wait for mods to kick in
-            TimeUnit.SECONDS.sleep(sleep);
+        if (waitForChange) {
+            waitForChange(file, modified);
+        }
+    }
+
+    /**
+     * The monitor only reloads when the file's time moves forward, and JMX reports
+     * that time to the second, so move it at least a second past what the broker
+     * last saw. Some file systems round to two seconds; keep going until the value
+     * read back is later than the previous one.
+     */
+    private static long bumpLastModified(File file, long previous) {
+        long modified = Math.max(System.currentTimeMillis(), previous + 1001);
+        for (int attempt = 0; attempt < 10; attempt++) {
+            assertTrue("could not set modification time on " + file, file.setLastModified(modified));
+            long readBack = file.lastModified();
+            if (readBack > previous) {
+                return readBack;
+            }
+            modified += 1000;
+        }
+        throw new AssertionError("modification time on " + file + " will not advance past " + previous);
+    }
+
+    private void waitForChange(File file, long modified) throws Exception {
+        RuntimeConfigurationBroker plugin = runtimeConfigurationBroker();
+        if (plugin == null || plugin.getCheckPeriod() <= 0) {
+            return;
+        }
+        boolean processed = Wait.waitFor(() -> plugin.getLastChecked() >= modified, TimeUnit.SECONDS.toMillis(MAX_CHANGE_WAIT_SECONDS), 10);
+        if (!processed) {
+            // the monitor runs on the broker scheduler thread; show what it was doing
+            Thread.getAllStackTraces().forEach((thread, stack) -> {
+                if (thread.getName().contains("Scheduler")) {
+                    LOG.error("{} state {}\n\t{}", thread.getName(), thread.getState(),
+                            Arrays.stream(stack).map(Object::toString).collect(Collectors.joining("\n\t")));
+                }
+            });
+        }
+        assertTrue("configuration change not processed within " + MAX_CHANGE_WAIT_SECONDS + "s; expected " + modified
+                + ", file " + file.lastModified() + ", broker lastModified " + plugin.getLastModified()
+                + ", lastChecked " + plugin.getLastChecked() + ", checkPeriod " + plugin.getCheckPeriod(), processed);
+    }
+
+    private RuntimeConfigurationBroker runtimeConfigurationBroker() {
+        if (brokerService == null || !brokerService.isStarted()) {
+            return null;
+        }
+        try {
+            return (RuntimeConfigurationBroker) brokerService.getBroker().getAdaptor(RuntimeConfigurationBroker.class);
+        } catch (Exception e) {
+            LOG.debug("No runtime configuration plugin on the broker", e);
+            return null;
         }
     }
 

--- a/activemq-runtime-config/src/test/java/org/apache/activemq/SpringBeanTest.java
+++ b/activemq-runtime-config/src/test/java/org/apache/activemq/SpringBeanTest.java
@@ -29,7 +29,6 @@ import org.apache.activemq.util.Wait;
 import org.junit.Ignore;
 import org.junit.Test;
 
-
 import static org.junit.Assert.*;
 
 public class SpringBeanTest extends RuntimeConfigTestSupport {
@@ -70,7 +69,6 @@ public class SpringBeanTest extends RuntimeConfigTestSupport {
         assertEquals("modified is same", props.get(propOfInterest), propsAfter.get(propOfInterest));
     }
 
-
     @Test
     public void testAddPropertyRef() throws Exception {
 
@@ -80,7 +78,7 @@ public class SpringBeanTest extends RuntimeConfigTestSupport {
         startBroker(brokerConfig);
         assertTrue("broker alive", brokerService.isStarted());
 
-        applyNewConfig(brokerConfig, "emptyUpdatableConfig1000-spring-property-nc", SLEEP);
+        applyNewConfig(brokerConfig, "emptyUpdatableConfig1000-spring-property-nc", WAIT_FOR_CHANGE);
 
         assertTrue("new network connectors", Wait.waitFor(new Wait.Condition() {
             @Override
@@ -104,7 +102,7 @@ public class SpringBeanTest extends RuntimeConfigTestSupport {
         startBroker(brokerConfig);
         assertTrue("broker alive", brokerService.isStarted());
 
-        applyNewConfig(brokerConfig, "emptyUpdatableConfig1000-spring-property-file-nc", SLEEP);
+        applyNewConfig(brokerConfig, "emptyUpdatableConfig1000-spring-property-file-nc", WAIT_FOR_CHANGE);
 
         assertTrue("new network connectors", Wait.waitFor(new Wait.Condition() {
             @Override
@@ -144,7 +142,6 @@ public class SpringBeanTest extends RuntimeConfigTestSupport {
 
         assertNotEquals("unknown", props.get(propOfInterest));
 
-
     }
 
     @Test
@@ -166,7 +163,7 @@ public class SpringBeanTest extends RuntimeConfigTestSupport {
             assertEquals("password resolved", System.getProperty("network.password"), nc.getPassword());
         }
 
-        applyNewConfig(brokerConfig, "emptyUpdatableConfig1000-spring-property-one-nc", SLEEP);
+        applyNewConfig(brokerConfig, "emptyUpdatableConfig1000-spring-property-one-nc", WAIT_FOR_CHANGE);
 
         assertTrue("one network connector remains", Wait.waitFor(new Wait.Condition() {
             @Override
@@ -216,7 +213,7 @@ public class SpringBeanTest extends RuntimeConfigTestSupport {
 
         assertEquals("our custom prop is applied", "isKing", brokerService.getBrokerName());
 
-        applyNewConfig(brokerConfig, "spring-property-file-list-and-beanFactory-new-nc", SLEEP);
+        applyNewConfig(brokerConfig, "spring-property-file-list-and-beanFactory-new-nc", WAIT_FOR_CHANGE);
 
         assertTrue("new network connectors", Wait.waitFor(new Wait.Condition() {
             @Override

--- a/activemq-runtime-config/src/test/java/org/apache/activemq/VirtualDestTest.java
+++ b/activemq-runtime-config/src/test/java/org/apache/activemq/VirtualDestTest.java
@@ -20,7 +20,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
-import java.util.concurrent.TimeUnit;
 
 import org.apache.activemq.broker.region.DestinationInterceptor;
 import org.apache.activemq.broker.region.virtual.VirtualDestinationInterceptor;
@@ -49,7 +48,7 @@ public class VirtualDestTest extends AbstractVirtualDestTest {
 
         exerciseVirtualTopic("VirtualTopic.Default");
 
-        applyNewConfig(brokerConfig, configurationSeed + "-one-vd", SLEEP);
+        applyNewConfig(brokerConfig, configurationSeed + "-one-vd", WAIT_FOR_CHANGE);
 
         assertEquals("one interceptor", 1, interceptors.length);
         assertTrue("it is virtual topic interceptor", interceptors[0] instanceof VirtualDestinationInterceptor);
@@ -73,7 +72,7 @@ public class VirtualDestTest extends AbstractVirtualDestTest {
         startBroker(brokerConfig);
         assertTrue("broker alive", brokerService.isStarted());
 
-        applyNewConfig(brokerConfig, configurationSeed + "-add-composite-vd", SLEEP);
+        applyNewConfig(brokerConfig, configurationSeed + "-add-composite-vd", WAIT_FOR_CHANGE);
 
         exerciseCompositeQueue("VirtualDestination.CompositeQueue", "VirtualDestination.QueueConsumer");
     }
@@ -86,7 +85,7 @@ public class VirtualDestTest extends AbstractVirtualDestTest {
         assertTrue("broker alive", brokerService.isStarted());
         exerciseCompositeQueue("VirtualDestination.CompositeQueue", "VirtualDestination.QueueConsumer");
 
-        applyNewConfig(brokerConfig, configurationSeed + "-mod-composite-vd", SLEEP);
+        applyNewConfig(brokerConfig, configurationSeed + "-mod-composite-vd", WAIT_FOR_CHANGE);
         exerciseCompositeQueue("VirtualDestination.CompositeQueue", "VirtualDestination.QueueConsumer");
 
         exerciseCompositeQueue("VirtualDestination.CompositeQueue", "VirtualDestination.CompositeQueue");
@@ -101,14 +100,12 @@ public class VirtualDestTest extends AbstractVirtualDestTest {
         brokerService.start();
         brokerService.waitUntilStarted();
 
-        TimeUnit.SECONDS.sleep(SLEEP);
-
         assertTrue("broker alive", brokerService.isStarted());
 
         DestinationInterceptor[] interceptors  = brokerService.getDestinationInterceptors();
         assertEquals("one interceptor", 0, interceptors.length);
 
-        applyNewConfig(brokerConfig, configurationSeed + "-one-vd", SLEEP);
+        applyNewConfig(brokerConfig, configurationSeed + "-one-vd", WAIT_FOR_CHANGE);
 
         // update will happen on addDestination
         exerciseVirtualTopic("A.Default");
@@ -133,14 +130,12 @@ public class VirtualDestTest extends AbstractVirtualDestTest {
         brokerService.start();
         brokerService.waitUntilStarted();
 
-        TimeUnit.SECONDS.sleep(SLEEP);
-
         assertTrue("broker alive", brokerService.isStarted());
 
         DestinationInterceptor[] interceptors  = brokerService.getDestinationInterceptors();
         assertEquals("expected interceptor", 2, interceptors.length);
 
-        applyNewConfig(brokerConfig, configurationSeed + "-one-vd", SLEEP);
+        applyNewConfig(brokerConfig, configurationSeed + "-one-vd", WAIT_FOR_CHANGE);
 
         // update will happen on addDestination
         exerciseVirtualTopic("A.Default");
@@ -173,7 +168,7 @@ public class VirtualDestTest extends AbstractVirtualDestTest {
 
         exerciseVirtualTopic("A.Default");
 
-        applyNewConfig(brokerConfig, RuntimeConfigTestSupport.EMPTY_UPDATABLE_CONFIG, SLEEP);
+        applyNewConfig(brokerConfig, RuntimeConfigTestSupport.EMPTY_UPDATABLE_CONFIG, WAIT_FOR_CHANGE);
 
         // update will happen on addDestination
         forceAddDestination("AnyDest");
@@ -186,7 +181,7 @@ public class VirtualDestTest extends AbstractVirtualDestTest {
         }));
 
         // reverse the remove, add again
-        applyNewConfig(brokerConfig, configurationSeed + "-one-vd", SLEEP);
+        applyNewConfig(brokerConfig, configurationSeed + "-one-vd", WAIT_FOR_CHANGE);
 
         // update will happen on addDestination
         exerciseVirtualTopic("A.NewOne");
@@ -206,12 +201,11 @@ public class VirtualDestTest extends AbstractVirtualDestTest {
         assertEquals("one interceptor", 1, brokerService.getDestinationInterceptors().length);
         exerciseVirtualTopic("A.Default");
 
-        applyNewConfig(brokerConfig, configurationSeed + "-mod-one-vd", SLEEP);
+        applyNewConfig(brokerConfig, configurationSeed + "-mod-one-vd", WAIT_FOR_CHANGE);
         exerciseVirtualTopic("B.Default");
 
         assertEquals("still one interceptor", 1, brokerService.getDestinationInterceptors().length);
     }
-
 
     @Test
     public void testModWithMirroredQueue() throws Exception {
@@ -222,12 +216,10 @@ public class VirtualDestTest extends AbstractVirtualDestTest {
         brokerService.start();
         brokerService.waitUntilStarted();
 
-        TimeUnit.SECONDS.sleep(SLEEP);
-
         assertEquals("one interceptor", 1, brokerService.getDestinationInterceptors().length);
         exerciseVirtualTopic("A.Default");
 
-        applyNewConfig(brokerConfig, configurationSeed + "-mod-one-vd", SLEEP);
+        applyNewConfig(brokerConfig, configurationSeed + "-mod-one-vd", WAIT_FOR_CHANGE);
         exerciseVirtualTopic("B.Default");
 
         assertEquals("still one interceptor", 1, brokerService.getDestinationInterceptors().length);
@@ -240,7 +232,7 @@ public class VirtualDestTest extends AbstractVirtualDestTest {
         startBroker(brokerConfig);
         assertTrue("broker alive", brokerService.isStarted());
 
-        applyNewConfig(brokerConfig, configurationSeed + "-add-filtered-composite-vd", SLEEP);
+        applyNewConfig(brokerConfig, configurationSeed + "-add-filtered-composite-vd", WAIT_FOR_CHANGE);
 
         exerciseFilteredCompositeQueue("VirtualDestination.FilteredCompositeQueue", "VirtualDestination.QueueConsumer", "yes");
     }
@@ -253,12 +245,9 @@ public class VirtualDestTest extends AbstractVirtualDestTest {
         assertTrue("broker alive", brokerService.isStarted());
         exerciseFilteredCompositeQueue("VirtualDestination.FilteredCompositeQueue", "VirtualDestination.QueueConsumer", "yes");
 
-        applyNewConfig(brokerConfig, configurationSeed + "-mod-filtered-composite-vd", SLEEP);
+        applyNewConfig(brokerConfig, configurationSeed + "-mod-filtered-composite-vd", WAIT_FOR_CHANGE);
         exerciseFilteredCompositeQueue("VirtualDestination.FilteredCompositeQueue", "VirtualDestination.QueueConsumer", "no");
         exerciseFilteredCompositeQueue("VirtualDestination.FilteredCompositeQueue", "VirtualDestination.QueueConsumer", "no");
     }
-
-
-
 
 }

--- a/activemq-runtime-config/src/test/java/org/apache/activemq/java/JavaAuthenticationTest.java
+++ b/activemq-runtime-config/src/test/java/org/apache/activemq/java/JavaAuthenticationTest.java
@@ -21,7 +21,6 @@ import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 import jakarta.jms.JMSException;
 import jakarta.jms.Session;
@@ -44,7 +43,6 @@ import org.junit.Test;
 
 public class JavaAuthenticationTest extends RuntimeConfigTestSupport {
 
-    public static final int SLEEP = 2; // seconds
     private JavaRuntimeConfigurationBroker javaConfigBroker;
     private SimpleAuthenticationPlugin authenticationPlugin;
 
@@ -109,8 +107,6 @@ public class JavaAuthenticationTest extends RuntimeConfigTestSupport {
         authenticationPlugin.setUsers(users);
         authenticationPlugin.setAnonymousAccessAllowed(true);
         javaConfigBroker.updateSimpleAuthenticationPlugin(authenticationPlugin);
-
-        TimeUnit.SECONDS.sleep(SLEEP);
 
         assertAllowed("test_user_password", "USERS.A");
         assertAllowed("another_test_user_password", "USERS.A");

--- a/activemq-runtime-config/src/test/java/org/apache/activemq/java/JavaAuthorizationTest.java
+++ b/activemq-runtime-config/src/test/java/org/apache/activemq/java/JavaAuthorizationTest.java
@@ -20,7 +20,6 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.activemq.AbstractAuthorizationTest;
 import org.apache.activemq.broker.BrokerPlugin;
@@ -37,7 +36,6 @@ import org.junit.Test;
 
 public class JavaAuthorizationTest extends AbstractAuthorizationTest {
 
-    public static final int SLEEP = 2; // seconds
     String configurationSeed = "authorizationTest";
 
     private JavaRuntimeConfigurationBroker javaConfigBroker;
@@ -47,7 +45,6 @@ public class JavaAuthorizationTest extends AbstractAuthorizationTest {
 
         JaasAuthenticationPlugin authenticationPlugin = new JaasAuthenticationPlugin();
         authenticationPlugin.setConfiguration("activemq-domain");
-
 
         AuthorizationPlugin authorizationPlugin = new AuthorizationPlugin();
         DefaultAuthorizationMap authorizationMap = new DefaultAuthorizationMap();
@@ -76,11 +73,10 @@ public class JavaAuthorizationTest extends AbstractAuthorizationTest {
 
         assertDeniedTemp("guest");
 
-       // applyNewConfig(brokerConfig, configurationSeed + "-users-guests", SLEEP);
+       // applyNewConfig(brokerConfig, configurationSeed + "-users-guests", WAIT_FOR_CHANGE);
 
         authorizationMap = buildUsersGuestsMap();
         javaConfigBroker.updateAuthorizationMap(authorizationMap);
-        TimeUnit.SECONDS.sleep(SLEEP);
 
         assertAllowed("user", "USERS.A");
         assertAllowed("guest", "GUESTS.A");
@@ -97,7 +93,6 @@ public class JavaAuthorizationTest extends AbstractAuthorizationTest {
         assertTrue("broker alive", brokerService.isStarted());
 
         javaConfigBroker.updateAuthorizationMap(authorizationMap);
-        TimeUnit.SECONDS.sleep(SLEEP);
         assertAllowed("user", "USERS.A");
         assertAllowed("guest", "GUESTS.A");
         assertDenied("user", "GUESTS.A");
@@ -105,7 +100,6 @@ public class JavaAuthorizationTest extends AbstractAuthorizationTest {
 
         authorizationMap = buildUsersMap();
         javaConfigBroker.updateAuthorizationMap(authorizationMap);
-        TimeUnit.SECONDS.sleep(SLEEP);
 
         assertAllowed("user", "USERS.A");
         assertDenied("user", "GUESTS.A");
@@ -120,7 +114,6 @@ public class JavaAuthorizationTest extends AbstractAuthorizationTest {
         assertTrue("broker alive", brokerService.isStarted());
 
         javaConfigBroker.updateAuthorizationMap(authorizationMap);
-        TimeUnit.SECONDS.sleep(SLEEP);
 
         final String ALL_USERS = "ALL.USERS.>";
         final String ALL_GUESTS = "ALL.GUESTS.>";
@@ -142,7 +135,6 @@ public class JavaAuthorizationTest extends AbstractAuthorizationTest {
 
         assertDenied("user", "USERS.>");
         assertDenied("guest", "GUESTS.>");
-
 
         assertAllowedTemp("guest");
     }
@@ -181,7 +173,6 @@ public class JavaAuthorizationTest extends AbstractAuthorizationTest {
         List<DestinationMapEntry> entries = new ArrayList<>();
         entries.add(buildQueueAuthorizationEntry(">", "admins", "admins", "admins"));
         entries.add(buildQueueAuthorizationEntry("USERS.>", "users", "users", "users"));
-
 
         entries.add(buildTopicAuthorizationEntry(">", "admins", "admins", "admins"));
         entries.add(buildTopicAuthorizationEntry("USERS.>", "users", "users", "users"));

--- a/activemq-runtime-config/src/test/java/org/apache/activemq/java/JavaNetworkConnectorTest.java
+++ b/activemq-runtime-config/src/test/java/org/apache/activemq/java/JavaNetworkConnectorTest.java
@@ -26,7 +26,6 @@ import static org.junit.Assert.fail;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.HashSet;
-import java.util.concurrent.TimeUnit;
 
 import javax.management.InstanceNotFoundException;
 
@@ -45,7 +44,6 @@ import org.junit.Test;
 
 public class JavaNetworkConnectorTest extends RuntimeConfigTestSupport {
 
-    public static final int SLEEP = 2; // seconds
     private JavaRuntimeConfigurationBroker javaConfigBroker;
 
     public void startBroker(BrokerService brokerService) throws Exception {
@@ -79,7 +77,6 @@ public class JavaNetworkConnectorTest extends RuntimeConfigTestSupport {
 
         NetworkConnector networkConnector = brokerService.getNetworkConnectors().get(0);
         javaConfigBroker.addNetworkConnector(nc);
-        TimeUnit.SECONDS.sleep(SLEEP);
         assertEquals("no new network connectors", 1, brokerService.getNetworkConnectors().size());
         assertSame("same instance", networkConnector, brokerService.getNetworkConnectors().get(0));
 
@@ -96,7 +93,6 @@ public class JavaNetworkConnectorTest extends RuntimeConfigTestSupport {
 
     }
 
-
     @Test
     public void testMod() throws Exception {
         final BrokerService brokerService = new BrokerService();
@@ -106,7 +102,6 @@ public class JavaNetworkConnectorTest extends RuntimeConfigTestSupport {
 
         DiscoveryNetworkConnector nc = createNetworkConnector();
         javaConfigBroker.addNetworkConnector(nc);
-        TimeUnit.SECONDS.sleep(SLEEP);
 
         assertEquals("one network connectors", 1, brokerService.getNetworkConnectors().size());
 
@@ -118,7 +113,6 @@ public class JavaNetworkConnectorTest extends RuntimeConfigTestSupport {
 
         nc.setNetworkTTL(2);
         javaConfigBroker.updateNetworkConnector(nc);
-        TimeUnit.SECONDS.sleep(SLEEP);
         assertEquals("still one network connectors", 1, brokerService.getNetworkConnectors().size());
 
         NetworkConnector modNetworkConnector = brokerService.getNetworkConnectors().get(0);
@@ -154,7 +148,6 @@ public class JavaNetworkConnectorTest extends RuntimeConfigTestSupport {
         javaConfigBroker.addNetworkConnector(nc1);
         javaConfigBroker.addNetworkConnector(nc2);
 
-        TimeUnit.SECONDS.sleep(SLEEP);
         assertEquals("correct network connectors", 2, brokerService.getNetworkConnectors().size());
 
         javaConfigBroker.removeNetworkConnector(nc2);

--- a/activemq-runtime-config/src/test/java/org/apache/activemq/java/JavaPolicyEntryTest.java
+++ b/activemq-runtime-config/src/test/java/org/apache/activemq/java/JavaPolicyEntryTest.java
@@ -23,7 +23,6 @@ import static org.junit.Assert.assertTrue;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 
 import jakarta.jms.Session;
 
@@ -45,7 +44,6 @@ import org.junit.Test;
 
 public class JavaPolicyEntryTest extends RuntimeConfigTestSupport {
 
-    public static final int SLEEP = 2; // seconds
     private JavaRuntimeConfigurationBroker javaConfigBroker;
 
     public void startBroker(BrokerService brokerService) throws Exception {
@@ -81,7 +79,6 @@ public class JavaPolicyEntryTest extends RuntimeConfigTestSupport {
         //Reapply new limit
         entry.setMemoryLimit(4194304);
         javaConfigBroker.modifyPolicyEntry(entry);
-        TimeUnit.SECONDS.sleep(SLEEP);
 
         verifyQueueLimit("After", 4194304);
 
@@ -121,7 +118,6 @@ public class JavaPolicyEntryTest extends RuntimeConfigTestSupport {
         properties.add("memoryLimit");
         properties.add("maxPageSize");
         javaConfigBroker.modifyPolicyEntry(entry, false, properties);
-        TimeUnit.SECONDS.sleep(SLEEP);
 
         verifyQueueLimit("After", 4194304);
         assertEquals(300, getQueue("After").getMaxPageSize());
@@ -161,7 +157,6 @@ public class JavaPolicyEntryTest extends RuntimeConfigTestSupport {
         topicProperties.add("lazyDispatch");
         javaConfigBroker.modifyPolicyEntry(qEntry, false, queueProperties);
         javaConfigBroker.modifyPolicyEntry(tEntry, false, topicProperties);
-        TimeUnit.SECONDS.sleep(SLEEP);
 
         assertEquals(false, getQueue("queueBefore").isPersistJMSRedelivered());
         assertEquals(false, getTopic("topicBefore").isLazyDispatch());
@@ -195,7 +190,6 @@ public class JavaPolicyEntryTest extends RuntimeConfigTestSupport {
         Set<String> properties = new HashSet<>();
         properties.add("enableAudit");
         javaConfigBroker.modifyPolicyEntry(entry, false, properties);
-        TimeUnit.SECONDS.sleep(SLEEP);
 
         //no change because enableAudit is excluded
         assertTrue(getQueue("Before").isEnableAudit());
@@ -223,7 +217,6 @@ public class JavaPolicyEntryTest extends RuntimeConfigTestSupport {
         Set<String> properties = new HashSet<>();
         properties.add("invalid");
         javaConfigBroker.modifyPolicyEntry(entry, false, properties);
-        TimeUnit.SECONDS.sleep(SLEEP);
 
         //This should be unchanged as the list of properties only
         //has an invalid property so nothing will be re-applied retrospectively
@@ -243,7 +236,6 @@ public class JavaPolicyEntryTest extends RuntimeConfigTestSupport {
         policyMap.setPolicyEntries(Arrays.asList(entry));
         brokerService.setDestinationPolicy(policyMap);
 
-
         startBroker(brokerService);
         assertTrue("broker alive", brokerService.isStarted());
 
@@ -255,7 +247,6 @@ public class JavaPolicyEntryTest extends RuntimeConfigTestSupport {
         entry2.setQueue(">");
         entry2.setMemoryLimit(4194304);
         javaConfigBroker.modifyPolicyEntry(entry2, true);
-        TimeUnit.SECONDS.sleep(SLEEP);
 
         // These should change because the policy entry passed in
         //matched an existing entry but was not the same reference.
@@ -289,7 +280,6 @@ public class JavaPolicyEntryTest extends RuntimeConfigTestSupport {
 
         //The true flag should add the new policy
         javaConfigBroker.modifyPolicyEntry(entry, true);
-        TimeUnit.SECONDS.sleep(SLEEP);
 
         //Make sure the new policy is added and applied
         verifyQueueLimit("Before", 1024);
@@ -325,13 +315,11 @@ public class JavaPolicyEntryTest extends RuntimeConfigTestSupport {
             caughtException = true;
         }
         assertTrue(caughtException);
-        TimeUnit.SECONDS.sleep(SLEEP);
 
         //Make sure there was no change
         verifyQueueLimit("Before", (int)brokerService.getSystemUsage().getMemoryUsage().getLimit());
         verifyQueueLimit("After", (int)brokerService.getSystemUsage().getMemoryUsage().getLimit());
     }
-
 
     @Test
     public void testModNewPolicyObjectCreateOrReplaceFalse() throws Exception {
@@ -359,7 +347,6 @@ public class JavaPolicyEntryTest extends RuntimeConfigTestSupport {
             caughtException = true;
         }
         assertTrue(caughtException);
-        TimeUnit.SECONDS.sleep(SLEEP);
 
         // These should not change because the policy entry passed in
         //matched an existing entry but was not the same reference.
@@ -396,7 +383,6 @@ public class JavaPolicyEntryTest extends RuntimeConfigTestSupport {
         //Reapply new limit to policy 2
         entry2.setMemoryLimit(4194304);
         javaConfigBroker.modifyPolicyEntry(entry2);
-        TimeUnit.SECONDS.sleep(SLEEP);
 
         //verify new dest and existing are changed
         verifyQueueLimit("queue.child.test", 4194304);
@@ -445,7 +431,6 @@ public class JavaPolicyEntryTest extends RuntimeConfigTestSupport {
         //Reapply new limit to policy 2
         entry3.setMemoryLimit(4194304);
         javaConfigBroker.modifyPolicyEntry(entry);
-        TimeUnit.SECONDS.sleep(SLEEP);
 
         //should be unchanged
         verifyQueueLimit("queue.child.>", 2048);
@@ -494,7 +479,6 @@ public class JavaPolicyEntryTest extends RuntimeConfigTestSupport {
         //Reapply new limit to policy 2
         entry2.setMemoryLimit(4194304);
         javaConfigBroker.modifyPolicyEntry(entry2);
-        TimeUnit.SECONDS.sleep(SLEEP);
 
         //verify that destination at a higher level policy is not affected
         verifyQueueLimit("queue.>", 1024);
@@ -534,7 +518,6 @@ public class JavaPolicyEntryTest extends RuntimeConfigTestSupport {
         //Reapply new limit to policy
         entry.setMemoryLimit(4194304);
         javaConfigBroker.modifyPolicyEntry(entry);
-        TimeUnit.SECONDS.sleep(SLEEP);
 
         //verify new dest and existing are not changed
         verifyQueueLimit("queue.child.test", 2048);
@@ -562,13 +545,11 @@ public class JavaPolicyEntryTest extends RuntimeConfigTestSupport {
 
         entry.setMemoryLimit(2048);
         javaConfigBroker.modifyPolicyEntry(entry);
-        TimeUnit.SECONDS.sleep(SLEEP);
 
         PolicyEntry newEntry = new PolicyEntry();
         newEntry.setTopic(">");
         newEntry.setMemoryLimit(2048);
         javaConfigBroker.addNewPolicyEntry(newEntry);
-        TimeUnit.SECONDS.sleep(SLEEP);
 
         verifyTopicLimit("After", 2048l);
         verifyQueueLimit("After", 2048);
@@ -595,7 +576,6 @@ public class JavaPolicyEntryTest extends RuntimeConfigTestSupport {
 
         entry.setMemoryLimit(2048);
         javaConfigBroker.modifyPolicyEntry(entry);
-        TimeUnit.SECONDS.sleep(SLEEP);
 
         PolicyEntry newEntry = new PolicyEntry();
         newEntry.setTopic("test2.>");
@@ -605,7 +585,6 @@ public class JavaPolicyEntryTest extends RuntimeConfigTestSupport {
         newEntry2.setMemoryLimit(4000);
         javaConfigBroker.addNewPolicyEntry(newEntry);
         javaConfigBroker.addNewPolicyEntry(newEntry2);
-        TimeUnit.SECONDS.sleep(SLEEP);
 
         verifyTopicLimit("test2.after", 2048l);
         verifyTopicLimit("test2.test.after", 4000l);
@@ -680,7 +659,6 @@ public class JavaPolicyEntryTest extends RuntimeConfigTestSupport {
         assertAllQueuePolicyProperties(getQueue("Before"), 10000, true, true, true, true, 100,
                 100, true, true);
 
-
         //change config
         setAllDestPolicyProperties(entry, false, false, 100,
                 1000, 2000, 10000, 4000, 400, 300, false, false, false, 1000, false, false,
@@ -689,7 +667,6 @@ public class JavaPolicyEntryTest extends RuntimeConfigTestSupport {
                 1000, false, false);
 
         javaConfigBroker.modifyPolicyEntry(entry, false, properties);
-        TimeUnit.SECONDS.sleep(SLEEP);
 
         assertAllDestPolicyProperties(getQueue("Before"), false, false, 100,
                 1000, 2000, 10000, 4000, 400, 300, false, false, false, 1000, false, false,
@@ -729,7 +706,6 @@ public class JavaPolicyEntryTest extends RuntimeConfigTestSupport {
                 30, true, true, true, true, true, true, true, true, true);
         assertAllTopicPolicyProperties(getTopic("Before"), 10000, true);
 
-
         //change config
         setAllDestPolicyProperties(entry, false, false, 100,
                 1000, 2000, 10000, 4000, 400, 300, false, false, false, 1000, false, false,
@@ -737,7 +713,6 @@ public class JavaPolicyEntryTest extends RuntimeConfigTestSupport {
         setAllTopicPolicyProperties(entry, 100000, false);
 
         javaConfigBroker.modifyPolicyEntry(entry, false, properties);
-        TimeUnit.SECONDS.sleep(SLEEP);
 
         assertAllDestPolicyProperties(getTopic("Before"), false, false, 100,
                 1000, 2000, 10000, 4000, 400, 300, false, false, false, 1000, false, false,

--- a/activemq-runtime-config/src/test/java/org/apache/activemq/java/JavaVirtualDestTest.java
+++ b/activemq-runtime-config/src/test/java/org/apache/activemq/java/JavaVirtualDestTest.java
@@ -22,7 +22,6 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.activemq.AbstractVirtualDestTest;
 import org.apache.activemq.broker.BrokerPlugin;
@@ -42,7 +41,6 @@ import org.junit.Test;
 
 public class JavaVirtualDestTest extends AbstractVirtualDestTest {
 
-    public static final int SLEEP = 2; // seconds
     private JavaRuntimeConfigurationBroker javaConfigBroker;
 
     public void startBroker(BrokerService brokerService) throws Exception {
@@ -73,7 +71,6 @@ public class JavaVirtualDestTest extends AbstractVirtualDestTest {
         exerciseVirtualTopic("VirtualTopic.Default");
 
         javaConfigBroker.setVirtualDestinations(new VirtualDestination[]{buildVirtualTopic("A.>", false)});
-        TimeUnit.SECONDS.sleep(SLEEP);
 
         assertEquals("one interceptor", 1, interceptors.length);
         assertTrue("it is virtual topic interceptor", interceptors[0] instanceof VirtualDestinationInterceptor);
@@ -87,7 +84,6 @@ public class JavaVirtualDestTest extends AbstractVirtualDestTest {
 
         // apply again - ensure no change
         javaConfigBroker.setVirtualDestinations(new VirtualDestination[]{buildVirtualTopic("A.>", false)});
-        TimeUnit.SECONDS.sleep(SLEEP);
         assertSame("same instance", newValue, brokerService.getDestinationInterceptors()[0]);
     }
 
@@ -101,7 +97,6 @@ public class JavaVirtualDestTest extends AbstractVirtualDestTest {
                 new ActiveMQTopic("VirtualDestination.TopicConsumer")));
 
         javaConfigBroker.setVirtualDestinations(new VirtualDestination[]{queue});
-        TimeUnit.SECONDS.sleep(SLEEP);
 
         exerciseCompositeQueue("VirtualDestination.CompositeQueue", "VirtualDestination.QueueConsumer");
     }
@@ -116,11 +111,9 @@ public class JavaVirtualDestTest extends AbstractVirtualDestTest {
                 new ActiveMQTopic("VirtualDestination.TopicConsumer")));
 
         javaConfigBroker.setVirtualDestinations(new VirtualDestination[]{queue}, true);
-        TimeUnit.SECONDS.sleep(SLEEP);
 
         exerciseCompositeQueue("VirtualDestination.CompositeQueue", "VirtualDestination.QueueConsumer");
     }
-
 
     @Test
     public void testModComposite() throws Exception {
@@ -136,7 +129,6 @@ public class JavaVirtualDestTest extends AbstractVirtualDestTest {
         startBroker(brokerService);
         assertTrue("broker alive", brokerService.isStarted());
 
-
         exerciseCompositeQueue("VirtualDestination.CompositeQueue", "VirtualDestination.QueueConsumer");
 
         //Apply updated config
@@ -144,21 +136,16 @@ public class JavaVirtualDestTest extends AbstractVirtualDestTest {
                 Arrays.asList(new ActiveMQQueue("VirtualDestination.QueueConsumer"),
                 new ActiveMQTopic("VirtualDestination.TopicConsumer")));
         javaConfigBroker.setVirtualDestinations(new VirtualDestination[]{newConfig});
-        TimeUnit.SECONDS.sleep(SLEEP);
-
 
         exerciseCompositeQueue("VirtualDestination.CompositeQueue", "VirtualDestination.QueueConsumer");
         exerciseCompositeQueue("VirtualDestination.CompositeQueue", "VirtualDestination.CompositeQueue");
     }
-
 
     @Test
     public void testNewNoDefaultVirtualTopicSupport() throws Exception {
         BrokerService brokerService = new BrokerService();
         brokerService.setUseVirtualTopics(false);
         startBroker(brokerService);
-
-        TimeUnit.SECONDS.sleep(SLEEP);
 
         assertTrue("broker alive", brokerService.isStarted());
 
@@ -167,7 +154,6 @@ public class JavaVirtualDestTest extends AbstractVirtualDestTest {
 
         //apply new config
         javaConfigBroker.setVirtualDestinations(new VirtualDestination[]{buildVirtualTopic("A.>", false)});
-        TimeUnit.SECONDS.sleep(SLEEP);
         // update will happen on addDestination
         exerciseVirtualTopic("A.Default");
 
@@ -177,7 +163,6 @@ public class JavaVirtualDestTest extends AbstractVirtualDestTest {
 
         //apply new config again, make sure still just 1 interceptor
         javaConfigBroker.setVirtualDestinations(new VirtualDestination[]{buildVirtualTopic("A.>", false)});
-        TimeUnit.SECONDS.sleep(SLEEP);
         // update will happen on addDestination
         exerciseVirtualTopic("A.Default");
 
@@ -187,15 +172,12 @@ public class JavaVirtualDestTest extends AbstractVirtualDestTest {
 
     }
 
-
     @Test
     public void testNewWithMirrorQueueSupport() throws Exception {
         BrokerService brokerService = new BrokerService();
         brokerService.setUseMirroredQueues(true);
         startBroker(brokerService);
         assertTrue("broker alive", brokerService.isStarted());
-
-        TimeUnit.SECONDS.sleep(SLEEP);
 
         assertTrue("broker alive", brokerService.isStarted());
 
@@ -204,7 +186,6 @@ public class JavaVirtualDestTest extends AbstractVirtualDestTest {
 
         //apply new config
         javaConfigBroker.setVirtualDestinations(new VirtualDestination[]{buildVirtualTopic("A.>", false)});
-        TimeUnit.SECONDS.sleep(SLEEP);
 
         // update will happen on addDestination
         exerciseVirtualTopic("A.Default");
@@ -243,7 +224,6 @@ public class JavaVirtualDestTest extends AbstractVirtualDestTest {
 
         //apply empty config - this removes all virtual destinations from the interceptor
         javaConfigBroker.setVirtualDestinations(new VirtualDestination[]{});
-        TimeUnit.SECONDS.sleep(SLEEP);
 
         // update will happen on addDestination
         forceAddDestination("AnyDest");
@@ -258,7 +238,6 @@ public class JavaVirtualDestTest extends AbstractVirtualDestTest {
 
         // reverse the remove, add again
         javaConfigBroker.setVirtualDestinations(new VirtualDestination[]{buildVirtualTopic("A.>", false)});
-        TimeUnit.SECONDS.sleep(SLEEP);
 
         // update will happen on addDestination
         exerciseVirtualTopic("A.NewOne");
@@ -282,7 +261,6 @@ public class JavaVirtualDestTest extends AbstractVirtualDestTest {
 
         //apply new config
         javaConfigBroker.setVirtualDestinations(new VirtualDestination[]{buildVirtualTopic("B.>", false)});
-        TimeUnit.SECONDS.sleep(SLEEP);
         exerciseVirtualTopic("B.Default");
 
         assertEquals("still one interceptor", 1, brokerService.getDestinationInterceptors().length);
@@ -302,12 +280,10 @@ public class JavaVirtualDestTest extends AbstractVirtualDestTest {
 
         //apply new config
         javaConfigBroker.setVirtualDestinations(new VirtualDestination[]{buildVirtualTopic("B.>", false)}, true);
-        TimeUnit.SECONDS.sleep(SLEEP);
         exerciseVirtualTopic("B.Default");
 
         assertEquals("still one interceptor", 1, brokerService.getDestinationInterceptors().length);
     }
-
 
     @Test
     public void testModWithMirroredQueue() throws Exception {
@@ -319,14 +295,11 @@ public class JavaVirtualDestTest extends AbstractVirtualDestTest {
         startBroker(brokerService);
         assertTrue("broker alive", brokerService.isStarted());
 
-        TimeUnit.SECONDS.sleep(SLEEP);
-
         assertEquals("one interceptor", 1, brokerService.getDestinationInterceptors().length);
         exerciseVirtualTopic("A.Default");
 
         //apply new config
         javaConfigBroker.setVirtualDestinations(new VirtualDestination[]{buildVirtualTopic("B.>", false)});
-        TimeUnit.SECONDS.sleep(SLEEP);
         exerciseVirtualTopic("B.Default");
 
         assertEquals("still one interceptor", 1, brokerService.getDestinationInterceptors().length);
@@ -346,7 +319,6 @@ public class JavaVirtualDestTest extends AbstractVirtualDestTest {
 
         //apply new config
         javaConfigBroker.setVirtualDestinations(new VirtualDestination[]{queue});
-        TimeUnit.SECONDS.sleep(SLEEP);
 
         exerciseFilteredCompositeQueue("VirtualDestination.FilteredCompositeQueue", "VirtualDestination.QueueConsumer", "yes");
     }
@@ -376,12 +348,10 @@ public class JavaVirtualDestTest extends AbstractVirtualDestTest {
 
         //apply new config
         javaConfigBroker.setVirtualDestinations(new VirtualDestination[]{queue});
-        TimeUnit.SECONDS.sleep(SLEEP);
 
         exerciseFilteredCompositeQueue("VirtualDestination.FilteredCompositeQueue", "VirtualDestination.QueueConsumer", "no");
         exerciseFilteredCompositeQueue("VirtualDestination.FilteredCompositeQueue", "VirtualDestination.QueueConsumer", "no");
     }
-
 
     protected static CompositeQueue buildCompositeQueue(String name, Collection<?> forwardTo) {
         return buildCompositeQueue(name, true, forwardTo);


### PR DESCRIPTION
RuntimeConfigurationBroker records the file time of its last completed update attempt. The test support bumps the config file's modification time itself and waits for that record to reach it, so the 4s sleeps after every broker start and config change go away. The Java plugin setters apply synchronously or on the next addDestination, so the sleeps after them were dead. The filtered composite queue check proves a rejected message was dropped by ordering rather than by a 10s timeout.

Module run: 76 tests, 8.3 min down to 52s.