### PR TITLE
fix: ActiveMQObjectMessage/ActiveMQMapMessage doGetBody() deserializes message body twice

### DIFF
--- a/activemq-client/src/main/java/org/apache/activemq/command/ActiveMQMapMessage.java
+++ b/activemq-client/src/main/java/org/apache/activemq/command/ActiveMQMapMessage.java
@@ -856,8 +856,7 @@ public class ActiveMQMapMessage extends ActiveMQMessage implements MapMessage {
     @SuppressWarnings("unchecked")
     protected <T> T doGetBody(Class<T> asType) throws JMSException {
         storeContent();
-        final ByteSequence content = getContent();
-        final Map<String, Object> map = content != null ? deserialize(content) : null;
+        final Map<String, Object> map = getContentMap();
 
         //This implementation treats an empty map as not having a body so if empty
         //we should return null as well

--- a/activemq-client/src/main/java/org/apache/activemq/command/ActiveMQObjectMessage.java
+++ b/activemq-client/src/main/java/org/apache/activemq/command/ActiveMQObjectMessage.java
@@ -301,7 +301,6 @@ public class ActiveMQObjectMessage extends ActiveMQMessage implements ObjectMess
     @SuppressWarnings("unchecked")
     protected <T> T doGetBody(Class<T> asType) throws JMSException {
         storeContent();
-        final ByteSequence content = getContent();
-        return content != null ? (T) deserialize(content) : null;
+        return (T) getObject();
     }
 }

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/command/ActiveMQMapMessageTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/command/ActiveMQMapMessageTest.java
@@ -19,6 +19,7 @@ package org.apache.activemq.command;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
@@ -29,6 +30,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
+import java.util.Map;
 
 import jakarta.jms.JMSException;
 import jakarta.jms.MessageFormatException;
@@ -514,5 +516,20 @@ public class ActiveMQMapMessageTest {
             assertTrue(
                     ExceptionUtils.getRootCause(e) instanceof ActiveMQUnmarshalEOFException);
         }
+    }
+
+    // JMS 2.0 getBody() calls isBodyAssignableTo() (which populates the cached
+    // map via getContentMap()) and then doGetBody(). doGetBody() must reuse that
+    // cache instead of deserializing the content a second time.
+    @Test(timeout = 10000)
+    public void testGetBodyDoesNotDeserializeTwice() throws Exception {
+        ActiveMQMapMessage msg = new ActiveMQMapMessage();
+        msg.setString("key", "value");
+        msg.storeContentAndClear();
+
+        Map<String, Object> body = msg.getBody(Map.class);
+        Map<String, Object> contentMap = msg.getContentMap();
+
+        assertSame("doGetBody() should reuse the cached map instead of deserializing again", contentMap, body);
     }
 }

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/command/ActiveMQObjectMessageTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/command/ActiveMQObjectMessageTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
+import java.io.Serializable;
 
 import jakarta.jms.JMSException;
 import jakarta.jms.MessageNotReadableException;
@@ -172,6 +173,20 @@ public class ActiveMQObjectMessageTest extends TestCase {
                 assertTrue(ExceptionUtils.getRootCause(e) instanceof ActiveMQUnmarshalEOFException);
             }
         }
+    }
+
+    // JMS 2.0 getBody() calls isBodyAssignableTo() (which populates the cached
+    // object via getObject()) and then doGetBody(). doGetBody() must reuse that
+    // cache instead of deserializing the content a second time.
+    public void testGetBodyDoesNotDeserializeTwice() throws Exception {
+        ActiveMQObjectMessage msg = new ActiveMQObjectMessage();
+        msg.setObject("value");
+        msg.storeContentAndClear();
+
+        Serializable body = msg.getBody(Serializable.class);
+        Serializable object = msg.getObject();
+
+        assertSame("doGetBody() should reuse the cached object instead of deserializing again", object, body);
     }
 
 }


### PR DESCRIPTION
doGetBody() in both classes re-deserializes the content directly instead of reusing the cache getObject()/getContentMap() already populate, so getBody() ends up deserializing twice. Fixed both to delegate to the cached getter, same as ActiveMQTextMessage already does. Added a test per class to catch the regression.

See: https://github.com/apache/activemq/issues/2516