### PR TITLE
[#2140] Widen MessageDatabase index-update points for subclasses

### DIFF
--- a/activemq-kahadb-store/src/main/java/org/apache/activemq/store/kahadb/MessageDatabase.java
+++ b/activemq-kahadb-store/src/main/java/org/apache/activemq/store/kahadb/MessageDatabase.java
@@ -225,6 +225,20 @@ public abstract class MessageDatabase extends ServiceSupport implements BrokerSe
             }
             os.writeInt(this.openwireVersion);
         }
+
+        // Accessors for lastUpdate, the most recent journal location applied
+        // to the index. A KahaDBStore subclass in another package can reach
+        // the protected metadata field of the outer class, but not the fields
+        // of this nested class, so a subclass that updates the index itself
+        // (for example after applying buffered transaction operations) needs
+        // these.
+        public Location getLastUpdate() {
+            return lastUpdate;
+        }
+
+        public void setLastUpdate(Location lastUpdate) {
+            this.lastUpdate = lastUpdate;
+        }
     }
 
     class MetadataMarshaller extends VariableMarshaller<Metadata> {
@@ -1432,7 +1446,7 @@ public abstract class MessageDatabase extends ServiceSupport implements BrokerSe
 
     protected final ReentrantLock indexLock = new ReentrantLock();
 
-    long updateIndex(Transaction tx, KahaAddMessageCommand command, Location location) throws IOException {
+    protected long updateIndex(Transaction tx, KahaAddMessageCommand command, Location location) throws IOException {
         StoredDestination sd = getExistingStoredDestination(command.getDestination(), tx);
         if (sd == null) {
             // if the store no longer exists, skip
@@ -1498,7 +1512,7 @@ public abstract class MessageDatabase extends ServiceSupport implements BrokerSe
         }
     }
 
-    void updateIndex(Transaction tx, KahaUpdateMessageCommand updateMessageCommand, Location location) throws IOException {
+    protected void updateIndex(Transaction tx, KahaUpdateMessageCommand updateMessageCommand, Location location) throws IOException {
         KahaAddMessageCommand command = updateMessageCommand.getMessage();
         StoredDestination sd = getStoredDestination(command.getDestination(), tx);
 
@@ -1541,7 +1555,7 @@ public abstract class MessageDatabase extends ServiceSupport implements BrokerSe
         }
     }
 
-    void updateIndex(Transaction tx, KahaRemoveMessageCommand command, Location ackLocation) throws IOException {
+    protected void updateIndex(Transaction tx, KahaRemoveMessageCommand command, Location ackLocation) throws IOException {
         StoredDestination sd = getStoredDestination(command.getDestination(), tx);
         if (!command.hasSubscriptionKey()) {
 
@@ -1590,7 +1604,13 @@ public abstract class MessageDatabase extends ServiceSupport implements BrokerSe
         }
     }
 
-    private void recordAckMessageReferenceLocation(Location ackLocation, Location messageLocation) {
+    /**
+     * Records that the journal file holding the given ack references the
+     * journal file holding the acked message. The ackMessageFileMap is
+     * guarded by the index lock: every reader and writer, including the ack
+     * compaction task, must hold that lock.
+     */
+    protected void recordAckMessageReferenceLocation(Location ackLocation, Location messageLocation) {
         Set<Integer> referenceFileIds = metadata.ackMessageFileMap.get(ackLocation.getDataFileId());
         if (referenceFileIds == null) {
             referenceFileIds = new HashSet<>();
@@ -1606,7 +1626,7 @@ public abstract class MessageDatabase extends ServiceSupport implements BrokerSe
         }
     }
 
-    void updateIndex(Transaction tx, KahaRemoveDestinationCommand command) throws IOException {
+    protected void updateIndex(Transaction tx, KahaRemoveDestinationCommand command) throws IOException {
         StoredDestination sd = getStoredDestination(command.getDestination(), tx);
         sd.orderIndex.remove(tx);
 
@@ -1646,7 +1666,7 @@ public abstract class MessageDatabase extends ServiceSupport implements BrokerSe
         storeCache.remove(key(command.getDestination()));
     }
 
-    void updateIndex(Transaction tx, KahaSubscriptionCommand command, Location location) throws IOException {
+    protected void updateIndex(Transaction tx, KahaSubscriptionCommand command, Location location) throws IOException {
         StoredDestination sd = getStoredDestination(command.getDestination(), tx);
         final String subscriptionKey = command.getSubscriptionKey();
 

--- a/activemq-kahadb-store/src/main/java/org/apache/activemq/store/kahadb/TransactionIdConversion.java
+++ b/activemq-kahadb-store/src/main/java/org/apache/activemq/store/kahadb/TransactionIdConversion.java
@@ -28,7 +28,7 @@ import org.apache.activemq.store.kahadb.data.KahaXATransactionId;
 
 public class TransactionIdConversion {
 
-    static KahaTransactionInfo convertToLocal(TransactionId tx) {
+    public static KahaTransactionInfo convertToLocal(TransactionId tx) {
         KahaTransactionInfo rc = new KahaTransactionInfo();
         LocalTransactionId t = (LocalTransactionId) tx;
         KahaLocalTransactionId kahaTxId = new KahaLocalTransactionId();
@@ -38,7 +38,7 @@ public class TransactionIdConversion {
         return rc;
     }
 
-    static KahaTransactionInfo convert(TransactionId txid) {
+    public static KahaTransactionInfo convert(TransactionId txid) {
         if (txid == null) {
             return null;
         }
@@ -58,7 +58,7 @@ public class TransactionIdConversion {
         return rc;
     }
 
-    static TransactionId convert(KahaTransactionInfo transactionInfo) {
+    public static TransactionId convert(KahaTransactionInfo transactionInfo) {
         if (transactionInfo.hasLocalTransactionId()) {
             KahaLocalTransactionId tx = transactionInfo.getLocalTransactionId();
             LocalTransactionId rc = new LocalTransactionId();

--- a/activemq-kahadb-store/src/test/java/org/apache/activemq/store/kahadb/MessageDatabaseExtensibilityTest.java
+++ b/activemq-kahadb-store/src/test/java/org/apache/activemq/store/kahadb/MessageDatabaseExtensibilityTest.java
@@ -1,0 +1,127 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.store.kahadb;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.jms.Session;
+
+import org.apache.activemq.ActiveMQConnectionFactory;
+import org.apache.activemq.broker.BrokerService;
+import org.apache.activemq.store.kahadb.data.KahaAddMessageCommand;
+import org.apache.activemq.store.kahadb.disk.journal.Location;
+import org.apache.activemq.store.kahadb.disk.page.Transaction;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Verifies the KahaDB extension points added for external subclasses
+ * (GH-2140): {@link KahaDBPersistenceAdapter#createStore()} lets an
+ * adapter supply a {@link KahaDBStore} subclass, and the protected
+ * {@code updateIndex} methods let that
+ * subclass see index updates without copying store code. The
+ * override below only counts invocations and delegates; the broker
+ * must behave identically to the stock store.
+ */
+public class MessageDatabaseExtensibilityTest {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    static class CountingStore extends KahaDBStore {
+        final AtomicInteger indexedAdds = new AtomicInteger();
+
+        @Override
+        protected long updateIndex(Transaction tx, KahaAddMessageCommand command,
+                Location location) throws IOException {
+            indexedAdds.incrementAndGet();
+            return super.updateIndex(tx, command, location);
+        }
+    }
+
+    static class CountingAdapter extends KahaDBPersistenceAdapter {
+        // createStore() is invoked from the superclass field initializer,
+        // before this subclass's own field initializers run, so the store
+        // must be constructed here, not in a field initializer.
+        CountingStore store;
+
+        @Override
+        protected KahaDBStore createStore() {
+            store = new CountingStore();
+            return store;
+        }
+    }
+
+    @Test
+    public void adapterSuppliedStoreSubclassObservesIndexUpdates() throws Exception {
+        var kahadbDir = temporaryFolder.newFolder("kahadb");
+        var broker = new BrokerService();
+        broker.setPersistent(true);
+        broker.setUseJmx(false);
+        broker.setAdvisorySupport(false);
+        broker.setDataDirectoryFile(kahadbDir.getParentFile());
+
+        var adapter = new CountingAdapter();
+        adapter.setDirectory(kahadbDir);
+        adapter.setCheckpointInterval(0);
+        adapter.setCleanupInterval(0);
+        // Deterministic counting: with concurrent store-and-dispatch the
+        // index update is asynchronous relative to send().
+        adapter.setConcurrentStoreAndDispatchQueues(false);
+        broker.setPersistenceAdapter(adapter);
+        broker.start();
+        broker.waitUntilStarted();
+
+        try {
+            var cf = new ActiveMQConnectionFactory(broker.getVmConnectorURI());
+            try (var connection = cf.createConnection()) {
+                connection.start();
+                var session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+                var queue = session.createQueue("EXTENSIBILITY.TEST");
+                var producer = session.createProducer(queue);
+                for (var i = 0; i < 25; i++) {
+                    producer.send(session.createTextMessage("msg-" + i));
+                }
+
+                // The subclass saw every persistent add.
+                assertEquals(25, adapter.store.indexedAdds.get());
+
+                // The Metadata accessors (added for cross-package
+                // subclasses, which cannot reach the nested class's fields)
+                // return the updated location.
+                assertNotNull("metadata lastUpdate should be set after messages are stored",
+                        adapter.store.metadata.getLastUpdate());
+
+                // Behavior is unchanged: all messages are consumable.
+                try (var consumer = session.createConsumer(queue)) {
+                    for (var i = 0; i < 25; i++) {
+                        var received = consumer.receive(10_000);
+                        assertNotNull("message " + i + " must be delivered", received);
+                    }
+                }
+            }
+        } finally {
+            broker.stop();
+            broker.waitUntilStopped();
+        }
+    }
+}


### PR DESCRIPTION
This change opens the possibility to extend KahaDB for performance improvements. Making architecture changes to KahaDB directly is considered risky, as KahaDB is very stable.

By supporting a subclassed KahaDB, developers and users may gradually rollout new KahaDB features and capabilities. Specifically, this relates to improving KahaDB throughput by being able to leverage modern JDK capabilities -- specifically Virtual Threads and aio.