### PR TITLE
StartCommand: keep waiting past the default start timeout unless a start exception was recorded

### DIFF
--- a/activemq-console/src/main/java/org/apache/activemq/console/command/StartCommand.java
+++ b/activemq-console/src/main/java/org/apache/activemq/console/command/StartCommand.java
@@ -92,8 +92,11 @@ public class StartCommand extends AbstractCommand {
                 throw e;
             }
 
-            if (!broker.waitUntilStarted()) {
-                throw new Exception(broker.getStartException());
+            while (!broker.waitUntilStarted()) {
+                if (broker.getStartException() != null) {
+                    throw new Exception(broker.getStartException());
+                }
+                // still starting (e.g. a slave waiting on the lock under startAsync) - keep waiting
             }
 
             // The broker started up fine.  Now lets wait for it to stop...


### PR DESCRIPTION
## Summary

- Fixes #2552: a broker started via `./activemq start` with `startAsync=true`, running as a slave, disappeared after roughly 10 minutes with nothing logged.
- `BrokerService.DEFAULT_START_TIMEOUT` is 10 minutes, and `StartCommand` called `broker.waitUntilStarted()` with that timeout, throwing (and exiting the process) whenever it returned `false`. Before `startAsync` existed this was harmless, since `start()` itself blocked until the broker became master. With `startAsync=true`, `start()` returns immediately, and a slave can legitimately wait on the lock far longer than 10 minutes.
- `StartCommand` now loops on `waitUntilStarted()`, only throwing/exiting once `broker.getStartException()` is actually non-null. This can't spin indefinitely: `BrokerService.stop()` always records a start exception (`BrokerStoppedException`) before it ever marks the broker as stopped, so a real stop or startup failure still surfaces immediately.

## Test plan

- [x] `mvn -pl activemq-console -am compile` succeeds
- [ ] Manual verification: start a slave broker with `startAsync=true` and confirm the process stays alive past 10 minutes while waiting on the lock, and exits promptly with a logged error on an actual startup failure

Fixes #2552