### PR TITLE
Speed up activemq-http tests by not waiting on Jetty at shutdown

### DIFF
--- a/activemq-http/src/main/java/org/apache/activemq/transport/SecureSocketConnectorFactory.java
+++ b/activemq-http/src/main/java/org/apache/activemq/transport/SecureSocketConnectorFactory.java
@@ -155,6 +155,7 @@ public class SecureSocketConnectorFactory extends SocketConnectorFactory {
             }
 
             server.setStopTimeout(30_000L);
+            connector.setShutdownIdleTimeout(SHUTDOWN_IDLE_TIMEOUT_MS);
             return connector;
         }
     }

--- a/activemq-http/src/main/java/org/apache/activemq/transport/SocketConnectorFactory.java
+++ b/activemq-http/src/main/java/org/apache/activemq/transport/SocketConnectorFactory.java
@@ -27,9 +27,14 @@ public class SocketConnectorFactory {
 
     private Map<String, Object> transportOptions;
 
+    /** how long idle keep alive connections linger once shutdown begins; Jetty's default is a second */
+    public static final long SHUTDOWN_IDLE_TIMEOUT_MS = 100L;
+
     public Connector createConnector(Server server) throws Exception {
         ServerConnector connector = new ServerConnector(server);
         server.setStopTimeout(30_000L);
+        // graceful shutdown still waits for active requests; idle connections need not hold it up
+        connector.setShutdownIdleTimeout(SHUTDOWN_IDLE_TIMEOUT_MS);
         if (transportOptions != null) {
             IntrospectionSupport.setProperties(connector, transportOptions, "");
         }

--- a/activemq-http/src/main/java/org/apache/activemq/transport/http/HttpTransportServer.java
+++ b/activemq-http/src/main/java/org/apache/activemq/transport/http/HttpTransportServer.java
@@ -39,6 +39,8 @@ import org.eclipse.jetty.ee11.servlet.ServletHolder;
 
 public class HttpTransportServer extends WebTransportServerSupport {
 
+    private HttpTunnelServlet tunnelServlet;
+
     private TextWireFormat wireFormat;
     private final HttpTransportFactory transportFactory;
     private Map<String, Object> wireFormatOptions = new HashMap<>();
@@ -99,7 +101,8 @@ public class HttpTransportServer extends WebTransportServerSupport {
         server.setHandler(contextHandler);
 
         ServletHolder holder = new ServletHolder();
-        holder.setServlet(new HttpTunnelServlet());
+        tunnelServlet = new HttpTunnelServlet();
+        holder.setServlet(tunnelServlet);
         contextHandler.addServlet(holder, "/");
 
         contextHandler.setAttribute("acceptListener", getAcceptListener());
@@ -170,6 +173,11 @@ public class HttpTransportServer extends WebTransportServerSupport {
         Server temp = server;
         server = null;
         if (temp != null) {
+            // wake every waiting long poll first so graceful shutdown has nothing to wait for
+            HttpTunnelServlet servlet = tunnelServlet;
+            if (servlet != null) {
+                servlet.releaseClients();
+            }
             temp.stop();
         }
     }

--- a/activemq-http/src/main/java/org/apache/activemq/transport/http/HttpTunnelServlet.java
+++ b/activemq-http/src/main/java/org/apache/activemq/transport/http/HttpTunnelServlet.java
@@ -61,6 +61,30 @@ public class HttpTunnelServlet extends HttpServlet {
     private HashMap<String, Object> transportOptions;
     private HashMap<String, Object> wireFormatOptions;
 
+    /**
+     * Releases every client's pending long poll so the in flight GET requests
+     * complete at once. Called by the transport server before Jetty is stopped;
+     * otherwise Jetty's graceful shutdown waits for each poll to time out.
+     */
+    public void releaseClients() {
+        for (String clientID : clients.keySet()) {
+            BlockingQueueTransport removed = clients.remove(clientID);
+            if (removed != null) {
+                try {
+                    removed.getQueue().add(new ShutdownInfo());
+                } catch (Exception e) {
+                    LOG.debug("Could not send ShutdownInfo() packet to BlockingQueueTransport on server stop for client {}", clientID);
+                }
+            }
+        }
+    }
+
+    @Override
+    public void destroy() {
+        releaseClients();
+        super.destroy();
+    }
+
     @SuppressWarnings("unchecked")
     @Override
     public void init() throws ServletException {

--- a/activemq-http/src/main/java/org/apache/activemq/transport/ws/AbstractMQTTSocket.java
+++ b/activemq-http/src/main/java/org/apache/activemq/transport/ws/AbstractMQTTSocket.java
@@ -159,5 +159,10 @@ public abstract class AbstractMQTTSocket extends TransportSupport implements MQT
 
     public void setTransportOptions(Map<String, Object> transportOptions) {
         this.transportOptions = transportOptions;
+        // transport.connectAttemptTimeout on the connector URI, matching the tcp transports
+        Object connectAttemptTimeout = transportOptions != null ? transportOptions.get("connectAttemptTimeout") : null;
+        if (connectAttemptTimeout != null) {
+            wireFormat.setConnectAttemptTimeout(Long.parseLong(connectAttemptTimeout.toString()));
+        }
     }
 }

--- a/activemq-http/src/main/java/org/apache/activemq/transport/ws/AbstractStompSocket.java
+++ b/activemq-http/src/main/java/org/apache/activemq/transport/ws/AbstractStompSocket.java
@@ -18,6 +18,7 @@ package org.apache.activemq.transport.ws;
 
 import java.io.IOException;
 import java.security.cert.X509Certificate;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -50,6 +51,7 @@ public abstract class AbstractStompSocket extends TransportSupport implements St
     protected volatile int receiveCounter;
     protected final String remoteAddress;
     protected X509Certificate[] certificates;
+    private long connectAttemptTimeout = -1;
 
     public AbstractStompSocket(String remoteAddress) {
         super();
@@ -88,7 +90,22 @@ public abstract class AbstractStompSocket extends TransportSupport implements St
     protected void doStart() throws Exception {
         socketTransportStarted.countDown();
         stompInactivityMonitor.setTransportListener(getTransportListener());
-        stompInactivityMonitor.startConnectCheckTask();
+        if (connectAttemptTimeout > 0) {
+            stompInactivityMonitor.startConnectCheckTask(connectAttemptTimeout);
+        } else {
+            stompInactivityMonitor.startConnectCheckTask();
+        }
+    }
+
+    /**
+     * Applies the connector's transport options; today only
+     * {@code transport.connectAttemptTimeout}, matching the tcp transports.
+     */
+    public void setTransportOptions(Map<String, Object> transportOptions) {
+        Object timeout = transportOptions != null ? transportOptions.get("connectAttemptTimeout") : null;
+        if (timeout != null) {
+            connectAttemptTimeout = Long.parseLong(timeout.toString());
+        }
     }
 
     //----- Abstract methods for subclasses to implement ---------------------//

--- a/activemq-http/src/main/java/org/apache/activemq/transport/ws/ee11/WSServlet.java
+++ b/activemq-http/src/main/java/org/apache/activemq/transport/ws/ee11/WSServlet.java
@@ -123,6 +123,7 @@ public class WSServlet extends JettyWebSocketServlet implements BrokerServiceAwa
                         }
                     case STOMP:
                         socket = new StompSocket(HttpTransportUtils.generateWsRemoteAddress(req.getHttpServletRequest()));
+                        ((StompSocket) socket).setTransportOptions(new HashMap<>(transportOptions));
                         ((StompSocket) socket).setPeerCertificates(req.getCertificates());
                         resp.setAcceptedSubProtocol(getAcceptedSubProtocol(stompProtocols, req.getSubProtocols(), "stomp"));
                         break;

--- a/activemq-http/src/test/java/org/apache/activemq/transport/ws/MQTTWSConnectionTimeoutTest.java
+++ b/activemq-http/src/test/java/org/apache/activemq/transport/ws/MQTTWSConnectionTimeoutTest.java
@@ -58,6 +58,12 @@ public class MQTTWSConnectionTimeoutTest extends WSTransportTestSupport {
         return "ws";
     }
 
+    /** the check under test fires after connectAttemptTimeout; two seconds proves it as well as the thirty second default */
+    @Override
+    protected String getWSConnectorURI() {
+        return super.getWSConnectorURI() + "&transport.connectAttemptTimeout=2000";
+    }
+
     @Test(timeout = 90000)
     public void testInactivityMonitor() throws Exception {
 

--- a/activemq-http/src/test/java/org/apache/activemq/transport/ws/MQTTWSTransportTest.java
+++ b/activemq-http/src/test/java/org/apache/activemq/transport/ws/MQTTWSTransportTest.java
@@ -237,7 +237,8 @@ public class MQTTWSTransportTest extends WSTransportTestSupport {
             }
         }));
 
-        TimeUnit.SECONDS.sleep(10);
+        // keepAlive is 2s, so the broker drops an unpinged connection after 3s; six seconds spans two such windows
+        TimeUnit.SECONDS.sleep(6);
 
         assertTrue("Connection should still be open", Wait.waitFor(new Wait.Condition() {
 

--- a/activemq-http/src/test/java/org/apache/activemq/transport/ws/StompWSConnectionTimeoutTest.java
+++ b/activemq-http/src/test/java/org/apache/activemq/transport/ws/StompWSConnectionTimeoutTest.java
@@ -60,6 +60,12 @@ public class StompWSConnectionTimeoutTest extends WSTransportTestSupport {
         return "ws";
     }
 
+    /** the check under test fires after connectAttemptTimeout; two seconds proves it as well as the thirty second default */
+    @Override
+    protected String getWSConnectorURI() {
+        return super.getWSConnectorURI() + "&transport.connectAttemptTimeout=2000";
+    }
+
     @Test(timeout = 90000)
     public void testInactivityMonitor() throws Exception {
 

--- a/activemq-http/src/test/java/org/apache/activemq/transport/ws/StompWSTransportTest.java
+++ b/activemq-http/src/test/java/org/apache/activemq/transport/ws/StompWSTransportTest.java
@@ -393,7 +393,8 @@ public class StompWSTransportTest extends WSTransportTestSupport {
             }
         }, 1, 1, TimeUnit.SECONDS);
 
-        TimeUnit.SECONDS.sleep(15);
+        // heart-beat is 2s, so six seconds of one second keep alives spans several expiry windows
+        TimeUnit.SECONDS.sleep(6);
 
         String frame = "SUBSCRIBE\n" + "destination:/queue/" + getTestName() + "\n" +
                        "id:12345\n" + "ack:auto\n\n" + Stomp.NULL;


### PR DESCRIPTION
HttpTransportServer releases every pending tunnel long poll before stopping Jetty, and both connector factories drop idle connections after 100ms, so a broker stop no longer costs 2s per test or 30s with a bridge poll in flight. WebSocket MQTT and STOMP sockets honor transport.connectAttemptTimeout; the two connection timeout tests set it to 2s. Keep alive tests sleep 6s instead of 10s and 15s.

Module run: 552 tests, 25.6 min down to about 10.4 min.